### PR TITLE
fix: facebook login exceptions

### DIFF
--- a/idp/facebook.go
+++ b/idp/facebook.go
@@ -122,9 +122,9 @@ func (idp *FacebookIdProvider) GetToken(code string) (*oauth2.Token, error) {
 //}
 
 type FacebookUserInfo struct {
-	Id         string `json:"id"`          // The app user's App-Scoped User ID. This ID is unique to the app and cannot be used by other apps.
-	Name       string `json:"name"`        // The person's full name.
-	NameFormat string `json:"name_format"` // The person's name formatted to correctly handle Chinese, Japanese, or Korean ordering.
+	Id         string   `json:"id"`          // The app user's App-Scoped User ID. This ID is unique to the app and cannot be used by other apps.
+	Name       string   `json:"name"`        // The person's full name.
+	NameFormat string   `json:"name_format"` // The person's name formatted to correctly handle Chinese, Japanese, or Korean ordering.
 	Picture    struct { // The person's profile picture.
 		Data struct { // This struct is different as https://developers.facebook.com/docs/graph-api/reference/user/picture/
 			Height       int    `json:"height"`
@@ -164,6 +164,7 @@ func (idp *FacebookIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, erro
 
 	userInfo := UserInfo{
 		Id:          facebookUserInfo.Id,
+		Username:    facebookUserInfo.Name,
 		DisplayName: facebookUserInfo.Name,
 		Email:       facebookUserInfo.Email,
 		AvatarUrl:   facebookUserInfo.Picture.Data.Url,


### PR DESCRIPTION
Fixed an exception caused by "Username" being empty when registering user information when logging in with Facebook.

![20220223-184504](https://user-images.githubusercontent.com/18255445/155304328-90f68915-3353-4d68-b800-d01e913971dc.png)

Signed-off-by: Jerry [lamjerry.johnsken@gmail.com](mailto:lamjerry.johnsken@gmail.com)