### PR TITLE
fix: check reset phone & email modify rules

### DIFF
--- a/controllers/verification.go
+++ b/controllers/verification.go
@@ -168,13 +168,35 @@ func (c *ApiController) ResetEmailOrPhone() {
 	}
 
 	checkDest := dest
+	org := object.GetOrganizationByUser(user)
 	if destType == "phone" {
-		org := object.GetOrganizationByUser(user)
+		phoneItem := object.GetAccountItemByName("Phone", org)
+		if phoneItem == nil {
+			c.ResponseError("Unable to get the phone modification rules.")
+			return
+		}
+
+		if pass, errMsg := object.CheckAccountItemModifyRule(phoneItem, user); !pass {
+			c.ResponseError(errMsg)
+			return
+		}
+
 		phonePrefix := "86"
 		if org != nil && org.PhonePrefix != "" {
 			phonePrefix = org.PhonePrefix
 		}
 		checkDest = fmt.Sprintf("+%s%s", phonePrefix, dest)
+	} else if destType == "email" {
+		emailItem := object.GetAccountItemByName("Email", org)
+		if emailItem == nil {
+			c.ResponseError("Unable to get the email modification rules.")
+			return
+		}
+
+		if pass, errMsg := object.CheckAccountItemModifyRule(emailItem, user); !pass {
+			c.ResponseError(errMsg)
+			return
+		}
 	}
 	if ret := object.CheckVerificationCode(checkDest, code); len(ret) != 0 {
 		c.ResponseError(ret)

--- a/controllers/verification.go
+++ b/controllers/verification.go
@@ -172,7 +172,7 @@ func (c *ApiController) ResetEmailOrPhone() {
 	if destType == "phone" {
 		phoneItem := object.GetAccountItemByName("Phone", org)
 		if phoneItem == nil {
-			c.ResponseError("Unable to get the phone modification rules.")
+			c.ResponseError("Unable to get the phone modify rule.")
 			return
 		}
 
@@ -189,7 +189,7 @@ func (c *ApiController) ResetEmailOrPhone() {
 	} else if destType == "email" {
 		emailItem := object.GetAccountItemByName("Email", org)
 		if emailItem == nil {
-			c.ResponseError("Unable to get the email modification rules.")
+			c.ResponseError("Unable to get the email modify rule.")
 			return
 		}
 

--- a/object/organization.go
+++ b/object/organization.go
@@ -16,6 +16,7 @@ package object
 
 import (
 	"fmt"
+
 	"github.com/casdoor/casdoor/cred"
 	"github.com/casdoor/casdoor/util"
 	"xorm.io/core"

--- a/object/organization.go
+++ b/object/organization.go
@@ -15,6 +15,7 @@
 package object
 
 import (
+	"fmt"
 	"github.com/casdoor/casdoor/cred"
 	"github.com/casdoor/casdoor/util"
 	"xorm.io/core"
@@ -185,4 +186,32 @@ func DeleteOrganization(organization *Organization) bool {
 
 func GetOrganizationByUser(user *User) *Organization {
 	return getOrganization("admin", user.Owner)
+}
+
+func GetAccountItemByName(name string, organization *Organization) *AccountItem {
+	if organization == nil {
+		return nil
+	}
+	for _, accountItem := range organization.AccountItems {
+		if accountItem.Name == name {
+			return accountItem
+		}
+	}
+	return nil
+}
+
+func CheckAccountItemModifyRule(accountItem *AccountItem, user *User) (bool, string) {
+	switch accountItem.ModifyRule {
+	case "Admin":
+		if !(user.IsAdmin || user.IsGlobalAdmin) {
+			return false, fmt.Sprintf("Only admin can modify the %s.", accountItem.Name)
+		}
+	case "Immutable":
+		return false, fmt.Sprintf("The %s is immutable.", accountItem.Name)
+	case "Self":
+		break
+	default:
+		return false, fmt.Sprintf("Unknown modify rule %s.", accountItem.ModifyRule)
+	}
+	return true, ""
 }

--- a/web/src/UserEditPage.js
+++ b/web/src/UserEditPage.js
@@ -291,7 +291,7 @@ class UserEditPage extends React.Component {
               }} />
           </Col>
           <Col span={11} >
-            {this.state.user.id === this.props.account?.id ? (<ResetModal application={this.state.application} buttonText={i18next.t("user:Reset Email...")} destType={"email"} />) : null}
+            {this.state.user.id === this.props.account?.id ? (<ResetModal application={this.state.application} disabled={disabled} buttonText={i18next.t("user:Reset Email...")} destType={"email"} />) : null}
           </Col>
         </Row>
       );
@@ -309,7 +309,7 @@ class UserEditPage extends React.Component {
               }} />
           </Col>
           <Col span={11} >
-            {this.state.user.id === this.props.account?.id ? (<ResetModal application={this.state.application} buttonText={i18next.t("user:Reset Phone...")} destType={"phone"} />) : null}
+            {this.state.user.id === this.props.account?.id ? (<ResetModal application={this.state.application} disabled={disabled} buttonText={i18next.t("user:Reset Phone...")} destType={"phone"} />) : null}
           </Col>
         </Row>
       );


### PR DESCRIPTION
This PR fixes the user can reset phone or email without checking `modifyRule` and set the `disabled` property when rendering in the frontend.