### PR TITLE
fix: unchanged masked client_secret/password updated to `***`

### DIFF
--- a/object/application.go
+++ b/object/application.go
@@ -257,7 +257,11 @@ func UpdateApplication(id string, application *Application) bool {
 		providerItem.Provider = nil
 	}
 
-	affected, err := adapter.Engine.ID(core.PK{owner, name}).AllCols().Update(application)
+	session := adapter.Engine.ID(core.PK{owner, name}).AllCols()
+	if application.ClientSecret == "***" {
+		session.Omit("client_secret")
+	}
+	affected, err := session.Update(application)
 	if err != nil {
 		panic(err)
 	}

--- a/object/organization.go
+++ b/object/organization.go
@@ -128,7 +128,7 @@ func UpdateOrganization(id string, organization *Organization) bool {
 		}
 	}
 
-	if organization.MasterPassword != "" {
+	if organization.MasterPassword != "" && organization.MasterPassword != "***" {
 		credManager := cred.GetCredManager(organization.PasswordType)
 		if credManager != nil {
 			hashedPassword := credManager.GetHashedPassword(organization.MasterPassword, "", organization.PasswordSalt)
@@ -136,7 +136,11 @@ func UpdateOrganization(id string, organization *Organization) bool {
 		}
 	}
 
-	affected, err := adapter.Engine.ID(core.PK{owner, name}).AllCols().Update(organization)
+	session := adapter.Engine.ID(core.PK{owner, name}).AllCols()
+	if organization.MasterPassword == "***" {
+		session.Omit("master_password")
+	}
+	affected, err := session.Update(organization)
 	if err != nil {
 		panic(err)
 	}

--- a/object/provider.go
+++ b/object/provider.go
@@ -172,7 +172,14 @@ func UpdateProvider(id string, provider *Provider) bool {
 		return false
 	}
 
-	affected, err := adapter.Engine.ID(core.PK{owner, name}).AllCols().Update(provider)
+	session := adapter.Engine.ID(core.PK{owner, name}).AllCols()
+	if provider.ClientSecret == "***" {
+		session = session.Omit("client_secret")
+	}
+	if provider.ClientSecret2 == "***" {
+		session = session.Omit("client_secret2")
+	}
+	affected, err := session.Update(provider)
 	if err != nil {
 		panic(err)
 	}

--- a/object/syncer.go
+++ b/object/syncer.go
@@ -133,7 +133,11 @@ func UpdateSyncer(id string, syncer *Syncer) bool {
 		return false
 	}
 
-	affected, err := adapter.Engine.ID(core.PK{owner, name}).AllCols().Update(syncer)
+	session := adapter.Engine.ID(core.PK{owner, name}).AllCols()
+	if syncer.Password == "***" {
+		session.Omit("password")
+	}
+	affected, err := session.Update(syncer)
 	if err != nil {
 		panic(err)
 	}

--- a/object/user.go
+++ b/object/user.go
@@ -314,6 +314,9 @@ func UpdateUser(id string, user *User, columns []string, isGlobalAdmin bool) boo
 		return false
 	}
 
+	if user.Password == "***" {
+		user.Password = oldUser.Password
+	}
 	user.UpdateUserHash()
 
 	if user.Avatar != oldUser.Avatar && user.Avatar != "" && user.PermanentAvatar != "*" {


### PR DESCRIPTION
For now, when editing `Organization`, master password is returned as the masked format `***`, so when clicking `Save` or `Save & Exit` without any change, master password will be updated to `***` or the hash value of `***`.

Similarly, when editing `Provider`, client secret and client secret 2 are both returned `***`, so when saving provider without any change, they will both be updated to `***`.

The solution is to check these columns before updating the record in DB, if they are `***`, then we should `Omit()` these fields.