### PR TITLE
feat: fix multi-platform docker image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,4 +8,5 @@ else
     echo "Google is blocked, Go proxy is enabled: GOPROXY=https://goproxy.cn,direct"
     export GOPROXY="https://goproxy.cn,direct"
 fi
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o server .
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o server_linux_amd64 .
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-w -s" -o server_linux_arm64 .


### PR DESCRIPTION
## How it works
Previously, `build.sh` was specified to build the binary for the `amd64` platform. It caused that an `amd64` binary was copied to an `arm64` docker image. Therefore, although `arm64` image can be built, the binary cannot run.
This PR fixed this by building two binary and copying the same arch binary to the docker image.