### PR TITLE
fix: nil error if init data is empty

### DIFF
--- a/object/init_data.go
+++ b/object/init_data.go
@@ -56,10 +56,38 @@ func readInitDataFromFile(filePath string) *InitData {
 
 	s := util.ReadStringFromPath(filePath)
 
-	data := &InitData{}
+	data := &InitData{
+		Organizations: []*Organization{},
+		Applications:  []*Application{},
+		Users:         []*User{},
+		Certs:         []*Cert{},
+		Providers:     []*Provider{},
+		Ldaps:         []*Ldap{},
+	}
 	err := util.JsonToStruct(s, data)
 	if err != nil {
 		panic(err)
+	}
+
+	// transform nil slice to empty slice
+	for _, organization := range data.Organizations {
+		if organization.Tags == nil {
+			organization.Tags = []string{}
+		}
+	}
+	for _, application := range data.Applications {
+		if application.Providers == nil {
+			application.Providers = []*ProviderItem{}
+		}
+		if application.SignupItems == nil {
+			application.SignupItems = []*SignupItem{}
+		}
+		if application.GrantTypes == nil {
+			application.GrantTypes = []string{}
+		}
+		if application.RedirectUris == nil {
+			application.RedirectUris = []string{}
+		}
 	}
 
 	return data


### PR DESCRIPTION
Nil array in JSON will be unmarshalled to nil slice in Go. It will cause the front end to crash because it will try to read the length of an `undefined` object.