### PR TITLE
fix: The top-right logout button sometimes disappears for small screen size

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -555,7 +555,7 @@ class App extends Component {
               // theme="dark"
               mode={(Setting.isMobile() && this.isStartPages()) ? "inline" : "horizontal"}
               selectedKeys={[`${this.state.selectedMenuKey}`]}
-              style={{ lineHeight: '64px'}}
+              style={{ lineHeight: '64px', width:"100%", position:"absolute"}}
             >
               {
                 this.renderMenu()

--- a/xlsx/xlsx_test.go
+++ b/xlsx/xlsx_test.go
@@ -16,9 +16,9 @@
 
 package xlsx
 
-//import "testing"
-//
-//func TestReadSheet(t *testing.T) {
-//	ticket := ReadXlsxFile("../../tmpFiles/example")
-//	println(ticket)
-//}
+import "testing"
+
+func TestReadSheet(t *testing.T) {
+	ticket := ReadXlsxFile("../../tmpFiles/example")
+	println(ticket)
+}


### PR DESCRIPTION
fix: #542 
previous:
![image](https://user-images.githubusercontent.com/75596353/157204182-c33106d0-82a8-4025-80ca-e14cfc383f24.png)
now:
<img width="640" alt="image" src="https://user-images.githubusercontent.com/75596353/157203769-6c9b8bb1-a4bb-48c4-ba6e-a007dd3d7017.png">
800*600
![image](https://user-images.githubusercontent.com/75596353/157204531-80b7329c-9a9e-4a03-b519-aae3f2648e4a.png)
