### PR TITLE
fix: Edited casdoor_session_id session to strict

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/casdoor/casdoor/proxy"
 	"github.com/casdoor/casdoor/routers"
 	_ "github.com/casdoor/casdoor/routers"
+	"net/http"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 		beego.BConfig.WebConfig.Session.SessionProviderConfig = conf.GetConfigString("redisEndpoint")
 	}
 	beego.BConfig.WebConfig.Session.SessionCookieLifeTime = 3600 * 24 * 30
-	//beego.BConfig.WebConfig.Session.SessionCookieSameSite = http.SameSiteNoneMode
+	beego.BConfig.WebConfig.Session.SessionCookieSameSite = http.SameSiteStrictMode
 
 	err := logs.SetLogger("file", `{"filename":"logs/casdoor.log","maxdays":99999,"perm":"0770"}`)
 	if err != nil {


### PR DESCRIPTION
### Description:
I have done this because of the CSRF attack, However that you send the data as json but the content_type header in the request is not assigned to application/json and you don't even check it on the backend to make sure that this data isn't sent from a form tag, By this an attacker can make a form tag to with content_type set to text/plain to make the user change his information without him knowing of the change, the impact of this is that the attacker can make an account takeover or he can get a very sensitive information.

Below is a proof of concept to validate it,  in order for this to work the attacker just has to know the victim username so edit the keyword "VALUEONE" in action attribute and in the name attribute in the below POC with the victim username that he has then edit "VALUETWO" in the displayName  with a name that you want to give him, then place the html code below in an html page and visit it the request will be right and you will receive a response with Affected keyword in it.

### Proof Of Concept:

https://pastebin.com/raw/nGXUt5Ut

### The Solution:

I choose to set the casdoor_session_id  to strict, by this the session will not be assigned to the request if the request is done from cross domain application

Please contact me if there is any explanation.
