### PR TITLE
feat: Support sub-directory

### DIFF
--- a/web/.env
+++ b/web/.env
@@ -1,0 +1,1 @@
+PUBLIC_URL=.


### PR DESCRIPTION
By adding PUBLIC_URL to relative `.`, we can access casdoor's all web pages and static asserts under relative public url.

Closes #933

Signed-off-by: zzjin <tczzjin@gmail.com>