### PR TITLE
fix(RoleEditPage): Fix a crash when the sample role domains is null

### DIFF
--- a/web/src/RoleEditPage.js
+++ b/web/src/RoleEditPage.js
@@ -173,7 +173,7 @@ class RoleEditPage extends React.Component {
               this.updateRoleField("domains", value);
             })}>
               {
-                this.state.role.domains.map((domain, index) => <Option key={index} value={domain}>{domain}</Option>)
+                this.state.role.domains?.map((domain, index) => <Option key={index} value={domain}>{domain}</Option>)
               }
             </Select>
           </Col>


### PR DESCRIPTION
Fix the crash when the role object domains is null in the on line demo role page
<img width="917" alt="截屏2022-11-06 21 56 52" src="https://user-images.githubusercontent.com/38446493/200174894-86c808d7-ae5b-44ec-9cbc-66f54718f4f5.png">
