### PR TITLE
fix: when req error, read body(nil) will panic

### DIFF
--- a/idp/lark.go
+++ b/idp/lark.go
@@ -169,8 +169,11 @@ func (idp *LarkIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error) {
 	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
 
 	resp, err := idp.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
 	data, err = ioutil.ReadAll(resp.Body)
-	err = resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When an HTTP request error occurs
the response.Body will be nil

ioutil.ReadAll(nil) will panic