### PR TITLE
fix: fix SAML sign element seq error #

### DIFF
--- a/object/saml_idp.go
+++ b/object/saml_idp.go
@@ -51,7 +51,7 @@ func NewSamlResponse(user *User, host string, publicKey string, destination stri
 	samlResponse.CreateAttr("Version", "2.0")
 	samlResponse.CreateAttr("IssueInstant", now)
 	samlResponse.CreateAttr("Destination", destination)
-	samlResponse.CreateAttr("InResponseTo", fmt.Sprintf("Casdoor_%s", arId))
+	samlResponse.CreateAttr("InResponseTo", fmt.Sprintf("_%s", arId))
 	samlResponse.CreateElement("saml:Issuer").SetText(host)
 
 	samlResponse.CreateElement("samlp:Status").CreateElement("samlp:StatusCode").CreateAttr("Value", "urn:oasis:names:tc:SAML:2.0:status:Success")
@@ -261,13 +261,15 @@ func GetSamlResponse(application *Application, user *User, samlRequest string, h
 	}
 	ctx := dsig.NewDefaultSigningContext(randomKeyStore)
 	ctx.Hash = crypto.SHA1
-	signedXML, err := ctx.SignEnveloped(samlResponse)
-	if err != nil {
-		return "", "", fmt.Errorf("err: %s", err.Error())
-	}
+	//signedXML, err := ctx.SignEnvelopedLimix(samlResponse)
+	//if err != nil {
+	//	return "", "", fmt.Errorf("err: %s", err.Error())
+	//}
+	sig, err := ctx.ConstructSignature(samlResponse, true)
+	samlResponse.InsertChildAt(1, sig)
 
 	doc := etree.NewDocument()
-	doc.SetRoot(signedXML)
+	doc.SetRoot(samlResponse)
 	xmlStr, err := doc.WriteToString()
 	if err != nil {
 		return "", "", fmt.Errorf("err: %s", err.Error())


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/798

```xml
<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
                    ID="ONELOGIN_20cf08f88736c7901b6c1b629ec5c53352a0be82"
                    Version="2.0"
                    ProviderName="ansible-tower"
                    IssueInstant="2022-06-14T08:38:05Z"
                    Destination="http://localhost:8001/login/saml/authorize/admin/awx"
                    ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
                    AssertionConsumerServiceURL="http://localhost:8013/sso/complete/saml/"
                    >
    <saml:Issuer>http://localhost:8013/sso/login/saml/?idp=idp</saml:Issuer>
    <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
                        AllowCreate="true"
                        />
</samlp:AuthnRequest>
```