### PR TITLE
feat: add implicit flow support

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -24,8 +24,10 @@ import (
 )
 
 const (
-	ResponseTypeLogin = "login"
-	ResponseTypeCode  = "code"
+	ResponseTypeLogin   = "login"
+	ResponseTypeCode    = "code"
+	ResponseTypeToken   = "token"
+	ResponseTypeIdToken = "id_token"
 )
 
 type RequestForm struct {

--- a/web/src/ApplicationEditPage.js
+++ b/web/src/ApplicationEditPage.js
@@ -453,6 +453,8 @@ class ApplicationEditPage extends React.Component {
                           {id: "authorization_code", name: "Authorization Code"},
                           {id: "password", name: "Password"},
                           {id: "client_credentials", name: "Client Credentials"},
+                          {id: "token", name: "Token"},
+                          {id: "id_token",name:"ID Token"},
                         ].map((item, index)=><Option key={index} value={item.id}>{item.name}</Option>)
                       }
             </Select>

--- a/web/src/auth/AuthCallback.js
+++ b/web/src/auth/AuthCallback.js
@@ -58,6 +58,10 @@ class AuthCallback extends React.Component {
       if (authServerUrl === realRedirectUrl) {
         return "login";
       } else {
+        const responseType = innerParams.get("response_type");
+        if (responseType !== null) {
+          return responseType
+        }
         return "code";
       }
     } else if (method === "link") {
@@ -116,6 +120,9 @@ class AuthCallback extends React.Component {
             const code = res.data;
             Setting.goToLink(`${oAuthParams.redirectUri}?code=${code}&state=${oAuthParams.state}`);
             // Util.showMessage("success", `Authorization code: ${res.data}`);
+          } else if (responseType === "token" || responseType === "id_token"){
+            const token = res.data;
+            Setting.goToLink(`${oAuthParams.redirectUri}?${responseType}=${token}&state=${oAuthParams.state}&token_type=bearer`);
           } else if (responseType === "link") {
             const from = innerParams.get("from");
             Setting.goToLinkSoft(this, from);

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -116,14 +116,18 @@ class LoginPage extends React.Component {
   onFinish(values) {
     const application = this.getApplicationObj();
     const ths = this;
-    values["type"] = this.state.type;
-    values["phonePrefix"] = this.getApplicationObj()?.organizationObj.phonePrefix;
     const oAuthParams = Util.getOAuthGetParameters();
-
+    if (oAuthParams !== null && oAuthParams.responseType!= null && oAuthParams.responseType !== "") {
+      values["type"] = oAuthParams.responseType
+    }else{
+      values["type"] = this.state.type;
+    }
+    values["phonePrefix"] = this.getApplicationObj()?.organizationObj.phonePrefix;
+    
     AuthBackend.login(values, oAuthParams)
       .then((res) => {
         if (res.status === 'ok') {
-          const responseType = this.state.type;
+          const responseType = values["type"];
           if (responseType === "login") {
             Util.showMessage("success", `Logged in successfully`);
 
@@ -156,6 +160,9 @@ class LoginPage extends React.Component {
             }
 
             // Util.showMessage("success", `Authorization code: ${res.data}`);
+          } else if (responseType === "token" || responseType === "id_token") {
+            const accessToken = res.data;
+            Setting.goToLink(`${oAuthParams.redirectUri}#${responseType}=${accessToken}?state=${oAuthParams.state}&token_type=bearer`);
           }
         } else {
           Util.showMessage("error", `Failed to log in: ${res.msg}`);


### PR DESCRIPTION
1. add implicit flow support
  access `/login/oauth/authorize?client_id=CLIENT_ID&redirect_uri=REDIRECT_URI&response_type=token&scope=openid+email+profile&state=1233` to get accesstoken and redirect to `REDIRECT_URI/#token=ACCESS_TOKEN`
2. add id_token response_type support
    access `/login/oauth/authorize?client_id=CLIENT_ID&redirect_uri=REDIRECT_URI&response_type=id_token&scope=openid+email+profile&state=1233` to get accesstoken and redirect to `REDIRECT_URI/#id_token=ID_TOKEN` 
 Fix: https://github.com/casdoor/casdoor/issues/514

Signed-off-by: Steve0x2a <stevesough@gmail.com>