### PR TITLE
fix: panic when creating a user in a non-existent org

### DIFF
--- a/object/user.go
+++ b/object/user.go
@@ -417,6 +417,10 @@ func AddUser(user *User) bool {
 	}
 
 	organization := GetOrganizationByUser(user)
+	if organization == nil {
+		return false
+	}
+
 	user.UpdateUserPassword(organization)
 
 	user.UpdateUserHash()


### PR DESCRIPTION
If you try to create a user in a non-existent org then panic will occur. This PR fixes this.

Fix: https://github.com/casdoor/casdoor/issues/968