### PR TITLE
fix: OAuth user id confusion caused by username

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -329,9 +329,6 @@ func (c *ApiController) Login() {
 				if user == nil {
 					user = object.GetUserByField(application.Organization, provider.Type, userInfo.Username)
 				}
-				if user == nil {
-					user = object.GetUserByField(application.Organization, "name", userInfo.Username)
-				}
 			}
 
 			if user != nil && user.IsDeleted == false {


### PR DESCRIPTION
## How it happens?
It just caused by this line `user = object.GetUserByField(application.Organization, "name", userInfo.Username)` . When a user login using an OAuth application for the first time, the value of user is nil, and the user is obtained from the username field, which causes the disaster.