### PR TITLE
feat: fix the issue of jumping back to the login page after resetting password

### DIFF
--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -764,9 +764,9 @@ export function renderLoginLink(application, text) {
   return renderLink(url, text, null);
 }
 
-export function redirectToLoginPage(application) {
+export function redirectToLoginPage(application, history) {
   const loginLink = getLoginLink(application);
-  window.location.replace(loginLink);
+  history.push(loginLink);
 }
 
 function renderLink(url, text, onClick) {

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from "react";
-import {Link, useHistory} from "react-router-dom";
+import {Link} from "react-router-dom";
 import {Tag, Tooltip, message} from "antd";
 import {QuestionCircleTwoTone} from "@ant-design/icons";
 import {isMobile as isMobileDevice} from "react-device-detect";
@@ -752,7 +752,7 @@ export function getLoginLink(application) {
   } else if (authConfig.appName === application.name) {
     url = "/login";
   } else if (application.signinUrl === "") {
-    url = path.join(application.homepageUrl, "login");
+    url = path.join(application.homepageUrl, "/login");
   } else {
     url = application.signinUrl;
   }
@@ -766,8 +766,7 @@ export function renderLoginLink(application, text) {
 
 export function redirectToLoginPage(application) {
   const loginLink = getLoginLink(application);
-  const history = useHistory();
-  history.push(loginLink);
+  window.location.replace(loginLink);
 }
 
 function renderLink(url, text, onClick) {

--- a/web/src/auth/ForgetPage.js
+++ b/web/src/auth/ForgetPage.js
@@ -167,7 +167,7 @@ class ForgetPage extends React.Component {
     values.userOwner = this.state.application?.organizationObj.name;
     UserBackend.setPassword(values.userOwner, values.username, "", values?.newPassword).then(res => {
       if (res.status === "ok") {
-        Setting.redirectToLoginPage(this.state.application, this.state.history);
+        Setting.redirectToLoginPage(this.state.application, this.props.history);
       } else {
         Setting.showMessage("error", i18next.t(`signup:${res.msg}`));
       }

--- a/web/src/auth/ForgetPage.js
+++ b/web/src/auth/ForgetPage.js
@@ -23,6 +23,7 @@ import {CountDownInput} from "../common/CountDownInput";
 import * as UserBackend from "../backend/UserBackend";
 import {CheckCircleOutlined, KeyOutlined, LockOutlined, SolutionOutlined, UserOutlined} from "@ant-design/icons";
 import CustomGithubCorner from "../CustomGithubCorner";
+import {withRouter} from "react-router-dom";
 
 const {Step} = Steps;
 const {Option} = Select;
@@ -166,7 +167,7 @@ class ForgetPage extends React.Component {
     values.userOwner = this.state.application?.organizationObj.name;
     UserBackend.setPassword(values.userOwner, values.username, "", values?.newPassword).then(res => {
       if (res.status === "ok") {
-        Setting.redirectToLoginPage(this.state.application);
+        Setting.redirectToLoginPage(this.state.application, this.state.history);
       } else {
         Setting.showMessage("error", i18next.t(`signup:${res.msg}`));
       }
@@ -550,4 +551,4 @@ class ForgetPage extends React.Component {
   }
 }
 
-export default ForgetPage;
+export default withRouter(ForgetPage);

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -30,6 +30,7 @@ import {CountDownInput} from "../common/CountDownInput";
 import SelectLanguageBox from "../SelectLanguageBox";
 import {withTranslation} from "react-i18next";
 import {CaptchaModal} from "../common/CaptchaModal";
+import {withRouter} from "react-router-dom";
 
 const {TabPane} = Tabs;
 
@@ -339,7 +340,7 @@ class LoginPage extends React.Component {
           title="Sign Up Error"
           subTitle={"The application does not allow to sign up new account"}
           extra={[
-            <Button type="primary" key="signin" onClick={() => Setting.redirectToLoginPage(application)}>
+            <Button type="primary" key="signin" onClick={() => Setting.redirectToLoginPage(application, this.props.history)}>
               {
                 i18next.t("login:Sign In")
               }
@@ -816,4 +817,4 @@ class LoginPage extends React.Component {
   }
 }
 
-export default withTranslation()(LoginPage);
+export default withTranslation()(withRouter(LoginPage));

--- a/web/src/auth/PromptPage.js
+++ b/web/src/auth/PromptPage.js
@@ -22,6 +22,7 @@ import i18next from "i18next";
 import AffiliationSelect from "../common/AffiliationSelect";
 import OAuthWidget from "../common/OAuthWidget";
 import SelectRegionBox from "../SelectRegionBox";
+import {withRouter} from "react-router-dom";
 
 class PromptPage extends React.Component {
   constructor(props) {
@@ -190,7 +191,7 @@ class PromptPage extends React.Component {
           if (redirectUrl !== "" && redirectUrl !== null) {
             Setting.goToLink(redirectUrl);
           } else {
-            Setting.redirectToLoginPage(this.getApplicationObj());
+            Setting.redirectToLoginPage(this.getApplicationObj(), this.props.history);
           }
         } else {
           Setting.showMessage("error", `Failed to log out: ${res.msg}`);
@@ -234,7 +235,7 @@ class PromptPage extends React.Component {
           title="Sign Up Error"
           subTitle={"You are unexpected to see this prompt page"}
           extra={[
-            <Button type="primary" key="signin" onClick={() => Setting.redirectToLoginPage(application)}>
+            <Button type="primary" key="signin" onClick={() => Setting.redirectToLoginPage(application, this.props.history)}>
               {
                 i18next.t("login:Sign In")
               }
@@ -272,4 +273,4 @@ class PromptPage extends React.Component {
   }
 }
 
-export default PromptPage;
+export default withRouter(PromptPage);

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -26,6 +26,7 @@ import {CountDownInput} from "../common/CountDownInput";
 import SelectRegionBox from "../SelectRegionBox";
 import CustomGithubCorner from "../CustomGithubCorner";
 import SelectLanguageBox from "../SelectLanguageBox";
+import {withRouter} from "react-router-dom";
 
 const formItemLayout = {
   labelCol: {
@@ -541,7 +542,7 @@ class SignupPage extends React.Component {
           title="Sign Up Error"
           subTitle={"The application does not allow to sign up new account"}
           extra={[
-            <Button type="primary" key="signin" onClick={() => Setting.redirectToLoginPage(application)}>
+            <Button type="primary" key="signin" onClick={() => Setting.redirectToLoginPage(application, this.props.history)}>
               {
                 i18next.t("login:Sign In")
               }
@@ -600,7 +601,7 @@ class SignupPage extends React.Component {
             if (linkInStorage !== null && linkInStorage !== "") {
               Setting.goToLink(linkInStorage);
             } else {
-              Setting.redirectToLoginPage(application);
+              Setting.redirectToLoginPage(application, this.props.history);
             }
           }}>
             {i18next.t("signup:sign in now")}
@@ -660,4 +661,4 @@ class SignupPage extends React.Component {
   }
 }
 
-export default SignupPage;
+export default withRouter(SignupPage);


### PR DESCRIPTION
Fix: #1272 

Original codes failed because:

1. `redirectToLoginPage()` was called in class components which is not compatible with react hooks (`useHistory()` in this case). `redirectToLoginPage()` now uses naive JS implementation of redirecting.
2. `path.join(application.homepageUrl, "login")` returns `login` instead of `/login`.