### PR TITLE
feat: fix bug in GetDefaultApplication() that caused login error for other orgs

### DIFF
--- a/object/organization.go
+++ b/object/organization.go
@@ -222,7 +222,7 @@ func GetDefaultApplication(id string) (*Application, error) {
 	}
 
 	if organization.DefaultApplication != "" {
-		return getApplication("admin", organization.DefaultApplication), fmt.Errorf("The default application: %s does not exist", organization.DefaultApplication)
+		return getApplication("admin", organization.DefaultApplication), nil
 	}
 
 	applications := []*Application{}

--- a/object/organization.go
+++ b/object/organization.go
@@ -222,7 +222,12 @@ func GetDefaultApplication(id string) (*Application, error) {
 	}
 
 	if organization.DefaultApplication != "" {
-		return getApplication("admin", organization.DefaultApplication), nil
+		defaultApplication := getApplication("admin", organization.DefaultApplication)
+		if defaultApplication == nil {
+			return nil, fmt.Errorf("The default application: %s does not exist", organization.DefaultApplication)
+		} else {
+			return defaultApplication, nil
+		}
 	}
 
 	applications := []*Application{}


### PR DESCRIPTION
Should return nil if the `organization.DefaultApplication` does exist, or we can't log in to other orgs
see:
![image](https://user-images.githubusercontent.com/101162387/201960913-8cf166a9-a06a-43c5-be42-c300c462309e.png)
