### PR TITLE
feat: support "+" in syncer column name

### DIFF
--- a/object/syncer_util.go
+++ b/object/syncer_util.go
@@ -178,7 +178,7 @@ func (syncer *Syncer) getOriginalUsersFromMap(results []map[string]string) []*Or
 				names := strings.Split(tableColumn.Name, "+")
 				var values []string
 				for _, name := range names {
-					values = append(values, result[name])
+					values = append(values, result[strings.Trim(name, " ")])
 				}
 				value = strings.Join(values, " ")
 			} else {

--- a/object/syncer_util.go
+++ b/object/syncer_util.go
@@ -173,7 +173,18 @@ func (syncer *Syncer) getOriginalUsersFromMap(results []map[string]string) []*Or
 		}
 
 		for _, tableColumn := range syncer.TableColumns {
-			syncer.setUserByKeyValue(originalUser, tableColumn.CasdoorName, result[tableColumn.Name])
+			value := ""
+			if strings.Contains(tableColumn.Name, "+") {
+				names := strings.Split(tableColumn.Name, "+")
+				var values []string
+				for _, name := range names {
+					values = append(values, result[name])
+				}
+				value = strings.Join(values, " ")
+			} else {
+				value = result[tableColumn.Name]
+			}
+			syncer.setUserByKeyValue(originalUser, tableColumn.CasdoorName, value)
 		}
 
 		if syncer.Type == "Keycloak" {

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -836,7 +836,7 @@ export function getSyncerTableColumns(syncer) {
           ]
         },
         {
-          "name":"USERNAME",
+          "name":"LAST_NAME+FIRST_NAME",
           "type":"string",
           "casdoorName":"DisplayName",
           "isHashed":true,


### PR DESCRIPTION
support "+" as below, it will contact the multiple values

![image](https://user-images.githubusercontent.com/33992371/168242663-3b0b6651-3fa6-4245-b175-d7416537e073.png)


Signed-off-by: Yixiang Zhao <seriouszyx@foxmail.com>