### PR TITLE
fix: use openid or unionid as username rather than nickname when logging with WeChat

### DIFF
--- a/idp/wechat.go
+++ b/idp/wechat.go
@@ -185,7 +185,7 @@ func (idp *WeChatIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error)
 
 	userInfo := UserInfo{
 		Id:          id,
-		Username:    wechatUserInfo.Nickname,
+		Username:    id,
 		DisplayName: wechatUserInfo.Nickname,
 		AvatarUrl:   wechatUserInfo.Headimgurl,
 	}


### PR DESCRIPTION
fix: use openid or unionid as username rather than nickname when logging with WeChat
FIX #762