### PR TITLE
fix: add 'use' and 'alg' in .well-known/jwks

### DIFF
--- a/object/oidc_discovery.go
+++ b/object/oidc_discovery.go
@@ -105,7 +105,7 @@ func GetJsonWebKeySet() (jose.JSONWebKeySet, error) {
 		jwk.Key = x509Cert.PublicKey
 		jwk.Certificates = []*x509.Certificate{x509Cert}
 		jwk.KeyID = cert.Name
-		jwk.Algorithm = "RS256"
+		jwk.Algorithm = cert.CryptoAlgorithm
 		jwk.Use = "sig"
 		jwks.Keys = append(jwks.Keys, jwk)
 	}

--- a/object/oidc_discovery.go
+++ b/object/oidc_discovery.go
@@ -105,6 +105,8 @@ func GetJsonWebKeySet() (jose.JSONWebKeySet, error) {
 		jwk.Key = x509Cert.PublicKey
 		jwk.Certificates = []*x509.Certificate{x509Cert}
 		jwk.KeyID = cert.Name
+		jwk.Algorithm = "RS256"
+		jwk.Use = "sig"
 		jwks.Keys = append(jwks.Keys, jwk)
 	}
 


### PR DESCRIPTION
According to #691 , now add the `alg` and `use` parameters to the response of `/.well-known/jwks`

Fix: https://github.com/casdoor/casdoor/issues/691