### PR TITLE
fix: add independent error message in token endpoint

### DIFF
--- a/object/token.go
+++ b/object/token.go
@@ -58,6 +58,7 @@ type TokenWrapper struct {
 	TokenType    string `json:"token_type"`
 	ExpiresIn    int    `json:"expires_in"`
 	Scope        string `json:"scope"`
+	Error        string `json:"error,omitempty"`
 }
 
 type IntrospectionResponse struct {
@@ -313,6 +314,7 @@ func GetOAuthToken(grantType string, clientId string, clientSecret string, code 
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
+			Error:       "error: invalid client_id",
 		}
 	}
 
@@ -323,6 +325,7 @@ func GetOAuthToken(grantType string, clientId string, clientSecret string, code 
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
+			Error:       fmt.Sprintf("error: grant_type: %s is not supported in this application", grantType),
 		}
 	}
 
@@ -343,6 +346,7 @@ func GetOAuthToken(grantType string, clientId string, clientSecret string, code 
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
+			Error:       err.Error(),
 		}
 	}
 
@@ -368,6 +372,7 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
+			Error:       "error: grant_type should be \"refresh_token\"",
 		}
 	}
 	application := GetApplicationByClientId(clientId)
@@ -377,6 +382,7 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
+			Error:       "error: invalid client_id",
 		}
 	}
 	if clientSecret != "" && application.ClientSecret != clientSecret {
@@ -385,6 +391,7 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
+			Error:       "error: invalid client_secret",
 		}
 	}
 	// check whether the refresh token is valid, and has not expired.
@@ -396,6 +403,7 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
+			Error:       "error: invalid refresh_token",
 		}
 	}
 
@@ -407,6 +415,7 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
+			Error:       fmt.Sprintf("error: %s", err.Error()),
 		}
 	}
 	// generate a new token
@@ -417,6 +426,7 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
+			Error:       "error: the user is forbidden to sign in, please contact the administrator",
 		}
 	}
 	newAccessToken, newRefreshToken, err := generateJwtToken(application, user, "", scope, host)

--- a/object/token.go
+++ b/object/token.go
@@ -320,12 +320,13 @@ func GetOAuthToken(grantType string, clientId string, clientSecret string, code 
 
 	//Check if grantType is allowed in the current application
 	if !IsGrantTypeValid(grantType, application.GrantTypes) {
+		errString := fmt.Sprintf("error: grant_type: %s is not supported in this application", grantType)
 		return &TokenWrapper{
-			AccessToken: fmt.Sprintf("error: grant_type: %s is not supported in this application", grantType),
+			AccessToken: errString,
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
-			Error:       fmt.Sprintf("error: grant_type: %s is not supported in this application", grantType),
+			Error:       errString,
 		}
 	}
 
@@ -410,12 +411,13 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 	cert := getCertByApplication(application)
 	_, err = ParseJwtToken(refreshToken, cert)
 	if err != nil {
+		errString := fmt.Sprintf("error: %s", err.Error())
 		return &TokenWrapper{
-			AccessToken: fmt.Sprintf("error: %s", err.Error()),
+			AccessToken: errString,
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
-			Error:       fmt.Sprintf("error: %s", err.Error()),
+			Error:       errString,
 		}
 	}
 	// generate a new token

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -2797,11 +2797,11 @@
         }
     },
     "definitions": {
-        "2026.0xc000380de0.false": {
+        "2127.0xc00036c600.false": {
             "title": "false",
             "type": "object"
         },
-        "2060.0xc000380e10.false": {
+        "2161.0xc00036c630.false": {
             "title": "false",
             "type": "object"
         },
@@ -2818,10 +2818,10 @@
             "type": "object",
             "properties": {
                 "data": {
-                    "$ref": "#/definitions/2026.0xc000380de0.false"
+                    "$ref": "#/definitions/2127.0xc00036c600.false"
                 },
                 "data2": {
-                    "$ref": "#/definitions/2060.0xc000380e10.false"
+                    "$ref": "#/definitions/2161.0xc00036c630.false"
                 },
                 "msg": {
                     "type": "string"
@@ -2842,10 +2842,10 @@
             "type": "object",
             "properties": {
                 "data": {
-                    "$ref": "#/definitions/2026.0xc000380de0.false"
+                    "$ref": "#/definitions/2127.0xc00036c600.false"
                 },
                 "data2": {
-                    "$ref": "#/definitions/2060.0xc000380e10.false"
+                    "$ref": "#/definitions/2161.0xc00036c630.false"
                 },
                 "msg": {
                     "type": "string"
@@ -3648,6 +3648,9 @@
                 "access_token": {
                     "type": "string"
                 },
+                "error": {
+                    "type": "string"
+                },
                 "expires_in": {
                     "type": "integer",
                     "format": "int64"
@@ -3680,6 +3683,9 @@
                     "type": "string"
                 },
                 "affiliation": {
+                    "type": "string"
+                },
+                "alipay": {
                     "type": "string"
                 },
                 "apple": {
@@ -3720,6 +3726,9 @@
                 },
                 "email": {
                     "type": "string"
+                },
+                "emailVerified": {
+                    "type": "boolean"
                 },
                 "facebook": {
                     "type": "string"

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -1831,10 +1831,10 @@ paths:
           schema:
             $ref: '#/definitions/object.Userinfo'
 definitions:
-  2026.0xc000380de0.false:
+  2127.0xc00036c600.false:
     title: "false"
     type: object
-  2060.0xc000380e10.false:
+  2161.0xc00036c630.false:
     title: "false"
     type: object
   RequestForm:
@@ -1848,9 +1848,9 @@ definitions:
     type: object
     properties:
       data:
-        $ref: '#/definitions/2026.0xc000380de0.false'
+        $ref: '#/definitions/2127.0xc00036c600.false'
       data2:
-        $ref: '#/definitions/2060.0xc000380e10.false'
+        $ref: '#/definitions/2161.0xc00036c630.false'
       msg:
         type: string
       name:
@@ -1864,9 +1864,9 @@ definitions:
     type: object
     properties:
       data:
-        $ref: '#/definitions/2026.0xc000380de0.false'
+        $ref: '#/definitions/2127.0xc00036c600.false'
       data2:
-        $ref: '#/definitions/2060.0xc000380e10.false'
+        $ref: '#/definitions/2161.0xc00036c630.false'
       msg:
         type: string
       name:
@@ -2407,6 +2407,8 @@ definitions:
     properties:
       access_token:
         type: string
+      error:
+        type: string
       expires_in:
         type: integer
         format: int64
@@ -2429,6 +2431,8 @@ definitions:
       adfs:
         type: string
       affiliation:
+        type: string
+      alipay:
         type: string
       apple:
         type: string
@@ -2456,6 +2460,8 @@ definitions:
         type: string
       email:
         type: string
+      emailVerified:
+        type: boolean
       facebook:
         type: string
       firstName:


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/611
For compatibility reasons, the error message is still in the accessToken, but we may remove it later.
The return value of the token endpoint is now shown below (in case of an error):
```json
{
    "access_token": "error: invalid username or password",
    "id_token": "",
    "refresh_token": "",
    "token_type": "",
    "expires_in": 0,
    "scope": "",
    "error": "error: invalid username or password"
}
```
Signed-off-by: Steve0x2a <stevesough@gmail.com>