### PR TITLE
fix: no database check when using accessToken

### DIFF
--- a/object/token.go
+++ b/object/token.go
@@ -156,6 +156,16 @@ func DeleteToken(token *Token) bool {
 	return affected != 0
 }
 
+func GetTokenByAccessToken(accessToken string) *Token {
+	//Check if the accessToken is in the database
+	token := Token{}
+	existed, err := adapter.Engine.Where("access_token=?", accessToken).Get(&token)
+	if err != nil || !existed {
+		return nil
+	}
+	return &token
+}
+
 func CheckOAuthLogin(clientId string, responseType string, redirectUri string, scope string, state string) (string, *Application) {
 	if responseType != "code" {
 		return "response_type should be \"code\"", nil

--- a/util/time.go
+++ b/util/time.go
@@ -28,3 +28,10 @@ func GetCurrentTime() string {
 func GetCurrentUnixTime() string {
 	return strconv.FormatInt(time.Now().UnixNano(), 10)
 }
+
+func CheckTokenExpireTime(createdTime string, expireIn int) bool {
+	create, _ := time.Parse(time.RFC3339, createdTime)
+	expireAt := create.Add(time.Duration(expireIn) * time.Minute)
+
+	return time.Now().Before(expireAt)
+}


### PR DESCRIPTION
In the current version, if we use accessToken for API request, casdoor will only check if the accessToken is issued by itself, but not if the accessToken still exists in the database.
This pr solves the above problem and decouples the accessToken from the identity, so the current code will still work if we support non-jwt accessToken format later.
Signed-off-by: 0x2a <stevesough@gmail.com>