### PR TITLE
feat: fix openid address format

### DIFF
--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -16,6 +16,7 @@ package object
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/casdoor/casdoor/util"
@@ -24,10 +25,15 @@ import (
 
 type Claims struct {
 	*User
-	Nonce string `json:"nonce,omitempty"`
-	Tag   string `json:"tag,omitempty"`
-	Scope string `json:"scope,omitempty"`
+	Address Address `json:"address"`
+	Nonce   string  `json:"nonce,omitempty"`
+	Tag     string  `json:"tag,omitempty"`
+	Scope   string  `json:"scope,omitempty"`
 	jwt.RegisteredClaims
+}
+
+type Address struct {
+	Formatted string `json:"formatted"`
 }
 
 type UserShort struct {
@@ -72,8 +78,9 @@ func generateJwtToken(application *Application, user *User, nonce string, scope 
 	jti := fmt.Sprintf("%s/%s", application.Owner, name)
 
 	claims := Claims{
-		User:  user,
-		Nonce: nonce,
+		User:    user,
+		Address: Address{Formatted: strings.Join(user.Address, ",")},
+		Nonce:   nonce,
 		// FIXME: A workaround for custom claim by reusing `tag` in user info
 		Tag:   user.Tag,
 		Scope: scope,


### PR DESCRIPTION
Previously, we return an address string in openid jwt payload, which is not meet the spec.

fix #1151 