### PR TITLE
fix: fix missing RefreshToken parameter in RefreshToken() API

### DIFF
--- a/controllers/token.go
+++ b/controllers/token.go
@@ -230,7 +230,7 @@ func (c *ApiController) RefreshToken() {
 			clientSecret = tokenRequest.ClientSecret
 			grantType = tokenRequest.GrantType
 			scope = tokenRequest.Scope
-
+			refreshToken = tokenRequest.RefreshToken
 		}
 	}
 

--- a/controllers/types.go
+++ b/controllers/types.go
@@ -25,4 +25,5 @@ type TokenRequest struct {
 	Password     string `json:"password"`
 	Tag          string `json:"tag"`
 	Avatar       string `json:"avatar"`
+	RefreshToken string `json:"refresh_token"`
 }


### PR DESCRIPTION
fix #693 