### PR TITLE
fix: Restrict the request permissions of providers and applications

### DIFF
--- a/authz/authz.go
+++ b/authz/authz.go
@@ -83,7 +83,7 @@ p, *, *, GET, /api/get-account, *, *
 p, *, *, GET, /api/userinfo, *, *
 p, *, *, *, /api/login/oauth, *, *
 p, *, *, GET, /api/get-application, *, *
-p, *, *, GET, /api/get-applications, *, *
+p, *, *, GET, /api/get-organization-applications, *, *
 p, *, *, GET, /api/get-user, *, *
 p, *, *, GET, /api/get-user-application, *, *
 p, *, *, GET, /api/get-resources, *, *
@@ -92,7 +92,6 @@ p, *, *, POST, /api/buy-product, *, *
 p, *, *, GET, /api/get-payment, *, *
 p, *, *, POST, /api/update-payment, *, *
 p, *, *, POST, /api/invoice-payment, *, *
-p, *, *, GET, /api/get-providers, *, *
 p, *, *, POST, /api/notify-payment, *, *
 p, *, *, POST, /api/unlink, *, *
 p, *, *, POST, /api/set-password, *, *

--- a/controllers/application.go
+++ b/controllers/application.go
@@ -94,6 +94,29 @@ func (c *ApiController) GetUserApplication() {
 	c.ServeJSON()
 }
 
+// GetOrganizationApplications
+// @Title GetOrganizationApplications
+// @Tag Application API
+// @Description get the detail of the organization's application
+// @Param   organization     query    string  true        "The organization name"
+// @Success 200 {array} object.Application The Response object
+// @router /get-organization-applications [get]
+func (c *ApiController) GetOrganizationApplications() {
+	userId := c.GetSessionUsername()
+	owner := c.Input().Get("owner")
+	organization := c.Input().Get("organization")
+
+	if organization == "" {
+		c.ResponseError("Parameter organization is missing")
+		return
+	}
+
+	var applications []*object.Application
+	applications = object.GetApplicationsByOrganizationName(owner, organization)
+	c.Data["json"] = object.GetMaskedApplications(applications, userId)
+	c.ServeJSON()
+}
+
 // UpdateApplication
 // @Title UpdateApplication
 // @Tag Application API

--- a/routers/router.go
+++ b/routers/router.go
@@ -116,6 +116,7 @@ func initAPI() {
 	beego.Router("/api/get-applications", &controllers.ApiController{}, "GET:GetApplications")
 	beego.Router("/api/get-application", &controllers.ApiController{}, "GET:GetApplication")
 	beego.Router("/api/get-user-application", &controllers.ApiController{}, "GET:GetUserApplication")
+	beego.Router("/api/get-organization-applications", &controllers.ApiController{}, "GET:GetOrganizationApplications")
 	beego.Router("/api/update-application", &controllers.ApiController{}, "POST:UpdateApplication")
 	beego.Router("/api/add-application", &controllers.ApiController{}, "POST:AddApplication")
 	beego.Router("/api/delete-application", &controllers.ApiController{}, "POST:DeleteApplication")

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1291,6 +1291,35 @@
                 }
             }
         },
+        "/api/get-organization-applications": {
+            "get": {
+                "tags": [
+                    "Application API"
+                ],
+                "description": "get the detail of the organization's application",
+                "operationId": "ApiController.GetOrganizationApplications",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "organization",
+                        "description": "The organization name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The Response object",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/object.Application"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/get-organizations": {
             "get": {
                 "tags": [
@@ -1852,6 +1881,24 @@
                         "name": "id",
                         "description": "The id of the user",
                         "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "owner",
+                        "description": "The owner of the user",
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "email",
+                        "description": "The email of the user",
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "phone",
+                        "description": "The phone of the user",
                         "type": "string"
                     }
                 ],
@@ -3220,11 +3267,11 @@
         }
     },
     "definitions": {
-        "2127.0xc000427560.false": {
+        "2200.0xc0003f8480.false": {
             "title": "false",
             "type": "object"
         },
-        "2161.0xc000427590.false": {
+        "2235.0xc0003f84b0.false": {
             "title": "false",
             "type": "object"
         },
@@ -3342,10 +3389,10 @@
             "type": "object",
             "properties": {
                 "data": {
-                    "$ref": "#/definitions/2127.0xc000427560.false"
+                    "$ref": "#/definitions/2200.0xc0003f8480.false"
                 },
                 "data2": {
-                    "$ref": "#/definitions/2161.0xc000427590.false"
+                    "$ref": "#/definitions/2235.0xc0003f84b0.false"
                 },
                 "msg": {
                     "type": "string"
@@ -3549,6 +3596,9 @@
                     "type": "integer",
                     "format": "int64"
                 },
+                "certificate": {
+                    "type": "string"
+                },
                 "createdTime": {
                     "type": "string"
                 },
@@ -3569,9 +3619,6 @@
                     "type": "string"
                 },
                 "privateKey": {
-                    "type": "string"
-                },
-                "certificate": {
                     "type": "string"
                 },
                 "scope": {
@@ -4585,6 +4632,12 @@
                 "permanentAvatar": {
                     "type": "string"
                 },
+                "permissions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/object.Permission"
+                    }
+                },
                 "phone": {
                     "type": "string"
                 },
@@ -4605,6 +4658,12 @@
                 },
                 "region": {
                     "type": "string"
+                },
+                "roles": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/object.Role"
+                    }
                 },
                 "score": {
                     "type": "integer",

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -837,6 +837,25 @@ paths:
           description: The Response object
           schema:
             $ref: '#/definitions/object.Organization'
+  /api/get-organization-applications:
+    get:
+      tags:
+      - Application API
+      description: get the detail of the organization's application
+      operationId: ApiController.GetOrganizationApplications
+      parameters:
+      - in: query
+        name: organization
+        description: The organization name
+        required: true
+        type: string
+      responses:
+        "200":
+          description: The Response object
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/object.Application'
   /api/get-organizations:
     get:
       tags:
@@ -1208,6 +1227,18 @@ paths:
         name: id
         description: The id of the user
         required: true
+        type: string
+      - in: query
+        name: owner
+        description: The owner of the user
+        type: string
+      - in: query
+        name: email
+        description: The email of the user
+        type: string
+      - in: query
+        name: phone
+        description: The phone of the user
         type: string
       responses:
         "200":
@@ -2108,10 +2139,10 @@ paths:
           schema:
             $ref: '#/definitions/Response'
 definitions:
-  2127.0xc000427560.false:
+  2200.0xc0003f8480.false:
     title: "false"
     type: object
-  2161.0xc000427590.false:
+  2235.0xc0003f84b0.false:
     title: "false"
     type: object
   Response:
@@ -2192,9 +2223,9 @@ definitions:
     type: object
     properties:
       data:
-        $ref: '#/definitions/2127.0xc000427560.false'
+        $ref: '#/definitions/2200.0xc0003f8480.false'
       data2:
-        $ref: '#/definitions/2161.0xc000427590.false'
+        $ref: '#/definitions/2235.0xc0003f84b0.false'
       msg:
         type: string
       name:
@@ -2331,6 +2362,8 @@ definitions:
       bitSize:
         type: integer
         format: int64
+      certificate:
+        type: string
       createdTime:
         type: string
       cryptoAlgorithm:
@@ -2345,8 +2378,6 @@ definitions:
       owner:
         type: string
       privateKey:
-        type: string
-      certificate:
         type: string
       scope:
         type: string
@@ -3027,6 +3058,10 @@ definitions:
         type: string
       permanentAvatar:
         type: string
+      permissions:
+        type: array
+        items:
+          $ref: '#/definitions/object.Permission'
       phone:
         type: string
       preHash:
@@ -3041,6 +3076,10 @@ definitions:
         format: int64
       region:
         type: string
+      roles:
+        type: array
+        items:
+          $ref: '#/definitions/object.Role'
       score:
         type: integer
         format: int64

--- a/web/src/backend/ApplicationBackend.js
+++ b/web/src/backend/ApplicationBackend.js
@@ -22,7 +22,7 @@ export function getApplications(owner, page = "", pageSize = "", field = "", val
 }
 
 export function getApplicationsByOrganization(owner, organization) {
-  return fetch(`${Setting.ServerUrl}/api/get-applications?owner=${owner}&organization=${organization}`, {
+  return fetch(`${Setting.ServerUrl}/api/get-organization-applications?owner=${owner}&organization=${organization}`, {
     method: "GET",
     credentials: "include"
   }).then(res => res.json());


### PR DESCRIPTION
Fix: #916 
I think use casbin to restrict the permission maybe a little difficult. I add a new api get-organzation-application to resolve the problem. The permissions of normal users to access the  all providers and applications are cancelled.  So far, no side effects.