### PR TITLE
feat: encode redirectUri

### DIFF
--- a/web/src/auth/AuthBackend.js
+++ b/web/src/auth/AuthBackend.js
@@ -54,7 +54,7 @@ export function oAuthParamsToQuery(oAuthParams) {
   }
 
   // code
-  return `?clientId=${oAuthParams.clientId}&responseType=${oAuthParams.responseType}&redirectUri=${oAuthParams.redirectUri}&scope=${oAuthParams.scope}&state=${oAuthParams.state}&nonce=${oAuthParams.nonce}&code_challenge_method=${oAuthParams.challengeMethod}&code_challenge=${oAuthParams.codeChallenge}`;
+  return `?clientId=${oAuthParams.clientId}&responseType=${oAuthParams.responseType}&redirectUri=${encodeURIComponent(oAuthParams.redirectUri)}&scope=${oAuthParams.scope}&state=${oAuthParams.state}&nonce=${oAuthParams.nonce}&code_challenge_method=${oAuthParams.challengeMethod}&code_challenge=${oAuthParams.codeChallenge}`;
 }
 
 export function getApplicationLogin(oAuthParams) {


### PR DESCRIPTION
Some single page application use hash route mode for the router, which will make all URLs in this application with a character `#`. Currently, the Casdoor front-end sends the redirect URI from application parameters directly without any changes. It will cause the backend side cannot to get the correct redirect URI. 

This commit uses the `encodeURIComponent` function to encode the redirect URI parameters before requesting for the backend. It should help to fix the problem without other side effects. 