### PR TITLE
fix: repair the problem that `AutoSigninFilter` middleware doesn't recognize the `access_token` request parameter

### DIFF
--- a/routers/auto_signin_filter.go
+++ b/routers/auto_signin_filter.go
@@ -29,10 +29,8 @@ func AutoSigninFilter(ctx *context.Context) {
 
 	// GET parameter like "/page?access_token=123" or
 	// HTTP Bearer token like "Authorization: Bearer 123"
-	accessToken := ctx.Input.Query("accessToken")
-	if accessToken == "" {
-		accessToken = parseBearerToken(ctx)
-	}
+	accessToken := util.GetMaxLenStr(ctx.Input.Query("accessToken"), ctx.Input.Query("access_token"), parseBearerToken(ctx))
+
 	if accessToken != "" {
 		token := object.GetTokenByAccessToken(accessToken)
 		if token == nil {


### PR DESCRIPTION
AutoSigninFilter method only checks for `accessToken` request parameters or `Authorization` request header, doesn't recognize `access_token` request parameters, now added, use `utils.GetMaxLenStr()` method to get the maximum length characters