### PR TITLE
fix: fail to return after flush the page

### DIFF
--- a/web/src/UserEditPage.js
+++ b/web/src/UserEditPage.js
@@ -49,6 +49,7 @@ class UserEditPage extends React.Component {
       applications: [],
       mode: props.location.mode !== undefined ? props.location.mode : "edit",
       loading: true,
+      returnUrl: null,
     };
   }
 
@@ -57,6 +58,7 @@ class UserEditPage extends React.Component {
     this.getOrganizations();
     this.getApplicationsByOrganization(this.state.organizationName);
     this.getUserApplication();
+    this.setReturnUrl();
   }
 
   getUser() {
@@ -100,9 +102,10 @@ class UserEditPage extends React.Component {
       });
   }
 
-  getReturnUrl() {
+  setReturnUrl() {
     const searchParams = new URLSearchParams(this.props.location.search);
-    return searchParams.get("returnUrl");
+    const returnUrl = searchParams.get("returnUrl");
+    returnUrl !== null ? this.setState({returnUrl: returnUrl}) : null;
   }
 
   parseUserField(key, value) {
@@ -619,7 +622,7 @@ class UserEditPage extends React.Component {
             }
           } else {
             if (willExist) {
-              const returnUrl = this.getReturnUrl();
+              const returnUrl = this.state.returnUrl;
               if (returnUrl) {
                 window.location.href = returnUrl;
               }


### PR DESCRIPTION
Old methed just get the url path parameter when click the butten. But when the page flushed, the returnUrl will disappear, so can not return to the specified page.