### PR TITLE
fix: fix CORS error after sucessful OPTION

### DIFF
--- a/routers/cors_filter.go
+++ b/routers/cors_filter.go
@@ -1,9 +1,24 @@
+// Copyright 2021 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package routers
 
 import (
 	"net/http"
 
 	"github.com/astaxie/beego/context"
+	"github.com/casdoor/casdoor/conf"
 	"github.com/casdoor/casdoor/object"
 )
 
@@ -15,17 +30,20 @@ const (
 )
 
 func CorsFilter(ctx *context.Context) {
-	if ctx.Input.Method() == "OPTIONS" {
-		origin := ctx.Input.Header(headerOrigin)
-
+	origin := ctx.Input.Header(headerOrigin)
+	if origin != "" && origin != conf.GetConfigString("origin") {
 		if object.IsAllowOrigin(origin) {
 			ctx.Output.Header(headerAllowOrigin, origin)
 			ctx.Output.Header(headerAllowMethods, "POST, GET, OPTIONS")
 			ctx.Output.Header(headerAllowHeaders, "Content-Type, Authorization")
-			ctx.ResponseWriter.WriteHeader(http.StatusOK)
 		} else {
 			ctx.ResponseWriter.WriteHeader(http.StatusForbidden)
+			return
 		}
-		return
+
+		if ctx.Input.Method() == "OPTIONS" {
+			ctx.ResponseWriter.WriteHeader(http.StatusOK)
+			return
+		}
 	}
 }


### PR DESCRIPTION
Cross-origin requests other than preflight requests also need to add CORS response headers.