### PR TITLE
feat: clear the session of a signin but non-existent user

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -245,8 +245,7 @@ func (c *ApiController) Logout() {
 	util.LogInfo(c.Ctx, "API: [%s] logged out", user)
 
 	application := c.GetSessionApplication()
-	c.SetSessionUsername("")
-	c.SetSessionData(nil)
+	c.ClearUserSession()
 
 	if application == nil || application.Name == "app-built-in" || application.HomepageUrl == "" {
 		c.ResponseOk(user)

--- a/controllers/base.go
+++ b/controllers/base.go
@@ -63,8 +63,7 @@ func (c *ApiController) GetSessionUsername() string {
 	if sessionData != nil &&
 		sessionData.ExpireTime != 0 &&
 		sessionData.ExpireTime < time.Now().Unix() {
-		c.SetSessionUsername("")
-		c.SetSessionData(nil)
+		c.ClearUserSession()
 		return ""
 	}
 
@@ -85,13 +84,17 @@ func (c *ApiController) GetSessionApplication() *object.Application {
 	return application
 }
 
+func (c *ApiController) ClearUserSession() {
+	c.SetSessionUsername("")
+	c.SetSessionData(nil)
+}
+
 func (c *ApiController) GetSessionOidc() (string, string) {
 	sessionData := c.GetSessionData()
 	if sessionData != nil &&
 		sessionData.ExpireTime != 0 &&
 		sessionData.ExpireTime < time.Now().Unix() {
-		c.SetSessionUsername("")
-		c.SetSessionData(nil)
+		c.ClearUserSession()
 		return "", ""
 	}
 	scopeValue := c.GetSession("scope")

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -98,6 +98,7 @@ func (c *ApiController) RequireSignedInUser() (*object.User, bool) {
 
 	user := object.GetUser(userId)
 	if user == nil {
+		c.ClearUserSession()
 		c.ResponseError(fmt.Sprintf(c.T("UserErr.DoNotExist"), userId))
 		return nil, false
 	}


### PR DESCRIPTION
When I login with the user and password, then bind the WeCom user.
The session stores the WeCom username, But link operation will not create a new user, normally it should be the original username, at this point, can't logout and can't login
![WX20221029-164459@2x](https://user-images.githubusercontent.com/58246546/198822873-372aa5a4-cc05-46c7-b298-1e6c8e42ddc6.png)
![WX20221029-164523@2x](https://user-images.githubusercontent.com/58246546/198822817-077ab1a4-faa2-4e5d-a4dc-ac99ec3cc14b.png)
