### PR TITLE
fix: update authz rule list

### DIFF
--- a/authz/authz.go
+++ b/authz/authz.go
@@ -83,14 +83,10 @@ p, *, *, GET, /api/get-account, *, *
 p, *, *, GET, /api/userinfo, *, *
 p, *, *, POST, /api/login/oauth/access_token, *, *
 p, *, *, POST, /api/login/oauth/refresh_token, *, *
-p, *, *, GET, /api/get-application, *, *
-p, *, *, GET, /api/get-users, *, *
+p, *, !anonymous, GET, /api/get-application, *, *
 p, *, *, GET, /api/get-user, *, *
-p, *, *, GET, /api/get-organizations, *, *
-p, *, *, GET, /api/get-user-application, *, *
-p, *, *, GET, /api/get-default-providers, *, *
+p, *, !anonymous, GET, /api/get-user-application, *, *
 p, *, *, GET, /api/get-resources, *, *
-p, *, *, POST, /api/upload-avatar, *, *
 p, *, *, POST, /api/unlink, *, *
 p, *, *, POST, /api/set-password, *, *
 p, *, *, POST, /api/send-verification-code, *, *

--- a/authz/authz.go
+++ b/authz/authz.go
@@ -83,9 +83,10 @@ p, *, *, GET, /api/get-account, *, *
 p, *, *, GET, /api/userinfo, *, *
 p, *, *, POST, /api/login/oauth/access_token, *, *
 p, *, *, POST, /api/login/oauth/refresh_token, *, *
-p, *, !anonymous, GET, /api/get-application, *, *
+p, *, *, GET, /api/login/oauth/logout, *, *
+p, *, *, GET, /api/get-application, *, *
 p, *, *, GET, /api/get-user, *, *
-p, *, !anonymous, GET, /api/get-user-application, *, *
+p, *, *, GET, /api/get-user-application, *, *
 p, *, *, GET, /api/get-resources, *, *
 p, *, *, POST, /api/unlink, *, *
 p, *, *, POST, /api/set-password, *, *


### PR DESCRIPTION
1. `/api/get-users` , `/api/get-organizations`  can return sensitive information, so only built-in access is allowed.
2. `/api/upload-avatar`, `/api/get-default-providers` are no longer available.
Signed-off-by: Steve0x2a <stevesough@gmail.com>