### PR TITLE
fix: redirect for non-built-in app logout

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -225,10 +225,15 @@ func (c *ApiController) Logout() {
 	user := c.GetSessionUsername()
 	util.LogInfo(c.Ctx, "API: [%s] logged out", user)
 
+	application := c.GetSessionApplication()
 	c.SetSessionUsername("")
 	c.SetSessionData(nil)
 
-	c.ResponseOk(user)
+	if application == nil || application.Name == "app-built-in" || application.HomepageUrl == "" {
+		c.ResponseOk(user)
+		return
+	}
+	c.ResponseOk(user, application.HomepageUrl)
 }
 
 // GetAccount

--- a/controllers/base.go
+++ b/controllers/base.go
@@ -72,6 +72,15 @@ func (c *ApiController) GetSessionUsername() string {
 	return user.(string)
 }
 
+func (c *ApiController) GetSessionApplication() *object.Application {
+	clientId := c.GetSession("aud")
+	if clientId == nil {
+		return nil
+	}
+	application := object.GetApplicationByClientId(clientId.(string))
+	return application
+}
+
 func (c *ApiController) GetSessionOidc() (string, string) {
 	sessionData := c.GetSessionData()
 	if sessionData != nil &&

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -235,8 +235,12 @@ class App extends Component {
           });
 
           Setting.showMessage("success", `Logged out successfully`);
-
-          Setting.goToLinkSoft(this, "/");
+          let redirectUri = res.data2;
+          if (redirectUri !== null && redirectUri !== undefined && redirectUri !== "") {
+            Setting.goToLink(redirectUri);
+          }else{
+            Setting.goToLinkSoft(this, "/");
+          }
         } else {
           Setting.showMessage("error", `Failed to log out: ${res.msg}`);
         }

--- a/web/src/auth/PromptPage.js
+++ b/web/src/auth/PromptPage.js
@@ -147,7 +147,10 @@ class PromptPage extends React.Component {
         if (res.status === 'ok') {
           this.onUpdateAccount(null);
 
-          const redirectUrl = this.getRedirectUrl();
+          let redirectUrl = this.getRedirectUrl();
+          if (redirectUrl === "") {
+            redirectUrl = res.data2
+          }
           if (redirectUrl !== "") {
             Setting.goToLink(redirectUrl);
           } else {


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/580
Now, after using the accessToken to log in to Casdoor, if you use the logout, you will directly jump to the homepage(if homepage is not empty) of the application that issued the accessToken.
Signed-off-by: Steve0x2a <stevesough@gmail.com>