### PR TITLE
fix: updateProviderField when add provider payment

### DIFF
--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -208,6 +208,8 @@ class ProviderEditPage extends React.Component {
                 this.updateProviderField("domain", Setting.getFullServerUrl());
               } else if (value === "SAML") {
                 this.updateProviderField("type", "Aliyun IDaaS");
+              } else if (value === "Payment") {
+                this.updateProviderField("type", "Alipay");
               } else if (value === "Captcha") {
                 this.updateProviderField("type", "Default");
               }


### PR DESCRIPTION
When change category from other to payment, the type don't follow the change it remains the type before, and it can add success with error type (i.e. `Category: Payment type: Bilibili`), then it lead to provider page error.

![image](https://user-images.githubusercontent.com/41513919/182748795-23267add-d807-4d47-9cc1-a31edb00e0f6.png)
