### PR TITLE
fix: fix permission page can't open

### DIFF
--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -596,6 +596,7 @@ export function getTagColor(s) {
 
 export function getTags(tags) {
   let res = [];
+  if (!tags) return res;
   tags.forEach((tag, i) => {
     res.push(
       <Tag color={getTagColor(tag)}>


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/445

fixed in a initial project, when open premission page, the page will be crash