### PR TITLE
feat(storage): add support for min.io storage

### DIFF
--- a/storage/minio_s3.go
+++ b/storage/minio_s3.go
@@ -1,0 +1,36 @@
+// Copyright 2021 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	awss3 "github.com/aws/aws-sdk-go/service/s3"
+	"github.com/casdoor/oss"
+	"github.com/casdoor/oss/s3"
+)
+
+func NewMINIOS3StorageProvider(clientId string, clientSecret string, region string, bucket string, endpoint string) oss.StorageInterface {
+	sp := s3.New(&s3.Config{
+		AccessID:         clientId,
+		AccessKey:        clientSecret,
+		Region:           region,
+		Bucket:           bucket,
+		Endpoint:         endpoint,
+		S3Endpoint:       endpoint,
+		ACL:              awss3.BucketCannedACLPublicRead,
+		S3ForcePathStyle: true,
+	})
+
+	return sp
+}

--- a/storage/minio_s3.go
+++ b/storage/minio_s3.go
@@ -20,7 +20,7 @@ import (
 	"github.com/casdoor/oss/s3"
 )
 
-func NewMINIOS3StorageProvider(clientId string, clientSecret string, region string, bucket string, endpoint string) oss.StorageInterface {
+func NewMinIOS3StorageProvider(clientId string, clientSecret string, region string, bucket string, endpoint string) oss.StorageInterface {
 	sp := s3.New(&s3.Config{
 		AccessID:         clientId,
 		AccessKey:        clientSecret,

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -22,8 +22,8 @@ func GetStorageProvider(providerType string, clientId string, clientSecret strin
 		return NewLocalFileSystemStorageProvider(clientId, clientSecret, region, bucket, endpoint)
 	case "AWS S3":
 		return NewAwsS3StorageProvider(clientId, clientSecret, region, bucket, endpoint)
-	case "MINIO":
-		return NewMINIOS3StorageProvider(clientId, clientSecret, region, bucket, endpoint)
+	case "MinIO":
+		return NewMinIOS3StorageProvider(clientId, clientSecret, region, bucket, endpoint)
 	case "Aliyun OSS":
 		return NewAliyunOssStorageProvider(clientId, clientSecret, region, bucket, endpoint)
 	case "Tencent Cloud COS":

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -22,6 +22,8 @@ func GetStorageProvider(providerType string, clientId string, clientSecret strin
 		return NewLocalFileSystemStorageProvider(clientId, clientSecret, region, bucket, endpoint)
 	case "AWS S3":
 		return NewAwsS3StorageProvider(clientId, clientSecret, region, bucket, endpoint)
+	case "MINIO":
+		return NewMINIOS3StorageProvider(clientId, clientSecret, region, bucket, endpoint)
 	case "Aliyun OSS":
 		return NewAliyunOssStorageProvider(clientId, clientSecret, region, bucket, endpoint)
 	case "Tencent Cloud COS":

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -474,7 +474,7 @@ class ProviderEditPage extends React.Component {
                 }} />
               </Col>
             </Row>
-            {["AWS S3", "MINIO", "Tencent Cloud COS"].includes(this.state.provider.type) ? (
+            {["AWS S3", "MinIO", "Tencent Cloud COS"].includes(this.state.provider.type) ? (
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={2}>
                   {Setting.getLabel(i18next.t("provider:Region ID"), i18next.t("provider:Region ID - Tooltip"))} :

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -474,7 +474,7 @@ class ProviderEditPage extends React.Component {
                 }} />
               </Col>
             </Row>
-            {this.state.provider.type === "AWS S3" || this.state.provider.type === "Tencent Cloud COS" ? (
+            {["AWS S3", "MINIO", "Tencent Cloud COS"].includes(this.state.provider.type) ? (
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={2}>
                   {Setting.getLabel(i18next.t("provider:Region ID"), i18next.t("provider:Region ID - Tooltip"))} :

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -69,6 +69,10 @@ export const OtherProviderInfo = {
       logo: `${StaticBaseUrl}/img/social_aws.png`,
       url: "https://aws.amazon.com/s3",
     },
+    "MINIO": {
+      logo: `https://min.io/resources/img/logo.svg`,
+      url: "https://min.io/",
+    },
     "Aliyun OSS": {
       logo: `${StaticBaseUrl}/img/social_aliyun.png`,
       url: "https://aliyun.com/product/oss",
@@ -612,6 +616,7 @@ export function getProviderTypeOptions(category) {
       [
         {id: "Local File System", name: "Local File System"},
         {id: "AWS S3", name: "AWS S3"},
+        {id: "MINIO", name: "MINIO"},
         {id: "Aliyun OSS", name: "Aliyun OSS"},
         {id: "Tencent Cloud COS", name: "Tencent Cloud COS"},
         {id: "Azure Blob", name: "Azure Blob"},

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -70,7 +70,7 @@ export const OtherProviderInfo = {
       url: "https://aws.amazon.com/s3",
     },
     "MINIO": {
-      logo: `https://min.io/resources/img/logo.svg`,
+      logo: "https://min.io/resources/img/logo.svg",
       url: "https://min.io/",
     },
     "Aliyun OSS": {

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -69,7 +69,7 @@ export const OtherProviderInfo = {
       logo: `${StaticBaseUrl}/img/social_aws.png`,
       url: "https://aws.amazon.com/s3",
     },
-    "MINIO": {
+    "MinIO": {
       logo: "https://min.io/resources/img/logo.svg",
       url: "https://min.io/",
     },
@@ -616,7 +616,7 @@ export function getProviderTypeOptions(category) {
       [
         {id: "Local File System", name: "Local File System"},
         {id: "AWS S3", name: "AWS S3"},
-        {id: "MINIO", name: "MINIO"},
+        {id: "MinIO", name: "MinIO"},
         {id: "Aliyun OSS", name: "Aliyun OSS"},
         {id: "Tencent Cloud COS", name: "Tencent Cloud COS"},
         {id: "Azure Blob", name: "Azure Blob"},


### PR DESCRIPTION
min.io server is compatible with aws s3 interface 🙃

for reference [go code](https://docs.min.io/docs/how-to-use-aws-sdk-for-go-with-minio-server.html) 