### PR TITLE
feat: support user migration from Keycloak using syncer

### DIFF
--- a/cred/manager.go
+++ b/cred/manager.go
@@ -28,6 +28,8 @@ func GetCredManager(passwordType string) CredManager {
 		return NewMd5UserSaltCredManager()
 	} else if passwordType == "bcrypt" {
 		return NewBcryptCredManager()
+	} else if passwordType == "pbkdf2-salt" {
+		return NewPbkdf2SaltCredManager()
 	}
 	return nil
 }

--- a/cred/pbkdf2-salt.go
+++ b/cred/pbkdf2-salt.go
@@ -1,0 +1,39 @@
+// Copyright 2022 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cred
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+type Pbkdf2SaltCredManager struct{}
+
+func NewPbkdf2SaltCredManager() *Pbkdf2SaltCredManager {
+	cm := &Pbkdf2SaltCredManager{}
+	return cm
+}
+
+func (cm *Pbkdf2SaltCredManager) GetHashedPassword(password string, userSalt string, organizationSalt string) string {
+	// https://www.keycloak.org/docs/latest/server_admin/index.html#password-database-compromised
+	decodedSalt, _ := base64.StdEncoding.DecodeString(userSalt)
+	res := pbkdf2.Key([]byte(password), decodedSalt, 27500, 64, sha256.New)
+	return base64.StdEncoding.EncodeToString(res)
+}
+
+func (cm *Pbkdf2SaltCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, userSalt string, organizationSalt string) bool {
+	return hashedPwd == cm.GetHashedPassword(plainPwd, userSalt, organizationSalt)
+}

--- a/object/syncer_user.go
+++ b/object/syncer_user.go
@@ -25,6 +25,11 @@ import (
 
 type OriginalUser = User
 
+type Credential struct {
+	Value string `json:"value"`
+	Salt  string `json:"salt"`
+}
+
 func (syncer *Syncer) getOriginalUsers() ([]*OriginalUser, error) {
 	sql := fmt.Sprintf("select * from %s", syncer.getTable())
 	results, err := syncer.Adapter.Engine.QueryString(sql)

--- a/object/syncer_util.go
+++ b/object/syncer_util.go
@@ -15,6 +15,7 @@
 package object
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -99,6 +100,10 @@ func (syncer *Syncer) setUserByKeyValue(user *User, key string, value string) {
 		user.PasswordSalt = value
 	case "DisplayName":
 		user.DisplayName = value
+	case "FirstName":
+		user.FirstName = value
+	case "LastName":
+		user.LastName = value
 	case "Avatar":
 		user.Avatar = syncer.getPartialAvatarUrl(value)
 	case "PermanentAvatar":
@@ -167,6 +172,26 @@ func (syncer *Syncer) getOriginalUsersFromMap(results []map[string]string) []*Or
 		for _, tableColumn := range syncer.TableColumns {
 			syncer.setUserByKeyValue(originalUser, tableColumn.CasdoorName, result[tableColumn.Name])
 		}
+
+		if syncer.Type == "Keycloak" {
+			// query and set password and password salt from credential table
+			sql := fmt.Sprintf("select * from credential where type = 'password' and user_id = '%s'", originalUser.Id)
+			credentialResult, _ := syncer.Adapter.Engine.QueryString(sql)
+			if len(credentialResult) > 0 {
+				credential := Credential{}
+				_ = json.Unmarshal([]byte(credentialResult[0]["SECRET_DATA"]), &credential)
+				originalUser.Password = credential.Value
+				originalUser.PasswordSalt = credential.Salt
+			}
+			// query and set signup application from user group table
+			sql = fmt.Sprintf("select name from keycloak_group where id = " +
+				"(select group_id as gid from user_group_membership where user_id = '%s')", originalUser.Id)
+			groupResult, _ := syncer.Adapter.Engine.QueryString(sql)
+			if len(groupResult) > 0 {
+				originalUser.SignupApplication = groupResult[0]["name"]
+			}
+		}
+
 		users = append(users, originalUser)
 	}
 	return users

--- a/web/src/OrganizationEditPage.js
+++ b/web/src/OrganizationEditPage.js
@@ -155,7 +155,7 @@ class OrganizationEditPage extends React.Component {
           <Col span={22} >
             <Select virtual={false} style={{width: '100%'}} value={this.state.organization.passwordType} onChange={(value => {this.updateOrganizationField('passwordType', value);})}>
               {
-                ['plain', 'salt', 'md5-salt', 'bcrypt']
+                ['plain', 'salt', 'md5-salt', 'bcrypt', 'pbkdf2-salt']
                   .map((item, index) => <Option key={index} value={item}>{item}</Option>)
               }
             </Select>

--- a/web/src/SyncerEditPage.js
+++ b/web/src/SyncerEditPage.js
@@ -119,7 +119,7 @@ class SyncerEditPage extends React.Component {
           <Col span={22} >
             <Select virtual={false} style={{width: '100%'}} value={this.state.syncer.type} onChange={(value => {this.updateSyncerField('type', value);})}>
               {
-                ['Database', 'LDAP']
+                ['Database', 'LDAP', 'Keycloak']
                   .map((item, index) => <Option key={index} value={item}>{item}</Option>)
               }
             </Select>

--- a/web/src/SyncerTableColumnTable.js
+++ b/web/src/SyncerTableColumnTable.js
@@ -98,7 +98,7 @@ class SyncerTableColumnTable extends React.Component {
           return (
             <Select virtual={false} style={{width: '100%'}} value={text} onChange={(value => {this.updateField(table, index, 'casdoorName', value);})}>
               {
-                ['Name', 'CreatedTime', 'UpdatedTime', 'Id', 'Type', 'Password', 'PasswordSalt', 'DisplayName', 'Avatar', 'PermanentAvatar', 'Email', 'Phone',
+                ['Name', 'CreatedTime', 'UpdatedTime', 'Id', 'Type', 'Password', 'PasswordSalt', 'DisplayName', 'FirstName', 'LastName', 'Avatar', 'PermanentAvatar', 'Email', 'Phone',
                   'Location', 'Address', 'Affiliation', 'Title', 'IdCardType', 'IdCard', 'Homepage', 'Bio', 'Tag', 'Region', 'Language', 'Gender', 'Birthday',
                   'Education', 'Score', 'Ranking', 'IsDefaultAvatar', 'IsOnline', 'IsAdmin', 'IsGlobalAdmin', 'IsForbidden', 'IsDeleted', 'CreatedIp']
                   .map((item, index) => <Option key={index} value={item}>{item}</Option>)


### PR DESCRIPTION
Essentially keycloak user migration is still based on database tables, but keycloak stores the credential and group message in 2 other tables. 

In addition, the default encrypt algorithm for keycloak passwords is pbkdf2, so I implemented a new credential manager.

The following is the syncer setting.

![image](https://user-images.githubusercontent.com/33992371/161503000-ce16a74e-697a-448e-ad17-92ad8036f32f.png)

users in keycloak:

![image](https://user-images.githubusercontent.com/33992371/161503180-3670583c-ad5a-49a5-ad96-a0d5a529eef2.png)

users in casdoor:

![image](https://user-images.githubusercontent.com/33992371/161503270-921612b2-568f-418b-96fb-5df4754eb2e5.png)


Signed-off-by: Yixiang Zhao <seriouszyx@foxmail.com>