### PR TITLE
fix: set the password of the sync ldap user to empty

### DIFF
--- a/object/ldap.go
+++ b/object/ldap.go
@@ -387,7 +387,7 @@ func SyncLdapUsers(owner string, users []LdapRespUser) (*[]LdapRespUser, *[]Ldap
 			Owner:       owner,
 			Name:        buildLdapUserName(user.Uid, user.UidNumber),
 			CreatedTime: util.GetCurrentTime(),
-			Password:    "123",
+			Password:    "",
 			DisplayName: user.Cn,
 			Avatar:      "https://casbin.org/img/casbin.svg",
 			Email:       user.Email,


### PR DESCRIPTION
Signed-off-by: Yixiang Zhao <seriouszyx@foxmail.com>