### PR TITLE
fix: Fixed some minor bugs and make Dockerfile more productive.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,18 @@ VOLUME /app/files /app/logs
 ENTRYPOINT ["/app/server"]
 
 
-FROM debian:latest AS ALLINONE
-LABEL MAINTAINER="https://casdoor.org/"
-
+FROM debian:latest AS ALLINONE_DB
 RUN apt update \
     && apt install -y \
         mariadb-server \
         mariadb-client \
     && rm -rf /var/lib/apt/lists/*
+
+
+FROM ALLINONE_DB AS ALLINONE
+LABEL MAINTAINER="https://casdoor.org/"
+
+ENV MYSQL_ROOT_PASSWORD=123456
 
 WORKDIR /app
 COPY --from=BACK /go/src/casdoor/server ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.17.5 AS BACK
 WORKDIR /go/src/casdoor
 COPY . .
-RUN ./build.sh && apt update && apt install wait-for-it && chmod +x /usr/bin/wait-for-it
+RUN ./build.sh
+
 
 FROM node:16.13.0 AS FRONT
 WORKDIR /web
@@ -10,28 +11,31 @@ RUN yarn config set registry https://registry.npmmirror.com
 RUN yarn install && yarn run build
 
 
+FROM alpine:latest AS STANDARD
+LABEL MAINTAINER="https://casdoor.org/"
+
+WORKDIR /app
+COPY --from=BACK /go/src/casdoor/server ./
+COPY --from=BACK /go/src/casdoor/conf/app.conf ./conf/app.conf
+COPY --from=FRONT /web/build ./web/build
+VOLUME /app/files /app/logs
+ENTRYPOINT ["/app/server"]
+
+
 FROM debian:latest AS ALLINONE
-RUN apt update
-RUN apt install -y ca-certificates && update-ca-certificates
-RUN apt install -y mariadb-server mariadb-client && mkdir -p web/build && chmod 777 /tmp
-LABEL MAINTAINER="https://casdoor.org/"
-COPY --from=BACK /go/src/casdoor/ ./
-COPY --from=BACK /usr/bin/wait-for-it ./
-COPY --from=FRONT /web/build /web/build
-CMD chmod 777 /tmp && service mariadb start&&\
-if [ "${MYSQL_ROOT_PASSWORD}" = "" ] ;then MYSQL_ROOT_PASSWORD=123456 ; fi&&\
-mysqladmin -u root password ${MYSQL_ROOT_PASSWORD} &&\
-./wait-for-it localhost:3306 -- ./server --createDatabase=true
-
-
-FROM alpine:latest
-RUN sed -i 's/https/http/' /etc/apk/repositories
-RUN apk add curl
-RUN apk add ca-certificates && update-ca-certificates
 LABEL MAINTAINER="https://casdoor.org/"
 
-COPY --from=BACK /go/src/casdoor/ ./
-COPY --from=BACK /usr/bin/wait-for-it ./
-RUN mkdir -p web/build && apk add --no-cache bash coreutils
-COPY --from=FRONT /web/build /web/build
-CMD  ./server
+RUN apt update \
+    && apt install -y \
+        mariadb-server \
+        mariadb-client \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=BACK /go/src/casdoor/server ./
+COPY --from=BACK /go/src/casdoor/docker-entrypoint.sh /docker-entrypoint.sh
+COPY --from=BACK /go/src/casdoor/conf/app.conf ./conf/app.conf
+COPY --from=FRONT /web/build ./web/build
+
+ENTRYPOINT ["/bin/bash"]
+CMD ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+service mariadb start
+
+if [ "${MYSQL_ROOT_PASSWORD}" = "" ]; then
+    MYSQL_ROOT_PASSWORD=123456
+fi
+
+mysqladmin -u root password ${MYSQL_ROOT_PASSWORD}
+
+exec /app/server --createDatabase=true

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,10 +2,6 @@
 
 service mariadb start
 
-if [ "${MYSQL_ROOT_PASSWORD}" = "" ]; then
-    MYSQL_ROOT_PASSWORD=123456
-fi
-
 mysqladmin -u root password ${MYSQL_ROOT_PASSWORD}
 
 exec /app/server --createDatabase=true

--- a/object/init.go
+++ b/object/init.go
@@ -104,7 +104,7 @@ func initBuiltInUser() {
 		IsGlobalAdmin:     true,
 		IsForbidden:       false,
 		IsDeleted:         false,
-		SignupApplication: "built-in-app",
+		SignupApplication: "app-built-in",
 		CreatedIp:         "127.0.0.1",
 		Properties:        make(map[string]string),
 	}

--- a/web/src/PermissionListPage.js
+++ b/web/src/PermissionListPage.js
@@ -93,7 +93,7 @@ class PermissionListPage extends BaseListPage {
         ...this.getColumnSearchProps('name'),
         render: (text, record, index) => {
           return (
-            <Link to={`/permissions/${text}`}>
+            <Link to={`/permissions/${record.owner}/${text}`}>
               {text}
             </Link>
           )


### PR DESCRIPTION
## Make Dockerfile more productive.

+ Build all-in-one image:

```
docker build --target ALLINONE -t casbin/casdoor-all-in-one:latest .
```

+ Build standard image:

```
docker build --target STANDARD -t casbin/casdoor:latest .
```

## Solve the problem that the PermissionList page jumped abnormally when clicking the permission name in the list.

+ Insert the owner into the url when jumping to the permissions details page.

## Fix incorrect SignupApplication field value in initBuiltInUser.

+ Wrong SignupApplication value causes exceptions in multiple functions for the first admin user, such as uploading avatars, user detail pages, etc.