### PR TITLE
fix: docker-compose up fails

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
+    entrypoint: /bin/sh -c './server --createDatabase=true'
     ports:
       - "8000:8000"
     depends_on:


### PR DESCRIPTION
Hi there, I encountered `docker-compose up` failure when I try to use docker-compose to start casdoor server, indicating "Unknown database 'casdoor'".
Here are the logs:
![image](https://user-images.githubusercontent.com/40566803/166095655-60961f94-f2d9-42a6-84d1-1c4f0fe83d06.png)
This is because the server won't create `casdoor` database unless provided with command flag `--createDatabase=true`.
However, the Docker image `CMD` is `./server`, so that server won't create database, which results in `docker-compose up` failure.
https://github.com/casdoor/casdoor/blob/c05fb772241a0f58650a5ed731208303c76580d5/Dockerfile#L37
To fix this issue, we can set `entrypoint` of service casdoor as `/bin/sh -c './server --createDatabase=true'` to make the server create database first.
Here are `docker-compose up` logs after I fixed it:
![image](https://user-images.githubusercontent.com/40566803/166095689-0bb29aa8-3e36-41f4-a03c-038b5eae5ae8.png)
