### PR TITLE
chore: modify docker compose mysql version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,7 @@ services:
       - ./conf:/conf/
   db:
     restart: always
-    image: mysql:8.0.25
-    platform: linux/amd64
+    image: mysql:8.0
     ports:
       - "3306:3306"
     environment:


### PR DESCRIPTION
Use MySQL 8.0 instead of specific version, and remove platform as it will use amd64 
mysql image on arm-based system.