### PR TITLE
feat: fix token info not contains roles and permissions

### DIFF
--- a/controllers/user.go
+++ b/controllers/user.go
@@ -119,9 +119,7 @@ func (c *ApiController) GetUser() {
 		user = object.GetUser(id)
 	}
 
-	if user != nil {
-		object.GetUserWithRolesAndPermissions(user)
-	}
+	object.ExtendUserWithRolesAndPermissions(user)
 
 	c.Data["json"] = object.GetMaskedUser(user)
 	c.ServeJSON()

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -120,10 +120,7 @@ func (c *ApiController) GetUser() {
 	}
 
 	if user != nil {
-		roles := object.GetRolesByUser(user.GetId())
-		user.Roles = roles
-		permissions := object.GetPermissionsByUser(user.GetId())
-		user.Permissions = permissions
+		object.GetUserWithRolesAndPermissions(user)
 	}
 
 	c.Data["json"] = object.GetMaskedUser(user)

--- a/object/token.go
+++ b/object/token.go
@@ -278,6 +278,9 @@ func GetOAuthCode(userId string, clientId string, responseType string, redirectU
 			Code:    "",
 		}
 	}
+	if user != nil {
+		GetUserWithRolesAndPermissions(user)
+	}
 
 	msg, application := CheckOAuthLogin(clientId, responseType, redirectUri, scope, state)
 	if msg != "" {
@@ -419,6 +422,9 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 			Error:            InvalidGrant,
 			ErrorDescription: "the user is forbidden to sign in, please contact the administrator",
 		}
+	}
+	if user != nil {
+		GetUserWithRolesAndPermissions(user)
 	}
 
 	newAccessToken, newRefreshToken, tokenName, err := generateJwtToken(application, user, "", scope, host)
@@ -570,6 +576,9 @@ func GetPasswordToken(application *Application, username string, password string
 			ErrorDescription: "the user is forbidden to sign in, please contact the administrator",
 		}
 	}
+	if user != nil {
+		GetUserWithRolesAndPermissions(user)
+	}
 
 	accessToken, refreshToken, tokenName, err := generateJwtToken(application, user, "", scope, host)
 	if err != nil {
@@ -640,6 +649,9 @@ func GetClientCredentialsToken(application *Application, clientSecret string, sc
 // GetTokenByUser
 // Implicit flow
 func GetTokenByUser(application *Application, user *User, scope string, host string) (*Token, error) {
+	if user != nil {
+		GetUserWithRolesAndPermissions(user)
+	}
 	accessToken, refreshToken, tokenName, err := generateJwtToken(application, user, "", scope, host)
 	if err != nil {
 		return nil, err
@@ -724,6 +736,8 @@ func GetWechatMiniProgramToken(application *Application, code string, host strin
 			},
 		}
 		AddUser(user)
+	} else {
+		GetUserWithRolesAndPermissions(user)
 	}
 
 	accessToken, refreshToken, tokenName, err := generateJwtToken(application, user, "", "", host)

--- a/object/token.go
+++ b/object/token.go
@@ -278,9 +278,6 @@ func GetOAuthCode(userId string, clientId string, responseType string, redirectU
 			Code:    "",
 		}
 	}
-	if user != nil {
-		GetUserWithRolesAndPermissions(user)
-	}
 
 	msg, application := CheckOAuthLogin(clientId, responseType, redirectUri, scope, state)
 	if msg != "" {
@@ -290,6 +287,7 @@ func GetOAuthCode(userId string, clientId string, responseType string, redirectU
 		}
 	}
 
+	ExtendUserWithRolesAndPermissions(user)
 	accessToken, refreshToken, tokenName, err := generateJwtToken(application, user, nonce, scope, host)
 	if err != nil {
 		panic(err)
@@ -423,10 +421,8 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 			ErrorDescription: "the user is forbidden to sign in, please contact the administrator",
 		}
 	}
-	if user != nil {
-		GetUserWithRolesAndPermissions(user)
-	}
 
+	ExtendUserWithRolesAndPermissions(user)
 	newAccessToken, newRefreshToken, tokenName, err := generateJwtToken(application, user, "", scope, host)
 	if err != nil {
 		return &TokenError{
@@ -576,10 +572,8 @@ func GetPasswordToken(application *Application, username string, password string
 			ErrorDescription: "the user is forbidden to sign in, please contact the administrator",
 		}
 	}
-	if user != nil {
-		GetUserWithRolesAndPermissions(user)
-	}
 
+	ExtendUserWithRolesAndPermissions(user)
 	accessToken, refreshToken, tokenName, err := generateJwtToken(application, user, "", scope, host)
 	if err != nil {
 		return nil, &TokenError{
@@ -649,9 +643,7 @@ func GetClientCredentialsToken(application *Application, clientSecret string, sc
 // GetTokenByUser
 // Implicit flow
 func GetTokenByUser(application *Application, user *User, scope string, host string) (*Token, error) {
-	if user != nil {
-		GetUserWithRolesAndPermissions(user)
-	}
+	ExtendUserWithRolesAndPermissions(user)
 	accessToken, refreshToken, tokenName, err := generateJwtToken(application, user, "", scope, host)
 	if err != nil {
 		return nil, err
@@ -736,10 +728,9 @@ func GetWechatMiniProgramToken(application *Application, code string, host strin
 			},
 		}
 		AddUser(user)
-	} else {
-		GetUserWithRolesAndPermissions(user)
 	}
 
+	ExtendUserWithRolesAndPermissions(user)
 	accessToken, refreshToken, tokenName, err := generateJwtToken(application, user, "", "", host)
 	if err != nil {
 		return nil, &TokenError{

--- a/object/user.go
+++ b/object/user.go
@@ -325,14 +325,6 @@ func GetUserByUserId(owner string, userId string) *User {
 	}
 }
 
-// GetUserWithRolesAndPermissions can supplement user roles and permissions info./**
-func GetUserWithRolesAndPermissions(user *User) {
-	roles := GetRolesByUser(user.GetId())
-	user.Roles = roles
-	permissions := GetPermissionsByUser(user.GetId())
-	user.Permissions = permissions
-}
-
 func GetUser(id string) *User {
 	owner, name := util.GetOwnerAndNameFromId(id)
 	return getUser(owner, name)
@@ -573,4 +565,13 @@ func (user *User) GetId() string {
 
 func isUserIdGlobalAdmin(userId string) bool {
 	return strings.HasPrefix(userId, "built-in/")
+}
+
+func ExtendUserWithRolesAndPermissions(user *User) {
+	if user == nil {
+		return
+	}
+
+	user.Roles = GetRolesByUser(user.GetId())
+	user.Permissions = GetPermissionsByUser(user.GetId())
 }

--- a/object/user.go
+++ b/object/user.go
@@ -325,6 +325,14 @@ func GetUserByUserId(owner string, userId string) *User {
 	}
 }
 
+// GetUserWithRolesAndPermissions can supplement user roles and permissions info./**
+func GetUserWithRolesAndPermissions(user *User) {
+	roles := GetRolesByUser(user.GetId())
+	user.Roles = roles
+	permissions := GetPermissionsByUser(user.GetId())
+	user.Permissions = permissions
+}
+
 func GetUser(id string) *User {
 	owner, name := util.GetOwnerAndNameFromId(id)
 	return getUser(owner, name)


### PR DESCRIPTION
Some users reported that the generated token did not contain roles and permissions information. After troubleshooting, it was found that the roles and permissions fields of the user table were empty, and the information of the user table was only used when generating the token, so it was incomplete.

Referring to the implementation in other places, a method to supplement the user roles and permissions information is added in the user.go.