### PR TITLE
fix: support user-defined clientId&Secret

### DIFF
--- a/init_data.json.template
+++ b/init_data.json.template
@@ -23,6 +23,8 @@
       "cert": "",
       "enablePassword": true,
       "enableSignUp": true,
+      "clientId": "",
+      "clientSecret": "",
       "providers": [
         {
           "name": "",

--- a/object/application.go
+++ b/object/application.go
@@ -280,8 +280,12 @@ func UpdateApplication(id string, application *Application) bool {
 }
 
 func AddApplication(application *Application) bool {
-	application.ClientId = util.GenerateClientId()
-	application.ClientSecret = util.GenerateClientSecret()
+	if application.ClientId == "" {
+		application.ClientId = util.GenerateClientId()
+	}
+	if application.ClientSecret == "" {
+		application.ClientSecret = util.GenerateClientSecret()
+	}
 	for _, providerItem := range application.Providers {
 		providerItem.Provider = nil
 	}


### PR DESCRIPTION
`AddApplication` only supports randomly generated clientId and clientSecret. So I copy its logic and support keeping user-defined clientId and clientSecret when initializing.