### PR TITLE
feat: add two authentication flow types

### DIFF
--- a/controllers/token.go
+++ b/controllers/token.go
@@ -171,12 +171,16 @@ func (c *ApiController) GetOAuthToken() {
 	clientSecret := c.Input().Get("client_secret")
 	code := c.Input().Get("code")
 	verifier := c.Input().Get("code_verifier")
+	scope := c.Input().Get("scope")
+	username := c.Input().Get("username")
+	password := c.Input().Get("password")
 
 	if clientId == "" && clientSecret == "" {
 		clientId, clientSecret, _ = c.Ctx.Request.BasicAuth()
 	}
+	host := c.Ctx.Request.Host
 
-	c.Data["json"] = object.GetOAuthToken(grantType, clientId, clientSecret, code, verifier)
+	c.Data["json"] = object.GetOAuthToken(grantType, clientId, clientSecret, code, verifier, scope, username, password, host)
 	c.ServeJSON()
 }
 

--- a/object/application.go
+++ b/object/application.go
@@ -38,7 +38,7 @@ type Application struct {
 	EnableCodeSignin    bool            `json:"enableCodeSignin"`
 	Providers           []*ProviderItem `xorm:"mediumtext" json:"providers"`
 	SignupItems         []*SignupItem   `xorm:"varchar(1000)" json:"signupItems"`
-	AllowMethods        []string        `xorm:"varchar(1000)" json:"allowMethods"`
+	GrantTypes          []string        `xorm:"varchar(1000)" json:"grantTypes"`
 	OrganizationObj     *Organization   `xorm:"-" json:"organizationObj"`
 
 	ClientId             string   `xorm:"varchar(100)" json:"clientId"`

--- a/object/application.go
+++ b/object/application.go
@@ -38,6 +38,7 @@ type Application struct {
 	EnableCodeSignin    bool            `json:"enableCodeSignin"`
 	Providers           []*ProviderItem `xorm:"mediumtext" json:"providers"`
 	SignupItems         []*SignupItem   `xorm:"varchar(1000)" json:"signupItems"`
+	AllowMethods        []string        `xorm:"varchar(1000)" json:"allowMethods"`
 	OrganizationObj     *Organization   `xorm:"-" json:"organizationObj"`
 
 	ClientId             string   `xorm:"varchar(100)" json:"clientId"`

--- a/object/token.go
+++ b/object/token.go
@@ -274,7 +274,7 @@ func GetOAuthToken(grantType string, clientId string, clientSecret string, code 
 	}
 
 	//Check if grantType is allowed in the current application
-	if !checkMethodValid(grantType, application.AllowMethods) {
+	if !checkMethodValid(grantType, application.GrantTypes) {
 		return &TokenWrapper{
 			AccessToken: "error: grant_type does not support in this application",
 			TokenType:   "",
@@ -425,11 +425,11 @@ func pkceChallenge(verifier string) string {
 
 // Check if grantType is allowed in the current application
 // authorization_code is allowed by default
-func checkMethodValid(method string, AllowMethods []string) bool {
+func checkMethodValid(method string, GrantTypes []string) bool {
 	if method == "authorization_code" {
 		return true
 	}
-	for _, m := range AllowMethods {
+	for _, m := range GrantTypes {
 		if m == method {
 			return true
 		}

--- a/object/token.go
+++ b/object/token.go
@@ -292,13 +292,6 @@ func GetOAuthToken(grantType string, clientId string, clientSecret string, code 
 		token, err = GetPasswordToken(application, username, password, scope, host)
 	case "client_credentials": // Client Credentials Grant
 		token, err = GetClientCredentialsToken(application, clientSecret, scope, host)
-	default:
-		return &TokenWrapper{
-			AccessToken: "error: grant_type does not support",
-			TokenType:   "",
-			ExpiresIn:   0,
-			Scope:       "",
-		}
 	}
 
 	if err != nil {

--- a/object/token.go
+++ b/object/token.go
@@ -274,9 +274,9 @@ func GetOAuthToken(grantType string, clientId string, clientSecret string, code 
 	}
 
 	//Check if grantType is allowed in the current application
-	if !checkMethodValid(grantType, application.GrantTypes) {
+	if !isGrantTypeValid(grantType, application.GrantTypes) {
 		return &TokenWrapper{
-			AccessToken: "error: grant_type does not support in this application",
+			AccessToken: fmt.Sprintf("error: grant_type: %s is not supported in this application", grantType),
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
@@ -425,11 +425,11 @@ func pkceChallenge(verifier string) string {
 
 // Check if grantType is allowed in the current application
 // authorization_code is allowed by default
-func checkMethodValid(method string, GrantTypes []string) bool {
+func isGrantTypeValid(method string, grantTypes []string) bool {
 	if method == "authorization_code" {
 		return true
 	}
-	for _, m := range GrantTypes {
+	for _, m := range grantTypes {
 		if m == method {
 			return true
 		}
@@ -474,7 +474,7 @@ func GetAuthorizationCodeToken(application *Application, clientSecret string, co
 func GetPasswordToken(application *Application, username string, password string, scope string, host string) (*Token, error) {
 	user := getUser(application.Organization, username)
 	if user == nil {
-		return nil, errors.New("error: invalid username or password")
+		return nil, errors.New("error: the user does not exist")
 	}
 	if user.Password != password {
 		return nil, errors.New("error: invalid username or password")

--- a/routers/auto_signin_filter.go
+++ b/routers/auto_signin_filter.go
@@ -62,7 +62,7 @@ func AutoSigninFilter(ctx *context.Context) {
 	// "/page?username=abc&password=123"
 	userId = ctx.Input.Query("username")
 	password := ctx.Input.Query("password")
-	if userId != "" && password != "" {
+	if userId != "" && password != "" && ctx.Input.Query("grant_type") == "" {
 		owner, name := util.GetOwnerAndNameFromId(userId)
 		_, msg := object.CheckUserPassword(owner, name, password)
 		if msg != "" {

--- a/web/src/ApplicationEditPage.js
+++ b/web/src/ApplicationEditPage.js
@@ -451,7 +451,7 @@ class ApplicationEditPage extends React.Component {
                     }} >
               {
                 (
-                  ["authorization_code","implicit","password","client_credentials"].map((option, index) => {
+                  ["authorization_code","password","client_credentials"].map((option, index) => {
                     return (
                       <Option key={option} value={option}>{option}</Option>
                     )

--- a/web/src/ApplicationEditPage.js
+++ b/web/src/ApplicationEditPage.js
@@ -61,6 +61,9 @@ class ApplicationEditPage extends React.Component {
   getApplication() {
     ApplicationBackend.getApplication("admin", this.state.applicationName)
       .then((application) => {
+        if (application.allowMethods === null || application.allowMethods.length === 0) {
+          application.allowMethods = ["authorization_code"];
+        }
         this.setState({
           application: application,
         });
@@ -433,6 +436,29 @@ class ApplicationEditPage extends React.Component {
                 this.updateApplicationField("signinHtml", e.target.value)
               }}/>
             </Popover>
+          </Col>
+        </Row>
+        <Row style={{marginTop: '20px'}} >
+          <Col style={{marginTop: '5px'}} span={(Setting.isMobile()) ? 22 : 2}>
+            {Setting.getLabel(i18next.t("application:Method"), i18next.t("application:Method - Tooltip"))} :
+          </Col>
+          <Col span={22} >
+            
+            <Select virtual={false} mode="tags" style={{width: '100%'}}
+                    value={this.state.application.allowMethods}
+                    onChange={value => {
+                      this.updateApplicationField('allowMethods', value);
+                    }} >
+              {
+                (
+                  ["authorization_code","implicit","password","client_credentials"].map((option, index) => {
+                    return (
+                      <Option key={option} value={option}>{option}</Option>
+                    )
+                  })
+                )
+              }
+            </Select>
           </Col>
         </Row>
         <Row style={{marginTop: '20px'}} >

--- a/web/src/ApplicationEditPage.js
+++ b/web/src/ApplicationEditPage.js
@@ -61,8 +61,8 @@ class ApplicationEditPage extends React.Component {
   getApplication() {
     ApplicationBackend.getApplication("admin", this.state.applicationName)
       .then((application) => {
-        if (application.allowMethods === null || application.allowMethods.length === 0) {
-          application.allowMethods = ["authorization_code"];
+        if (application.grantTypes === null || application.grantTypes.length === 0) {
+          application.grantTypes = ["authorization_code"];
         }
         this.setState({
           application: application,
@@ -440,24 +440,22 @@ class ApplicationEditPage extends React.Component {
         </Row>
         <Row style={{marginTop: '20px'}} >
           <Col style={{marginTop: '5px'}} span={(Setting.isMobile()) ? 22 : 2}>
-            {Setting.getLabel(i18next.t("application:Method"), i18next.t("application:Method - Tooltip"))} :
+            {Setting.getLabel(i18next.t("application:Grant Types"), i18next.t("application:Grant Types - Tooltip"))} :
           </Col>
           <Col span={22} >
             
             <Select virtual={false} mode="tags" style={{width: '100%'}}
-                    value={this.state.application.allowMethods}
-                    onChange={value => {
-                      this.updateApplicationField('allowMethods', value);
-                    }} >
-              {
-                (
-                  ["authorization_code","password","client_credentials"].map((option, index) => {
-                    return (
-                      <Option key={option} value={option}>{option}</Option>
-                    )
-                  })
-                )
-              }
+                    value={this.state.application.grantTypes}
+                    onChange={(value => {
+                      this.updateApplicationField('grantTypes', value);
+                    })} >
+                      {
+                        [
+                          {id: "authorization_code", name: "Authorization Code"},
+                          {id: "password", name: "Password"},
+                          {id: "client_credentials", name: "Client Credentials"},
+                        ].map((item, index)=><Option key={index} value={item.id}>{item.name}</Option>)
+                      }
             </Select>
           </Col>
         </Row>


### PR DESCRIPTION
According to [RFC-6749](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4), the following authentication methods have been added.
1. Resource Owner Password Credentials Grant
  access `/api/login/oauth/access_token?grant_type=password&username=USERNAME&password=PASSWORD&client_id=CLIENT_ID` to get accessToken
2. Client Credentials Grant
  access `/api/login/oauth/access_token?grant_type=client_credentials&client_id=CLIENT_ID&client_secret=CLIENT_SECRET` to get accessToken
3. The application administrator can add or remove allowed authentication methods from the application management page, where the authorization_code method is currently allowed by default. 
  
![image](https://user-images.githubusercontent.com/17063270/155724472-16b3fd29-8d4b-42f9-b5af-fff840f8dbc0.png)

The implicit method is not currently supported because it involves front-end modifications.
Signed-off-by: Steve0x2a <stevesough@gmail.com>