### PR TITLE
feat: fix oauth unknown authority in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ RUN ./build.sh
 FROM alpine:latest AS STANDARD
 LABEL MAINTAINER="https://casdoor.org/"
 
+RUN sed -i 's/https/http/' /etc/apk/repositories
+RUN apk add curl
+RUN apk add ca-certificates && update-ca-certificates
+
 WORKDIR /
 COPY --from=BACK /go/src/casdoor/server ./server
 COPY --from=BACK /go/src/casdoor/swagger ./swagger
@@ -33,7 +37,8 @@ RUN apt update \
 FROM db AS ALLINONE
 LABEL MAINTAINER="https://casdoor.org/"
 
-ENV MYSQL_ROOT_PASSWORD=123456
+RUN apt update
+RUN apt install -y ca-certificates && update-ca-certificates
 
 WORKDIR /
 COPY --from=BACK /go/src/casdoor/server ./server

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+if [ "${MYSQL_ROOT_PASSWORD}" = "" ] ;then MYSQL_ROOT_PASSWORD=123456 ;fi
 
 service mariadb start
 


### PR DESCRIPTION
This has been fixed in PR: https://github.com/casdoor/casdoor/pull/491 by adding `ca-certificate`. But PR https://github.com/casdoor/casdoor/pull/831 removed these as 

> There are many unnecessary shell commands in the old Dockerfile, such as install ca-certificates && update-ca-certificates. When we use debian:lates or alpine:latest as the base image, /etc/ssl/certs/ca-certificates.crt already contains the latest ca certificates, and we don't need to perform an update operation every time we build.

 However, when I test with Github OAuth, `Post "https://github.com/login/oauth/access_token": X509 certificate signed by unknown authority` still raised. I guess default certificate in debain system is out of date. After I added `ca-certificate` again, it works.