### PR TITLE
feat: add arm docker support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,12 @@ jobs:
               
           fi
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         if: github.repository == 'casdoor/casdoor' && github.event_name == 'push' &&steps.should_push.outputs.push=='true'
@@ -111,17 +117,19 @@ jobs:
 
 
       - name: Push to Docker Hub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         if: github.repository == 'casdoor/casdoor' && github.event_name == 'push' && steps.should_push.outputs.push=='true'
         with:
           target: STANDARD
           push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: casbin/casdoor:${{steps.get-current-tag.outputs.tag }},casbin/casdoor:latest
 
       - name: Push All In One Version to Docker Hub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         if: github.repository == 'casdoor/casdoor' && github.event_name == 'push' && steps.should_push.outputs.push=='true'
         with:
           target: ALLINONE
           push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: casbin/casdoor-all-in-one:${{steps.get-current-tag.outputs.tag }},casbin/casdoor-all-in-one:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16.13.0 AS FRONT
 WORKDIR /web
 COPY ./web .
 RUN yarn config set registry https://registry.npmmirror.com
-RUN yarn install && yarn run build
+RUN yarn install --network-timeout 200000 && yarn run build
 
 
 FROM golang:1.17.5 AS BACK

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #try to connect to google to determine whether user need to use proxy
-curl www.google.com -o /dev/null --connect-timeout 5 2 > /dev/null
+curl google.com -o /dev/null --connect-timeout 5 2>/dev/null
 if [ $? == 0 ]
 then
     echo "Successfully connected to Google, no need to use Go proxy"


### PR DESCRIPTION
`build.sh` shell rdedirect is  invalid 。
add arm64 and armv7  docker, use qemu and compilation arm time  is long(about 40 min  ),because the [yarn or node bug](https://github.com/yarnpkg/yarn/issues/5259) 