### PR TITLE
feat: use another filename when uploading a duplicated file instead of replacing it

### DIFF
--- a/controllers/resource.go
+++ b/controllers/resource.go
@@ -171,6 +171,20 @@ func (c *ApiController) UploadResource() {
 		fileType, _ = util.GetOwnerAndNameFromId(mimeType)
 	}
 
+	// fullFilePath conflict, either replace or rename
+	if tag != "avatar" && tag != "termsOfUse" {
+		// rename
+		ext := filepath.Ext(filepath.Base(fullFilePath))
+		index := len(fullFilePath) - len(ext)
+		for i := 1; ; i++ {
+			_, objectKey := object.GetUploadFileUrl(provider, fullFilePath, true)
+			if object.GetResourceCount(owner, username, "name", objectKey) == 0 {
+				break
+			}
+			fullFilePath = fullFilePath[:index] + fmt.Sprintf("-%d", i) + ext
+		}
+	}
+
 	fileUrl, objectKey, err := object.UploadFileSafe(provider, fullFilePath, fileBuffer)
 	if err != nil {
 		c.ResponseError(err.Error())

--- a/controllers/resource.go
+++ b/controllers/resource.go
@@ -171,9 +171,7 @@ func (c *ApiController) UploadResource() {
 		fileType, _ = util.GetOwnerAndNameFromId(mimeType)
 	}
 
-	// fullFilePath conflict, either replace or rename
 	if tag != "avatar" && tag != "termsOfUse" {
-		// rename
 		ext := filepath.Ext(filepath.Base(fullFilePath))
 		index := len(fullFilePath) - len(ext)
 		for i := 1; ; i++ {
@@ -181,6 +179,8 @@ func (c *ApiController) UploadResource() {
 			if object.GetResourceCount(owner, username, "name", objectKey) == 0 {
 				break
 			}
+
+			// duplicated fullFilePath found, change it
 			fullFilePath = fullFilePath[:index] + fmt.Sprintf("-%d", i) + ext
 		}
 	}

--- a/object/avatar.go
+++ b/object/avatar.go
@@ -60,7 +60,7 @@ func getPermanentAvatarUrl(organization string, username string, url string, upl
 	}
 
 	fullFilePath := fmt.Sprintf("/avatar/%s/%s.png", organization, username)
-	uploadedFileUrl, _ := getUploadFileUrl(defaultStorageProvider, fullFilePath, false)
+	uploadedFileUrl, _ := GetUploadFileUrl(defaultStorageProvider, fullFilePath, false)
 
 	if upload {
 		DownloadAndUpload(url, fullFilePath)

--- a/object/storage.go
+++ b/object/storage.go
@@ -54,7 +54,7 @@ func escapePath(path string) string {
 	return res
 }
 
-func getUploadFileUrl(provider *Provider, fullFilePath string, hasTimestamp bool) (string, string) {
+func GetUploadFileUrl(provider *Provider, fullFilePath string, hasTimestamp bool) (string, string) {
 	escapedPath := util.UrlJoin(provider.PathPrefix, escapePath(fullFilePath))
 	objectKey := util.UrlJoin(util.GetUrlPath(provider.Domain), escapedPath)
 
@@ -93,7 +93,7 @@ func uploadFile(provider *Provider, fullFilePath string, fileBuffer *bytes.Buffe
 		UpdateProvider(provider.GetId(), provider)
 	}
 
-	fileUrl, objectKey := getUploadFileUrl(provider, fullFilePath, true)
+	fileUrl, objectKey := GetUploadFileUrl(provider, fullFilePath, true)
 
 	_, err := storageProvider.Put(objectKey, fileBuffer)
 	if err != nil {


### PR DESCRIPTION
Fix: #1310 
When uploading a new file, check whether the file already exists according to the owner and name fields. If it exists, add "-n" at the end of the file name, and n keeps increasing until there are no duplicates.