### PR TITLE
fix: Email config on provider edit page missing required field

### DIFF
--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -350,7 +350,7 @@ class ProviderEditPage extends React.Component {
           )
         }
         {
-          this.state.provider.type !== "Default" && 
+          this.state.provider.type !== "Default" && this.state.provider.category === "Captcha" &&
           <>
             <Row style={{marginTop: '20px'}} >
               <Col style={{marginTop: '5px'}} span={(Setting.isMobile()) ? 22 : 2}>
@@ -641,7 +641,7 @@ class ProviderEditPage extends React.Component {
         }
         {this.getAppIdRow()}
         {
-          this.state.provider.type !== "Default" &&
+          this.state.provider.type !== "Default" && this.state.provider.category === "Captcha" &&
           <Row style={{marginTop: '20px'}} >
             <Col style={{marginTop: '5px'}} span={(Setting.isMobile()) ? 22 : 2}>
               {Setting.getLabel(i18next.t("provider:Provider URL"), i18next.t("provider:Provider URL - Tooltip"))} :


### PR DESCRIPTION
## How it happens?

Caused by https://github.com/casdoor/casdoor/commit/2e42511bc4e55cd5380c75d32671a493cb377ea7#diff-cb4ada41a4a0008e5952845545683e39ddd2442b8b020154470ba6183c643f19

`username` and `password` is missing

In https://door.casdoor.com/providers/provider_casbin_email
![image](https://user-images.githubusercontent.com/69711608/174935541-d40bdf68-af6c-48de-a497-a5ca5a9d0688.png)
But in current version:
![image](https://user-images.githubusercontent.com/69711608/174935577-775eb002-7d27-4a41-b836-bccde68d37a9.png)