### PR TITLE
feat(RoleEditPage): Fix a crash when the sample role domains is null

### DIFF
--- a/web/src/RoleEditPage.js
+++ b/web/src/RoleEditPage.js
@@ -173,7 +173,7 @@ class RoleEditPage extends React.Component {
               this.updateRoleField("domains", value);
             })}>
               {
-                this.state.role.domains.map((domain, index) => <Option key={index} value={domain}>{domain}</Option>)
+                this.state.role.domains?.map((domain, index) => <Option key={index} value={domain}>{domain}</Option>)
               }
             </Select>
           </Col>


### PR DESCRIPTION
Fix the crash when the role object domains is null in the on line demo role page
<img width="972" alt="截屏2022-11-06 21 06 07" src="https://user-images.githubusercontent.com/38446493/200172407-b7664436-bfe5-4207-ac95-5e07aae3ab39.png">
