### PR TITLE
fix: token endpoint supports json format

### DIFF
--- a/controllers/token.go
+++ b/controllers/token.go
@@ -179,6 +179,20 @@ func (c *ApiController) GetOAuthToken() {
 	if clientId == "" && clientSecret == "" {
 		clientId, clientSecret, _ = c.Ctx.Request.BasicAuth()
 	}
+	if clientId == "" {
+		// If clientID is empty, try to read data from RequestBody
+		var tokenRequest TokenRequest
+		if err := json.Unmarshal(c.Ctx.Input.RequestBody, &tokenRequest); err == nil {
+			clientId = tokenRequest.ClientId
+			clientSecret = tokenRequest.ClientSecret
+			grantType = tokenRequest.GrantType
+			code = tokenRequest.Code
+			verifier = tokenRequest.Verifier
+			scope = tokenRequest.Scope
+			username = tokenRequest.Username
+			password = tokenRequest.Password
+		}
+	}
 	host := c.Ctx.Request.Host
 
 	c.Data["json"] = object.GetOAuthToken(grantType, clientId, clientSecret, code, verifier, scope, username, password, host)
@@ -203,6 +217,18 @@ func (c *ApiController) RefreshToken() {
 	clientId := c.Input().Get("client_id")
 	clientSecret := c.Input().Get("client_secret")
 	host := c.Ctx.Request.Host
+
+	if clientId == "" {
+		// If clientID is empty, try to read data from RequestBody
+		var tokenRequest TokenRequest
+		if err := json.Unmarshal(c.Ctx.Input.RequestBody, &tokenRequest); err == nil {
+			clientId = tokenRequest.ClientId
+			clientSecret = tokenRequest.ClientSecret
+			grantType = tokenRequest.GrantType
+			scope = tokenRequest.Scope
+
+		}
+	}
 
 	c.Data["json"] = object.RefreshToken(grantType, refreshToken, scope, clientId, clientSecret, host)
 	c.ServeJSON()

--- a/controllers/types.go
+++ b/controllers/types.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+type TokenRequest struct {
+	GrantType    string `json:"grant_type"`
+	Code         string `json:"code"`
+	ClientId     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	Verifier     string `json:"code_verifier"`
+	Scope        string `json:"scope"`
+	Username     string `json:"username"`
+	Password     string `json:"password"`
+}


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/637
The accessToken and refreshToken ports now support JSON data in the requestBody.

```json
//test.json
{
  "grant_type": "authorization_code",
  "client_id": "c58c570b63c9bdbfe00c",
  "client_secret": "deabbc5717262b162c2b7235bc32496b05549e87",
  "code": "2d17202bef2a1c65cd88"
}
```
use curl:
```bash
curl -v -d @test.json http://localhost:8000/api/login/oauth/access_token
```
Signed-off-by: Steve0x2a <stevesough@gmail.com>