### PR TITLE
fix: check whether to use go proxy in build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #try to connect to google to determine whether user need to use proxy
-curl www.google.com -o /dev/null --connect-timeout 5 2 > /dev/null
+curl www.google.com -o /dev/null --connect-timeout 5 2> /dev/null
 if [ $? == 0 ]
 then
     echo "Successfully connected to Google, no need to use Go proxy"


### PR DESCRIPTION
I used a DigitalOcean server to build the docker image, which can connect
to Google directly. However, while building, I found it used goproxy for go build.

I think we need to ignore the curl output instead of connect to google twice. This pr fixes it.

<img width="724" alt="image" src="https://user-images.githubusercontent.com/69113276/191445989-2973b398-0bc1-4a03-8e22-b3bc68a1a69f.png">

<img width="658" alt="image" src="https://user-images.githubusercontent.com/69113276/191446068-a4acc6a7-2d91-4bd0-b45a-7d227cdbdaea.png">
