### PR TITLE
fix: fix missing +build

### DIFF
--- a/object/product_test.go
+++ b/object/product_test.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //go:build !skipCi
+// +build !skipCi
 
 package object
 


### PR DESCRIPTION
fix: fix missing // +build
without this line of comment, code won't be able to be compiled with golang whose version is not greater than 1.16