### PR TITLE
feat: add userinfo endpoint

### DIFF
--- a/authz/authz.go
+++ b/authz/authz.go
@@ -80,6 +80,7 @@ p, *, *, POST, /api/login, *, *
 p, *, *, GET, /api/get-app-login, *, *
 p, *, *, POST, /api/logout, *, *
 p, *, *, GET, /api/get-account, *, *
+p, *, *, GET, /api/userinfo, *, *
 p, *, *, POST, /api/login/oauth/access_token, *, *
 p, *, *, POST, /api/login/oauth/refresh_token, *, *
 p, *, *, GET, /api/get-application, *, *

--- a/controllers/account.go
+++ b/controllers/account.go
@@ -67,6 +67,14 @@ type Response struct {
 	Data2  interface{} `json:"data2"`
 }
 
+type Userinfo struct {
+	Sub         string `json:"sub"`
+	Name        string `json:"name"`
+	DisplayName string `json:"preferred_username"`
+	Email       string `json:"email"`
+	Avatar      string `json:"picture"`
+}
+
 type HumanCheck struct {
 	Type         string      `json:"type"`
 	AppKey       string      `json:"appKey"`
@@ -226,6 +234,33 @@ func (c *ApiController) GetAccount() {
 		Name:   user.Name,
 		Data:   user,
 		Data2:  organization,
+	}
+	c.Data["json"] = resp
+	c.ServeJSON()
+}
+
+// UserInfo
+// @Title UserInfo
+// @Tag Account API
+// @Description return user information according to OIDC standards
+// @Success 200 {object} controllers.Userinfo The Response object
+// @router /userinfo [get]
+func (c *ApiController) GetUserinfo() {
+	userId, ok := c.RequireSignedIn()
+	if !ok {
+		return
+	}
+	user := object.GetUser(userId)
+	if user == nil {
+		c.ResponseError(fmt.Sprintf("The user: %s doesn't exist", userId))
+		return
+	}
+	resp := Userinfo{
+		Sub:         user.Id,
+		Name:        user.Name,
+		DisplayName: user.DisplayName,
+		Email:       user.Email,
+		Avatar:      user.Avatar,
 	}
 	c.Data["json"] = resp
 	c.ServeJSON()

--- a/controllers/account.go
+++ b/controllers/account.go
@@ -261,7 +261,7 @@ func (c *ApiController) GetUserinfo() {
 		c.ResponseError(fmt.Sprintf("The user: %s doesn't exist", userId))
 		return
 	}
-	scope, aud := c.GetSessionOIDC()
+	scope, aud := c.GetSessionOidc()
 	iss := beego.AppConfig.String("origin")
 	resp := Userinfo{
 		Sub: user.Id,

--- a/controllers/base.go
+++ b/controllers/base.go
@@ -72,7 +72,7 @@ func (c *ApiController) GetSessionUsername() string {
 	return user.(string)
 }
 
-func (c *ApiController) GetSessionOIDC() (string, string) {
+func (c *ApiController) GetSessionOidc() (string, string) {
 	sessionData := c.GetSessionData()
 	if sessionData != nil &&
 		sessionData.ExpireTime != 0 &&

--- a/controllers/base.go
+++ b/controllers/base.go
@@ -72,6 +72,28 @@ func (c *ApiController) GetSessionUsername() string {
 	return user.(string)
 }
 
+func (c *ApiController) GetSessionOIDC() (string, string) {
+	sessionData := c.GetSessionData()
+	if sessionData != nil &&
+		sessionData.ExpireTime != 0 &&
+		sessionData.ExpireTime < time.Now().Unix() {
+		c.SetSessionUsername("")
+		c.SetSessionData(nil)
+		return "", ""
+	}
+	scopeValue := c.GetSession("scope")
+	audValue := c.GetSession("aud")
+	var scope, aud string
+	var ok bool
+	if scope, ok = scopeValue.(string); !ok {
+		scope = ""
+	}
+	if aud, ok = audValue.(string); !ok {
+		aud = ""
+	}
+	return scope, aud
+}
+
 // SetSessionUsername ...
 func (c *ApiController) SetSessionUsername(user string) {
 	c.SetSession("username", user)

--- a/object/oidc_discovery.go
+++ b/object/oidc_discovery.go
@@ -54,7 +54,7 @@ func init() {
 		Issuer:                                 origin,
 		AuthorizationEndpoint:                  fmt.Sprintf("%s/login/oauth/authorize", origin),
 		TokenEndpoint:                          fmt.Sprintf("%s/api/login/oauth/access_token", origin),
-		UserinfoEndpoint:                       fmt.Sprintf("%s/api/get-account", origin),
+		UserinfoEndpoint:                       fmt.Sprintf("%s/api/userinfo", origin),
 		JwksUri:                                fmt.Sprintf("%s/api/certs", origin),
 		ResponseTypesSupported:                 []string{"id_token"},
 		ResponseModesSupported:                 []string{"login", "code", "link"},

--- a/object/token.go
+++ b/object/token.go
@@ -208,12 +208,12 @@ func GetOAuthCode(userId string, clientId string, responseType string, redirectU
 		}
 	}
 
-	accessToken, refreshToken, err := generateJwtToken(application, user, nonce)
+	accessToken, refreshToken, err := generateJwtToken(application, user, nonce, scope)
 	if err != nil {
 		panic(err)
 	}
 
-	if challenge == "null"{
+	if challenge == "null" {
 		challenge = ""
 	}
 
@@ -376,7 +376,7 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 			Scope:       "",
 		}
 	}
-	newAccessToken, newRefreshToken, err := generateJwtToken(application, user, "")
+	newAccessToken, newRefreshToken, err := generateJwtToken(application, user, "", scope)
 	if err != nil {
 		panic(err)
 	}

--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -27,6 +27,7 @@ type Claims struct {
 	*User
 	Nonce string `json:"nonce,omitempty"`
 	Tag   string `json:"tag,omitempty"`
+	Scope string `json:"scope,omitempty"`
 	jwt.RegisteredClaims
 }
 
@@ -38,6 +39,7 @@ type UserShort struct {
 type ClaimsShort struct {
 	*UserShort
 	Nonce string `json:"nonce,omitempty"`
+	Scope string `json:"scope,omitempty"`
 	jwt.RegisteredClaims
 }
 
@@ -53,12 +55,13 @@ func getShortClaims(claims Claims) ClaimsShort {
 	res := ClaimsShort{
 		UserShort:        getShortUser(claims.User),
 		Nonce:            claims.Nonce,
+		Scope:            claims.Scope,
 		RegisteredClaims: claims.RegisteredClaims,
 	}
 	return res
 }
 
-func generateJwtToken(application *Application, user *User, nonce string) (string, string, error) {
+func generateJwtToken(application *Application, user *User, nonce string, scope string) (string, string, error) {
 	nowTime := time.Now()
 	expireTime := nowTime.Add(time.Duration(application.ExpireInHours) * time.Hour)
 	refreshExpireTime := nowTime.Add(time.Duration(application.RefreshExpireInHours) * time.Hour)
@@ -69,7 +72,8 @@ func generateJwtToken(application *Application, user *User, nonce string) (strin
 		User:  user,
 		Nonce: nonce,
 		// FIXME: A workaround for custom claim by reusing `tag` in user info
-		Tag: user.Tag,
+		Tag:   user.Tag,
+		Scope: scope,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    beego.AppConfig.String("origin"),
 			Subject:   user.Id,

--- a/routers/auto_signin_filter.go
+++ b/routers/auto_signin_filter.go
@@ -43,7 +43,7 @@ func AutoSigninFilter(ctx *context.Context) {
 
 		userId := fmt.Sprintf("%s/%s", claims.User.Owner, claims.User.Name)
 		setSessionUser(ctx, userId)
-		setSessionOIDC(ctx, claims.Scope, claims.Audience[0])
+		setSessionOidc(ctx, claims.Scope, claims.Audience[0])
 		return
 	}
 
@@ -82,6 +82,6 @@ func AutoSigninFilter(ctx *context.Context) {
 
 		setSessionUser(ctx, fmt.Sprintf("%s/%s", claims.Owner, claims.Name))
 		setSessionExpire(ctx, claims.ExpiresAt.Unix())
-		setSessionOIDC(ctx, claims.Scope, claims.Audience[0])
+		setSessionOidc(ctx, claims.Scope, claims.Audience[0])
 	}
 }

--- a/routers/auto_signin_filter.go
+++ b/routers/auto_signin_filter.go
@@ -43,6 +43,7 @@ func AutoSigninFilter(ctx *context.Context) {
 
 		userId := fmt.Sprintf("%s/%s", claims.User.Owner, claims.User.Name)
 		setSessionUser(ctx, userId)
+		setSessionOIDC(ctx, claims.Scope, claims.Audience[0])
 		return
 	}
 
@@ -81,5 +82,6 @@ func AutoSigninFilter(ctx *context.Context) {
 
 		setSessionUser(ctx, fmt.Sprintf("%s/%s", claims.Owner, claims.Name))
 		setSessionExpire(ctx, claims.ExpiresAt.Unix())
+		setSessionOIDC(ctx, claims.Scope, claims.Audience[0])
 	}
 }

--- a/routers/base.go
+++ b/routers/base.go
@@ -97,7 +97,7 @@ func setSessionExpire(ctx *context.Context, ExpireTime int64) {
 	ctx.Input.CruSession.SessionRelease(ctx.ResponseWriter)
 }
 
-func setSessionOIDC(ctx *context.Context, scope string, aud string) {
+func setSessionOidc(ctx *context.Context, scope string, aud string) {
 	err := ctx.Input.CruSession.Set("scope", scope)
 	if err != nil {
 		panic(err)

--- a/routers/base.go
+++ b/routers/base.go
@@ -97,6 +97,18 @@ func setSessionExpire(ctx *context.Context, ExpireTime int64) {
 	ctx.Input.CruSession.SessionRelease(ctx.ResponseWriter)
 }
 
+func setSessionOIDC(ctx *context.Context, scope string, aud string) {
+	err := ctx.Input.CruSession.Set("scope", scope)
+	if err != nil {
+		panic(err)
+	}
+	err = ctx.Input.CruSession.Set("aud", aud)
+	if err != nil {
+		panic(err)
+	}
+	ctx.Input.CruSession.SessionRelease(ctx.ResponseWriter)
+}
+
 func parseBearerToken(ctx *context.Context) string {
 	header := ctx.Request.Header.Get("Authorization")
 	tokens := strings.Split(header, " ")

--- a/routers/router.go
+++ b/routers/router.go
@@ -50,6 +50,7 @@ func initAPI() {
 	beego.Router("/api/get-app-login", &controllers.ApiController{}, "GET:GetApplicationLogin")
 	beego.Router("/api/logout", &controllers.ApiController{}, "POST:Logout")
 	beego.Router("/api/get-account", &controllers.ApiController{}, "GET:GetAccount")
+	beego.Router("/api/userinfo", &controllers.ApiController{}, "GET:GetUserinfo")
 	beego.Router("/api/unlink", &controllers.ApiController{}, "POST:Unlink")
 	beego.Router("/api/get-saml-login", &controllers.ApiController{}, "GET:GetSamlLogin")
 	beego.Router("/api/acs", &controllers.ApiController{}, "POST:HandleSamlLogin")


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/443
Userinfo endpoint has been implemented according to the [OIDC standard](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse). 

We also need to adjust the uri of the userinfo_endpoint in oidc discovery, but since our current documentation still uses the old get-account endpoint for the integration, e.g. [Jenkins documentation](https://casdoor.org/docs/integration/jenkins/), we need to synchronize the documentation before.

If we use "openid" scope to get userinfo endpoint, we will get like:
```json
{
    "sub": "2f80c349-4beb-407f-b1f0-528aac0f1acd",
    "iss": "https://door.casbin.com",
    "aud": "7a11****0fa2172"
}
```
and if we use "openid profile address phone email", we will get like:
```json
{
    "sub": "2f80c349-4beb-407f-b1f0-528aac0f1acd",
    "iss": "https://door.casbin.com",
    "aud": "7a11****0fa2172",
    "name": "admin",
    "preferred_username": "Admin",
    "email": "admin@example.com",
    "picture": "https://casbin.org/img/casbin.svg",
    "address": "Guangdong",
    "phone": "12345678910"
}
```
Signed-off-by: 0x2a <stevesough@gmail.com>