### PR TITLE
fix: add JTI name to JWT token

### DIFF
--- a/object/token.go
+++ b/object/token.go
@@ -287,7 +287,9 @@ func GetOAuthCode(userId string, clientId string, responseType string, redirectU
 		}
 	}
 
-	accessToken, refreshToken, err := generateJwtToken(application, user, nonce, scope, host)
+	name := util.GenerateId()
+	jti := fmt.Sprintf("%s/%s", application.Owner, name)
+	accessToken, refreshToken, err := generateJwtToken(application, user, nonce, scope, host, jti)
 	if err != nil {
 		panic(err)
 	}
@@ -298,7 +300,7 @@ func GetOAuthCode(userId string, clientId string, responseType string, redirectU
 
 	token := &Token{
 		Owner:         application.Owner,
-		Name:          util.GenerateId(),
+		Name:          name,
 		CreatedTime:   util.GetCurrentTime(),
 		Application:   application.Name,
 		Organization:  user.Owner,
@@ -420,7 +422,10 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 			ErrorDescription: "the user is forbidden to sign in, please contact the administrator",
 		}
 	}
-	newAccessToken, newRefreshToken, err := generateJwtToken(application, user, "", scope, host)
+
+	name := util.GenerateId()
+	jti := fmt.Sprintf("%s/%s", application.Owner, name)
+	newAccessToken, newRefreshToken, err := generateJwtToken(application, user, "", scope, host, jti)
 	if err != nil {
 		return &TokenError{
 			Error:            ENDPOINT_ERROR,
@@ -430,7 +435,7 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 
 	newToken := &Token{
 		Owner:        application.Owner,
-		Name:         util.GenerateId(),
+		Name:         name,
 		CreatedTime:  util.GetCurrentTime(),
 		Application:  application.Name,
 		Organization: user.Owner,
@@ -566,7 +571,10 @@ func GetPasswordToken(application *Application, username string, password string
 			ErrorDescription: "the user is forbidden to sign in, please contact the administrator",
 		}
 	}
-	accessToken, refreshToken, err := generateJwtToken(application, user, "", scope, host)
+
+	name := util.GenerateId()
+	jti := fmt.Sprintf("%s/%s", application.Owner, name)
+	accessToken, refreshToken, err := generateJwtToken(application, user, "", scope, host, jti)
 	if err != nil {
 		return nil, &TokenError{
 			Error:            ENDPOINT_ERROR,
@@ -575,7 +583,7 @@ func GetPasswordToken(application *Application, username string, password string
 	}
 	token := &Token{
 		Owner:        application.Owner,
-		Name:         util.GenerateId(),
+		Name:         name,
 		CreatedTime:  util.GetCurrentTime(),
 		Application:  application.Name,
 		Organization: user.Owner,
@@ -605,7 +613,10 @@ func GetClientCredentialsToken(application *Application, clientSecret string, sc
 		Id:    application.GetId(),
 		Name:  fmt.Sprintf("app/%s", application.Name),
 	}
-	accessToken, _, err := generateJwtToken(application, nullUser, "", scope, host)
+
+	name := util.GenerateId()
+	jti := fmt.Sprintf("%s/%s", application.Owner, name)
+	accessToken, _, err := generateJwtToken(application, nullUser, "", scope, host, jti)
 	if err != nil {
 		return nil, &TokenError{
 			Error:            ENDPOINT_ERROR,
@@ -614,7 +625,7 @@ func GetClientCredentialsToken(application *Application, clientSecret string, sc
 	}
 	token := &Token{
 		Owner:        application.Owner,
-		Name:         util.GenerateId(),
+		Name:         name,
 		CreatedTime:  util.GetCurrentTime(),
 		Application:  application.Name,
 		Organization: application.Organization,
@@ -632,13 +643,15 @@ func GetClientCredentialsToken(application *Application, clientSecret string, sc
 
 // Implicit flow
 func GetTokenByUser(application *Application, user *User, scope string, host string) (*Token, error) {
-	accessToken, refreshToken, err := generateJwtToken(application, user, "", scope, host)
+	name := util.GenerateId()
+	jti := fmt.Sprintf("%s/%s", application.Owner, name)
+	accessToken, refreshToken, err := generateJwtToken(application, user, "", scope, host, jti)
 	if err != nil {
 		return nil, err
 	}
 	token := &Token{
 		Owner:        application.Owner,
-		Name:         util.GenerateId(),
+		Name:         name,
 		CreatedTime:  util.GetCurrentTime(),
 		Application:  application.Name,
 		Organization: user.Owner,
@@ -717,7 +730,9 @@ func GetWechatMiniProgramToken(application *Application, code string, host strin
 		AddUser(user)
 	}
 
-	accessToken, refreshToken, err := generateJwtToken(application, user, "", "", host)
+	name := util.GenerateId()
+	jti := fmt.Sprintf("%s/%s", application.Owner, name)
+	accessToken, refreshToken, err := generateJwtToken(application, user, "", "", host, jti)
 	if err != nil {
 		return nil, &TokenError{
 			Error:            ENDPOINT_ERROR,
@@ -727,7 +742,7 @@ func GetWechatMiniProgramToken(application *Application, code string, host strin
 
 	token := &Token{
 		Owner:        application.Owner,
-		Name:         util.GenerateId(),
+		Name:         name,
 		CreatedTime:  util.GetCurrentTime(),
 		Application:  application.Name,
 		Organization: user.Owner,

--- a/object/token.go
+++ b/object/token.go
@@ -287,9 +287,7 @@ func GetOAuthCode(userId string, clientId string, responseType string, redirectU
 		}
 	}
 
-	name := util.GenerateId()
-	jti := fmt.Sprintf("%s/%s", application.Owner, name)
-	accessToken, refreshToken, err := generateJwtToken(application, user, nonce, scope, host, jti)
+	accessToken, refreshToken, tokenName, err := generateJwtToken(application, user, nonce, scope, host)
 	if err != nil {
 		panic(err)
 	}
@@ -300,7 +298,7 @@ func GetOAuthCode(userId string, clientId string, responseType string, redirectU
 
 	token := &Token{
 		Owner:         application.Owner,
-		Name:          name,
+		Name:          tokenName,
 		CreatedTime:   util.GetCurrentTime(),
 		Application:   application.Name,
 		Organization:  user.Owner,
@@ -423,9 +421,7 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 		}
 	}
 
-	name := util.GenerateId()
-	jti := fmt.Sprintf("%s/%s", application.Owner, name)
-	newAccessToken, newRefreshToken, err := generateJwtToken(application, user, "", scope, host, jti)
+	newAccessToken, newRefreshToken, tokenName, err := generateJwtToken(application, user, "", scope, host)
 	if err != nil {
 		return &TokenError{
 			Error:            ENDPOINT_ERROR,
@@ -435,7 +431,7 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 
 	newToken := &Token{
 		Owner:        application.Owner,
-		Name:         name,
+		Name:         tokenName,
 		CreatedTime:  util.GetCurrentTime(),
 		Application:  application.Name,
 		Organization: user.Owner,
@@ -572,9 +568,7 @@ func GetPasswordToken(application *Application, username string, password string
 		}
 	}
 
-	name := util.GenerateId()
-	jti := fmt.Sprintf("%s/%s", application.Owner, name)
-	accessToken, refreshToken, err := generateJwtToken(application, user, "", scope, host, jti)
+	accessToken, refreshToken, tokenName, err := generateJwtToken(application, user, "", scope, host)
 	if err != nil {
 		return nil, &TokenError{
 			Error:            ENDPOINT_ERROR,
@@ -583,7 +577,7 @@ func GetPasswordToken(application *Application, username string, password string
 	}
 	token := &Token{
 		Owner:        application.Owner,
-		Name:         name,
+		Name:         tokenName,
 		CreatedTime:  util.GetCurrentTime(),
 		Application:  application.Name,
 		Organization: user.Owner,
@@ -614,9 +608,7 @@ func GetClientCredentialsToken(application *Application, clientSecret string, sc
 		Name:  fmt.Sprintf("app/%s", application.Name),
 	}
 
-	name := util.GenerateId()
-	jti := fmt.Sprintf("%s/%s", application.Owner, name)
-	accessToken, _, err := generateJwtToken(application, nullUser, "", scope, host, jti)
+	accessToken, _, tokenName, err := generateJwtToken(application, nullUser, "", scope, host)
 	if err != nil {
 		return nil, &TokenError{
 			Error:            ENDPOINT_ERROR,
@@ -625,7 +617,7 @@ func GetClientCredentialsToken(application *Application, clientSecret string, sc
 	}
 	token := &Token{
 		Owner:        application.Owner,
-		Name:         name,
+		Name:         tokenName,
 		CreatedTime:  util.GetCurrentTime(),
 		Application:  application.Name,
 		Organization: application.Organization,
@@ -643,15 +635,13 @@ func GetClientCredentialsToken(application *Application, clientSecret string, sc
 
 // Implicit flow
 func GetTokenByUser(application *Application, user *User, scope string, host string) (*Token, error) {
-	name := util.GenerateId()
-	jti := fmt.Sprintf("%s/%s", application.Owner, name)
-	accessToken, refreshToken, err := generateJwtToken(application, user, "", scope, host, jti)
+	accessToken, refreshToken, tokenName, err := generateJwtToken(application, user, "", scope, host)
 	if err != nil {
 		return nil, err
 	}
 	token := &Token{
 		Owner:        application.Owner,
-		Name:         name,
+		Name:         tokenName,
 		CreatedTime:  util.GetCurrentTime(),
 		Application:  application.Name,
 		Organization: user.Owner,
@@ -730,9 +720,7 @@ func GetWechatMiniProgramToken(application *Application, code string, host strin
 		AddUser(user)
 	}
 
-	name := util.GenerateId()
-	jti := fmt.Sprintf("%s/%s", application.Owner, name)
-	accessToken, refreshToken, err := generateJwtToken(application, user, "", "", host, jti)
+	accessToken, refreshToken, tokenName, err := generateJwtToken(application, user, "", "", host)
 	if err != nil {
 		return nil, &TokenError{
 			Error:            ENDPOINT_ERROR,
@@ -742,7 +730,7 @@ func GetWechatMiniProgramToken(application *Application, code string, host strin
 
 	token := &Token{
 		Owner:        application.Owner,
-		Name:         name,
+		Name:         tokenName,
 		CreatedTime:  util.GetCurrentTime(),
 		Application:  application.Name,
 		Organization: user.Owner,

--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -16,10 +16,10 @@ package object
 
 import (
 	"fmt"
-	"github.com/casdoor/casdoor/util"
 	"time"
 
 	"github.com/casdoor/casdoor/conf"
+	"github.com/casdoor/casdoor/util"
 	"github.com/golang-jwt/jwt/v4"
 )
 

--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -60,7 +60,7 @@ func getShortClaims(claims Claims) ClaimsShort {
 	return res
 }
 
-func generateJwtToken(application *Application, user *User, nonce string, scope string, host string) (string, string, error) {
+func generateJwtToken(application *Application, user *User, nonce string, scope string, host string, jti string) (string, string, error) {
 	nowTime := time.Now()
 	expireTime := nowTime.Add(time.Duration(application.ExpireInHours) * time.Hour)
 	refreshExpireTime := nowTime.Add(time.Duration(application.RefreshExpireInHours) * time.Hour)
@@ -85,7 +85,7 @@ func generateJwtToken(application *Application, user *User, nonce string, scope 
 			ExpiresAt: jwt.NewNumericDate(expireTime),
 			NotBefore: jwt.NewNumericDate(nowTime),
 			IssuedAt:  jwt.NewNumericDate(nowTime),
-			ID:        "",
+			ID:        jti,
 		},
 	}
 


### PR DESCRIPTION
Fix: [#899](https://github.com/casdoor/casdoor/issues/899)

Use `owner/name` as jti. It can ensure the uniqueness of jti.