### PR TITLE
fix: docker-compose.yml has duplicated label

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       RUNNING_IN_DOCKER: "true"
     volumes:
       - ./conf:/conf/
-    restart: always
   db:
     restart: always
     image: mysql:8.0.25


### PR DESCRIPTION
the casdoor service config in docker-compose.yml has duplicated restart label