### PR TITLE
feat: restrict DingTalk user log in who is under the DingTalk Org(which ClientId belong)

### DIFF
--- a/controllers/util.go
+++ b/controllers/util.go
@@ -56,6 +56,9 @@ func (c *ApiController) T(error string) string {
 // GetAcceptLanguage ...
 func (c *ApiController) GetAcceptLanguage() string {
 	lang := c.Ctx.Request.Header.Get("Accept-Language")
+	if lang == "" {
+		lang = "en"
+	}
 	return lang[0:2]
 }
 

--- a/idp/dingtalk.go
+++ b/idp/dingtalk.go
@@ -85,12 +85,10 @@ func (idp *DingTalkIdProvider) GetToken(code string) (*oauth2.Token, error) {
 		Code         string `json:"code"`
 		GrantType    string `json:"grantType"`
 	}{idp.Config.ClientID, idp.Config.ClientSecret, code, "authorization_code"}
-	fmt.Println("idp.Config.ClientID----", idp.Config.ClientID, "idp.Config.ClientSecret----", idp.Config.ClientSecret, "code----", code)
 	data, err := idp.postWithBody(pTokenParams, idp.Config.Endpoint.TokenURL)
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(string(data), "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")
 	pToken := &DingTalkAccessToken{}
 	err = json.Unmarshal(data, pToken)
 	if err != nil {

--- a/idp/dingtalk.go
+++ b/idp/dingtalk.go
@@ -85,10 +85,12 @@ func (idp *DingTalkIdProvider) GetToken(code string) (*oauth2.Token, error) {
 		Code         string `json:"code"`
 		GrantType    string `json:"grantType"`
 	}{idp.Config.ClientID, idp.Config.ClientSecret, code, "authorization_code"}
+
 	data, err := idp.postWithBody(pTokenParams, idp.Config.Endpoint.TokenURL)
 	if err != nil {
 		return nil, err
 	}
+
 	pToken := &DingTalkAccessToken{}
 	err = json.Unmarshal(data, pToken)
 	if err != nil {
@@ -162,7 +164,7 @@ func (idp *DingTalkIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, erro
 
 	userInfo := UserInfo{
 		Id:          dtUserInfo.OpenId,
-		Username:    "|" + dtUserInfo.Nick,
+		Username:    dtUserInfo.Nick,
 		DisplayName: dtUserInfo.Nick,
 		UnionId:     dtUserInfo.UnionId,
 		Email:       dtUserInfo.Email,

--- a/idp/dingtalk.go
+++ b/idp/dingtalk.go
@@ -152,6 +152,7 @@ func (idp *DingTalkIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, erro
 	if err != nil {
 		return nil, err
 	}
+
 	err = json.Unmarshal(data, dtUserInfo)
 	if err != nil {
 		return nil, err
@@ -160,8 +161,6 @@ func (idp *DingTalkIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, erro
 	if dtUserInfo.Errmsg != "" {
 		return nil, fmt.Errorf("userIdResp.Errcode = %s, userIdResp.Errmsg = %s", dtUserInfo.Errcode, dtUserInfo.Errmsg)
 	}
-
-	//appName := idp.getAppName(dtUserInfo.UnionId)
 
 	userInfo := UserInfo{
 		Id:          dtUserInfo.OpenId,


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/1231

https://user-images.githubusercontent.com/101162387/197991232-9b42bef2-ce68-40ad-9475-a3b15202b20b.mp4

demo video here

Using the following APIs:
https://open.dingtalk.com/document/orgapp-server/obtain-the-access_token-of-an-internal-app
https://open.dingtalk.com/document/orgapp-server/obtains-the-information-about-the-current-application