### PR TITLE
fix: bilibili name and avatar

### DIFF
--- a/idp/bilibili.go
+++ b/idp/bilibili.go
@@ -187,9 +187,10 @@ func (idp *BilibiliIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, erro
 	}
 
 	userInfo := &UserInfo{
-		Id:        bUserInfoResponse.Data.OpenId,
-		Username:  bUserInfoResponse.Data.Name,
-		AvatarUrl: bUserInfoResponse.Data.Face,
+		Id:          bUserInfoResponse.Data.OpenId,
+		Username:    bUserInfoResponse.Data.Name,
+		DisplayName: bUserInfoResponse.Data.Name,
+		AvatarUrl:   bUserInfoResponse.Data.Face,
 	}
 
 	return userInfo, nil

--- a/web/src/common/OAuthWidget.js
+++ b/web/src/common/OAuthWidget.js
@@ -142,7 +142,7 @@ class OAuthWidget extends React.Component {
           </span>
         </Col>
         <Col span={24 - this.props.labelSpan} >
-          <img style={{marginRight: '10px'}} width={30} height={30} src={avatarUrl} alt={name} />
+          <img style={{marginRight: '10px'}} width={30} height={30} src={avatarUrl} alt={name} referrerPolicy="no-referrer" />
           <span style={{width: this.props.labelSpan === 3 ? '300px' : '130px', display: (Setting.isMobile()) ? 'inline' : "inline-block"}}>
             {
               linkedValue === "" ? (


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/761

The avatar of bilibili user can't be displayed because of [anti-theft](https://xiaojuzi.fun/pages/8b9f9f/#%E8%A7%A3%E5%86%B3b%E7%AB%99%E9%98%B2%E7%9B%97%E9%93%BE-403).

now:

![image](https://user-images.githubusercontent.com/33992371/171172063-7874c98d-fcff-4f75-a5ed-77395055153a.png)


Signed-off-by: Yixiang Zhao <seriouszyx@foxmail.com>