### PR TITLE
fix: docker-compose up can't work on linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - db
     environment:
       RUNNING_IN_DOCKER: "true"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./conf:/conf/
   db:


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/69711608/159417667-cc711f31-ddb4-456f-a305-2efdf6baefbf.png)

At  `./conf/conf.go:64`, when running in docker, `localhost` is replaced with `host.docker.internal`, however on linux the Docker host cannot be direct access via the `host.docker.internal` hostname. 

The following configuration needs to be added `--add-host=host.docker.internal:host-gateway`.