### PR TITLE
fix: WeComInternalIdProvider GetUserInfo method could not get the correct user id

### DIFF
--- a/idp/wecom_internal.go
+++ b/idp/wecom_internal.go
@@ -111,6 +111,7 @@ type WecomInternalUserInfo struct {
 	Email   string `json:"email"`
 	Avatar  string `json:"avatar"`
 	OpenId  string `json:"open_userid"`
+	UserId  string `json:"userid"`
 }
 
 func (idp *WeComInternalIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error) {
@@ -156,7 +157,7 @@ func (idp *WeComInternalIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo,
 		return nil, fmt.Errorf("userInfoResp.errcode = %d, userInfoResp.errmsg = %s", infoResp.Errcode, infoResp.Errmsg)
 	}
 	userInfo := UserInfo{
-		Id:          infoResp.OpenId,
+		Id:          infoResp.UserId,
 		Username:    infoResp.Name,
 		DisplayName: infoResp.Name,
 		Email:       infoResp.Email,


### PR DESCRIPTION
According to the Wecom official API documentation, Modify GetUserInfo method in order to get the correct user id instead of always the username.

Reference link：https://developer.work.weixin.qq.com/document/path/90196