### PR TITLE
fix: miss ca-certificates in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN yarn install && yarn run build
 
 
 FROM debian:latest AS ALLINONE
-RUN apt update && apt install -y mariadb-server mariadb-client&&mkdir -p web/build && chmod 777 /tmp
+RUN apt update
+RUN apt install -y ca-certificates && update-ca-certificates
+RUN apt install -y mariadb-server mariadb-client && mkdir -p web/build && chmod 777 /tmp
 LABEL MAINTAINER="https://casdoor.org/"
 COPY --from=BACK /go/src/casdoor/ ./
 COPY --from=BACK /usr/bin/wait-for-it ./
@@ -26,6 +28,7 @@ mysqladmin -u root password ${MYSQL_ROOT_PASSWORD} &&\
 FROM alpine:latest
 RUN sed -i 's/https/http/' /etc/apk/repositories
 RUN apk add curl
+RUN apk add ca-certificates && update-ca-certificates
 LABEL MAINTAINER="https://casdoor.org/"
 
 COPY --from=BACK /go/src/casdoor/ ./
@@ -33,4 +36,3 @@ COPY --from=BACK /usr/bin/wait-for-it ./
 RUN mkdir -p web/build && apk add --no-cache bash coreutils
 COPY --from=FRONT /web/build /web/build
 CMD  ./server
-


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Summary

When I test the Casdoor with the Github provider, I got `Post "https://github.com/login/oauth/access_token": X509 certificate signed by unknown authority`, so I write a Golang project to request this, but I still get the same error. The root cause is the OS doesn't know the correctness of the website ca, so we need to install `ca-certificates` in OS.

