### PR TITLE
feat: reformat frontend alert texts with correct i18n

### DIFF
--- a/i18n/generate.go
+++ b/i18n/generate.go
@@ -83,7 +83,7 @@ func parseToData() *I18nData {
 
 	data := I18nData{}
 	for _, word := range allWords {
-		tokens := strings.Split(word, ":")
+		tokens := strings.SplitN(word, ":", 2)
 		namespace := tokens[0]
 		key := tokens[1]
 

--- a/web/src/AdapterEditPage.js
+++ b/web/src/AdapterEditPage.js
@@ -263,8 +263,8 @@ class AdapterEditPage extends React.Component {
     const adapter = Setting.deepCopy(this.state.adapter);
     AdapterBackend.updateAdapter(this.state.adapter.owner, this.state.adapterName, adapter)
       .then((res) => {
-        if (res.msg === "") {
-          Setting.showMessage("success", "Successfully saved");
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
             adapterName: this.state.adapter.name,
           });
@@ -280,7 +280,7 @@ class AdapterEditPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/AdapterEditPage.js
+++ b/web/src/AdapterEditPage.js
@@ -275,22 +275,26 @@ class AdapterEditPage extends React.Component {
             this.props.history.push(`/adapters/${this.state.owner}/${this.state.adapter.name}`);
           }
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
           this.updateAdapterField("name", this.state.adapterName);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteAdapter() {
     AdapterBackend.deleteAdapter(this.state.adapter)
-      .then(() => {
-        this.props.history.push("/adapters");
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/adapters");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
       })
       .catch(error => {
-        Setting.showMessage("error", `adapter failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/AdapterListPage.js
+++ b/web/src/AdapterListPage.js
@@ -47,26 +47,31 @@ class AdapterListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           this.props.history.push({pathname: `/adapters/${newAdapter.organization}/${newAdapter.name}`, mode: "add"});
+          Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
-          Setting.showMessage("error", i18next.t("adapter:Failed to add the adapter") + res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteAdapter(i) {
     AdapterBackend.deleteAdapter(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "Deleted successfully");
-        this.setState({
-          data: Setting.deleteRow(this.state.data, i),
-          pagination: {total: this.state.pagination.total - 1},
-        });
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully deleted"));
+          this.setState({
+            data: Setting.deleteRow(this.state.data, i),
+            pagination: {total: this.state.pagination.total - 1},
+          });
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/AdapterListPage.js
+++ b/web/src/AdapterListPage.js
@@ -48,26 +48,25 @@ class AdapterListPage extends BaseListPage {
         if (res.status === "ok") {
           this.props.history.push({pathname: `/adapters/${newAdapter.organization}/${newAdapter.name}`, mode: "add"});
         } else {
-          Setting.showMessage("error", `Adapter failed to add: ${res.msg}`);
+          Setting.showMessage("error", i18next.t("adapter:Failed to add the adapter") + res.msg);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Adapter failed to add: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 
   deleteAdapter(i) {
     AdapterBackend.deleteAdapter(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "Adapter deleted successfully");
+        Setting.showMessage("success", "Deleted successfully");
         this.setState({
           data: Setting.deleteRow(this.state.data, i),
           pagination: {total: this.state.pagination.total - 1},
         });
-      }
-      )
+      })
       .catch(error => {
-        Setting.showMessage("error", `Adapter failed to delete: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/ApplicationEditPage.js
+++ b/web/src/ApplicationEditPage.js
@@ -787,7 +787,7 @@ class ApplicationEditPage extends React.Component {
     ApplicationBackend.updateApplication("admin", this.state.applicationName, application)
       .then((res) => {
         if (res.status === "ok") {
-          Setting.showMessage("success", "Successfully saved");
+          Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
             applicationName: this.state.application.name,
           });
@@ -803,7 +803,7 @@ class ApplicationEditPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/ApplicationEditPage.js
+++ b/web/src/ApplicationEditPage.js
@@ -191,7 +191,7 @@ class ApplicationEditPage extends React.Component {
           Setting.showMessage("success", i18next.t("application:File uploaded successfully"));
           this.updateApplicationField("termsOfUse", res.data);
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
         }
       }).finally(() => {
         this.setState({uploading: false});
@@ -798,22 +798,26 @@ class ApplicationEditPage extends React.Component {
             this.props.history.push(`/applications/${this.state.application.organization}/${this.state.application.name}`);
           }
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
           this.updateApplicationField("name", this.state.applicationName);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteApplication() {
     ApplicationBackend.deleteApplication(this.state.application)
-      .then(() => {
-        this.props.history.push("/applications");
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/applications");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
       })
       .catch(error => {
-        Setting.showMessage("error", `Application failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/ApplicationListPage.js
+++ b/web/src/ApplicationListPage.js
@@ -80,27 +80,31 @@ class ApplicationListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           this.props.history.push({pathname: `/applications/${newApplication.organization}/${newApplication.name}`, mode: "add"});
+          Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
-          Setting.showMessage("error", `Application failed to add: ${res.msg}`);
+          Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Application failed to add: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteApplication(i) {
     ApplicationBackend.deleteApplication(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "Application deleted successfully");
-        this.setState({
-          data: Setting.deleteRow(this.state.data, i),
-          pagination: {total: this.state.pagination.total - 1},
-        });
-      }
-      )
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully deleted"));
+          this.setState({
+            data: Setting.deleteRow(this.state.data, i),
+            pagination: {total: this.state.pagination.total - 1},
+          });
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
       .catch(error => {
-        Setting.showMessage("error", `Application failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/CertEditPage.js
+++ b/web/src/CertEditPage.js
@@ -217,8 +217,8 @@ class CertEditPage extends React.Component {
     const cert = Setting.deepCopy(this.state.cert);
     CertBackend.updateCert(this.state.cert.owner, this.state.certName, cert)
       .then((res) => {
-        if (res.msg === "") {
-          Setting.showMessage("success", "Successfully saved");
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
             certName: this.state.cert.name,
           });
@@ -234,7 +234,7 @@ class CertEditPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/CertEditPage.js
+++ b/web/src/CertEditPage.js
@@ -229,22 +229,26 @@ class CertEditPage extends React.Component {
             this.props.history.push(`/certs/${this.state.cert.name}`);
           }
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
           this.updateCertField("name", this.state.certName);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteCert() {
     CertBackend.deleteCert(this.state.cert)
-      .then(() => {
-        this.props.history.push("/certs");
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/certs");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
       })
       .catch(error => {
-        Setting.showMessage("error", `Cert failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/CertListPage.js
+++ b/web/src/CertListPage.js
@@ -45,27 +45,31 @@ class CertListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           this.props.history.push({pathname: `/certs/${newCert.name}`, mode: "add"});
+          Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
-          Setting.showMessage("error", `Cert failed to add: ${res.msg}`);
+          Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Cert failed to add: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteCert(i) {
     CertBackend.deleteCert(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "Cert deleted successfully");
-        this.setState({
-          data: Setting.deleteRow(this.state.data, i),
-          pagination: {total: this.state.pagination.total - 1},
-        });
-      }
-      )
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully deleted"));
+          this.setState({
+            data: Setting.deleteRow(this.state.data, i),
+            pagination: {total: this.state.pagination.total - 1},
+          });
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
       .catch(error => {
-        Setting.showMessage("error", `Cert failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/LdapTable.js
+++ b/web/src/LdapTable.js
@@ -81,7 +81,7 @@ class LdapTable extends React.Component {
           table = Setting.deleteRow(table, i);
           this.updateTable(table);
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
         }
       }
       )

--- a/web/src/ModelEditPage.js
+++ b/web/src/ModelEditPage.js
@@ -158,8 +158,8 @@ class ModelEditPage extends React.Component {
     const model = Setting.deepCopy(this.state.model);
     ModelBackend.updateModel(this.state.organizationName, this.state.modelName, model)
       .then((res) => {
-        if (res.msg === "") {
-          Setting.showMessage("success", "Successfully saved");
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
             modelName: this.state.model.name,
           });
@@ -175,7 +175,7 @@ class ModelEditPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/ModelEditPage.js
+++ b/web/src/ModelEditPage.js
@@ -170,22 +170,26 @@ class ModelEditPage extends React.Component {
             this.props.history.push(`/models/${this.state.model.owner}/${this.state.model.name}`);
           }
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
           this.updateModelField("name", this.state.modelName);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteModel() {
     ModelBackend.deleteModel(this.state.model)
-      .then(() => {
-        this.props.history.push("/models");
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/models");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
       })
       .catch(error => {
-        Setting.showMessage("error", `Model failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/ModelListPage.js
+++ b/web/src/ModelListPage.js
@@ -40,27 +40,31 @@ class ModelListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           this.props.history.push({pathname: `/models/${newModel.owner}/${newModel.name}`, mode: "add"});
+          Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
-          Setting.showMessage("error", `Model failed to add: ${res.msg}`);
+          Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Model failed to add: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteModel(i) {
     ModelBackend.deleteModel(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "Model deleted successfully");
-        this.setState({
-          data: Setting.deleteRow(this.state.data, i),
-          pagination: {total: this.state.pagination.total - 1},
-        });
-      }
-      )
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully deleted"));
+          this.setState({
+            data: Setting.deleteRow(this.state.data, i),
+            pagination: {total: this.state.pagination.total - 1},
+          });
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
       .catch(error => {
-        Setting.showMessage("error", `Model failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/OrganizationEditPage.js
+++ b/web/src/OrganizationEditPage.js
@@ -336,7 +336,7 @@ class OrganizationEditPage extends React.Component {
     OrganizationBackend.updateOrganization(this.state.organization.owner, this.state.organizationName, organization)
       .then((res) => {
         if (res.status === "ok") {
-          Setting.showMessage("success", "Successfully saved");
+          Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
             organizationName: this.state.organization.name,
           });
@@ -352,7 +352,7 @@ class OrganizationEditPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 
@@ -362,7 +362,7 @@ class OrganizationEditPage extends React.Component {
         this.props.history.push("/organizations");
       })
       .catch(error => {
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/OrganizationEditPage.js
+++ b/web/src/OrganizationEditPage.js
@@ -347,22 +347,26 @@ class OrganizationEditPage extends React.Component {
             this.props.history.push(`/organizations/${this.state.organization.name}`);
           }
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
           this.updateOrganizationField("name", this.state.organizationName);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteOrganization() {
     OrganizationBackend.deleteOrganization(this.state.organization)
-      .then(() => {
-        this.props.history.push("/organizations");
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/organizations");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/OrganizationListPage.js
+++ b/web/src/OrganizationListPage.js
@@ -77,27 +77,31 @@ class OrganizationListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           this.props.history.push({pathname: `/organizations/${newOrganization.name}`, mode: "add"});
+          Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
-          Setting.showMessage("error", `Organization failed to add: ${res.msg}`);
+          Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Organization failed to add: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteOrganization(i) {
     OrganizationBackend.deleteOrganization(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "Organization deleted successfully");
-        this.setState({
-          data: Setting.deleteRow(this.state.data, i),
-          pagination: {total: this.state.pagination.total - 1},
-        });
-      }
-      )
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully deleted"));
+          this.setState({
+            data: Setting.deleteRow(this.state.data, i),
+            pagination: {total: this.state.pagination.total - 1},
+          });
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
       .catch(error => {
-        Setting.showMessage("error", `Organization failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/PaymentEditPage.js
+++ b/web/src/PaymentEditPage.js
@@ -90,7 +90,7 @@ class PaymentEditPage extends React.Component {
         this.setState({
           isInvoiceLoading: false,
         });
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
@@ -455,22 +455,26 @@ class PaymentEditPage extends React.Component {
             this.props.history.push(`/payments/${this.state.payment.name}`);
           }
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
           this.updatePaymentField("name", this.state.paymentName);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deletePayment() {
     PaymentBackend.deletePayment(this.state.payment)
-      .then(() => {
-        this.props.history.push("/payments");
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/payments");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
       })
       .catch(error => {
-        Setting.showMessage("error", `Payment failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/PaymentEditPage.js
+++ b/web/src/PaymentEditPage.js
@@ -78,7 +78,7 @@ class PaymentEditPage extends React.Component {
         this.setState({
           isInvoiceLoading: false,
         });
-        if (res.msg === "") {
+        if (res.status === "ok") {
           Setting.showMessage("success", "Successfully invoiced");
           Setting.openLinkSafe(res.data);
           this.getPayment();
@@ -90,7 +90,7 @@ class PaymentEditPage extends React.Component {
         this.setState({
           isInvoiceLoading: false,
         });
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 
@@ -443,8 +443,8 @@ class PaymentEditPage extends React.Component {
     const payment = Setting.deepCopy(this.state.payment);
     PaymentBackend.updatePayment(this.state.payment.owner, this.state.paymentName, payment)
       .then((res) => {
-        if (res.msg === "") {
-          Setting.showMessage("success", "Successfully saved");
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
             paymentName: this.state.payment.name,
           });
@@ -460,7 +460,7 @@ class PaymentEditPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/PaymentListPage.js
+++ b/web/src/PaymentListPage.js
@@ -53,28 +53,32 @@ class PaymentListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           this.props.history.push({pathname: `/payments/${newPayment.name}`, mode: "add"});
+          Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
-          Setting.showMessage("error", `Payment failed to add: ${res.msg}`);
+          Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
       }
       )
       .catch(error => {
-        Setting.showMessage("error", `Payment failed to add: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deletePayment(i) {
     PaymentBackend.deletePayment(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "Payment deleted successfully");
-        this.setState({
-          data: Setting.deleteRow(this.state.data, i),
-          pagination: {total: this.state.pagination.total - 1},
-        });
-      }
-      )
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully deleted"));
+          this.setState({
+            data: Setting.deleteRow(this.state.data, i),
+            pagination: {total: this.state.pagination.total - 1},
+          });
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
       .catch(error => {
-        Setting.showMessage("error", `Payment failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/PermissionEditPage.js
+++ b/web/src/PermissionEditPage.js
@@ -417,8 +417,8 @@ class PermissionEditPage extends React.Component {
     const permission = Setting.deepCopy(this.state.permission);
     PermissionBackend.updatePermission(this.state.organizationName, this.state.permissionName, permission)
       .then((res) => {
-        if (res.msg === "") {
-          Setting.showMessage("success", "Successfully saved");
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
             permissionName: this.state.permission.name,
           });
@@ -434,7 +434,7 @@ class PermissionEditPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/PermissionEditPage.js
+++ b/web/src/PermissionEditPage.js
@@ -429,22 +429,26 @@ class PermissionEditPage extends React.Component {
             this.props.history.push(`/permissions/${this.state.permission.owner}/${this.state.permission.name}`);
           }
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
           this.updatePermissionField("name", this.state.permissionName);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deletePermission() {
     PermissionBackend.deletePermission(this.state.permission)
-      .then(() => {
-        this.props.history.push("/permissions");
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/permissions");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
       })
       .catch(error => {
-        Setting.showMessage("error", `Permission failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/PermissionListPage.js
+++ b/web/src/PermissionListPage.js
@@ -50,27 +50,31 @@ class PermissionListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           this.props.history.push({pathname: `/permissions/${newPermission.owner}/${newPermission.name}`, mode: "add"});
+          Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
-          Setting.showMessage("error", `Permission failed to add: ${res.msg}`);
+          Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Permission failed to add: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deletePermission(i) {
     PermissionBackend.deletePermission(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "Permission deleted successfully");
-        this.setState({
-          data: Setting.deleteRow(this.state.data, i),
-          pagination: {total: this.state.pagination.total - 1},
-        });
-      }
-      )
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully deleted"));
+          this.setState({
+            data: Setting.deleteRow(this.state.data, i),
+            pagination: {total: this.state.pagination.total - 1},
+          });
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
       .catch(error => {
-        Setting.showMessage("error", `Permission failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/ProductBuyPage.js
+++ b/web/src/ProductBuyPage.js
@@ -85,7 +85,7 @@ class ProductBuyPage extends React.Component {
           const payUrl = res.data;
           Setting.goToLink(payUrl);
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
 
           this.setState({
             isPlacingOrder: false,
@@ -93,7 +93,7 @@ class ProductBuyPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/ProductBuyPage.js
+++ b/web/src/ProductBuyPage.js
@@ -81,7 +81,7 @@ class ProductBuyPage extends React.Component {
 
     ProductBackend.buyProduct(this.state.product.owner, this.state.productName, provider.name)
       .then((res) => {
-        if (res.msg === "") {
+        if (res.status === "ok") {
           const payUrl = res.data;
           Setting.goToLink(payUrl);
         } else {
@@ -93,7 +93,7 @@ class ProductBuyPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/ProductEditPage.js
+++ b/web/src/ProductEditPage.js
@@ -271,8 +271,8 @@ class ProductEditPage extends React.Component {
     const product = Setting.deepCopy(this.state.product);
     ProductBackend.updateProduct(this.state.product.owner, this.state.productName, product)
       .then((res) => {
-        if (res.msg === "") {
-          Setting.showMessage("success", "Successfully saved");
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
             productName: this.state.product.name,
           });
@@ -288,7 +288,7 @@ class ProductEditPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/ProductEditPage.js
+++ b/web/src/ProductEditPage.js
@@ -283,22 +283,26 @@ class ProductEditPage extends React.Component {
             this.props.history.push(`/products/${this.state.product.name}`);
           }
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
           this.updateProductField("name", this.state.productName);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteProduct() {
     ProductBackend.deleteProduct(this.state.product)
-      .then(() => {
-        this.props.history.push("/products");
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/products");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
       })
       .catch(error => {
-        Setting.showMessage("error", `Product failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/ProductListPage.js
+++ b/web/src/ProductListPage.js
@@ -47,27 +47,31 @@ class ProductListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           this.props.history.push({pathname: `/products/${newProduct.name}`, mode: "add"});
+          Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
-          Setting.showMessage("error", `Product failed to add: ${res.msg}`);
+          Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Product failed to add: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteProduct(i) {
     ProductBackend.deleteProduct(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "Product deleted successfully");
-        this.setState({
-          data: Setting.deleteRow(this.state.data, i),
-          pagination: {total: this.state.pagination.total - 1},
-        });
-      }
-      )
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully deleted"));
+          this.setState({
+            data: Setting.deleteRow(this.state.data, i),
+            pagination: {total: this.state.pagination.total - 1},
+          });
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
       .catch(error => {
-        Setting.showMessage("error", `Product failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -802,22 +802,26 @@ class ProviderEditPage extends React.Component {
             this.props.history.push(`/providers/${this.state.provider.owner}/${this.state.provider.name}`);
           }
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
           this.updateProviderField("name", this.state.providerName);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteProvider() {
     ProviderBackend.deleteProvider(this.state.provider)
-      .then(() => {
-        this.props.history.push("/providers");
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/providers");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
       })
       .catch(error => {
-        Setting.showMessage("error", `Provider failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -790,7 +790,7 @@ class ProviderEditPage extends React.Component {
     ProviderBackend.updateProvider(this.state.owner, this.state.providerName, provider)
       .then((res) => {
         if (res.status === "ok") {
-          Setting.showMessage("success", "Successfully saved");
+          Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
             owner: this.state.provider.owner,
             providerName: this.state.provider.name,
@@ -807,7 +807,7 @@ class ProviderEditPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/ProviderListPage.js
+++ b/web/src/ProviderListPage.js
@@ -63,27 +63,31 @@ class ProviderListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           this.props.history.push({pathname: `/providers/${newProvider.owner}/${newProvider.name}`, mode: "add"});
+          Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
-          Setting.showMessage("error", `Provider failed to add: ${res.msg}`);
+          Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Provider failed to add: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteProvider(i) {
     ProviderBackend.deleteProvider(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "Provider deleted successfully");
-        this.setState({
-          data: Setting.deleteRow(this.state.data, i),
-          pagination: {total: this.state.pagination.total - 1},
-        });
-      }
-      )
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully deleted"));
+          this.setState({
+            data: Setting.deleteRow(this.state.data, i),
+            pagination: {total: this.state.pagination.total - 1},
+          });
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
       .catch(error => {
-        Setting.showMessage("error", `Provider failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/ResourceListPage.js
+++ b/web/src/ResourceListPage.js
@@ -43,15 +43,18 @@ class ResourceListPage extends BaseListPage {
   deleteResource(i) {
     ResourceBackend.deleteResource(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "Resource deleted successfully");
-        this.setState({
-          data: Setting.deleteRow(this.state.data, i),
-          pagination: {total: this.state.pagination.total - 1},
-        });
-      }
-      )
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully deleted"));
+          this.setState({
+            data: Setting.deleteRow(this.state.data, i),
+            pagination: {total: this.state.pagination.total - 1},
+          });
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
       .catch(error => {
-        Setting.showMessage("error", `Resource failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/RoleEditPage.js
+++ b/web/src/RoleEditPage.js
@@ -196,8 +196,8 @@ class RoleEditPage extends React.Component {
     const role = Setting.deepCopy(this.state.role);
     RoleBackend.updateRole(this.state.organizationName, this.state.roleName, role)
       .then((res) => {
-        if (res.msg === "") {
-          Setting.showMessage("success", "Successfully saved");
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
             roleName: this.state.role.name,
           });
@@ -213,7 +213,7 @@ class RoleEditPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/RoleEditPage.js
+++ b/web/src/RoleEditPage.js
@@ -208,22 +208,26 @@ class RoleEditPage extends React.Component {
             this.props.history.push(`/roles/${this.state.role.owner}/${this.state.role.name}`);
           }
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
           this.updateRoleField("name", this.state.roleName);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteRole() {
     RoleBackend.deleteRole(this.state.role)
-      .then(() => {
-        this.props.history.push("/roles");
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/roles");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
       })
       .catch(error => {
-        Setting.showMessage("error", `Role failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/RoleListPage.js
+++ b/web/src/RoleListPage.js
@@ -42,27 +42,31 @@ class RoleListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           this.props.history.push({pathname: `/roles/${newRole.owner}/${newRole.name}`, mode: "add"});
+          Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
-          Setting.showMessage("error", `Role failed to add: ${res.msg}`);
+          Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Role failed to add: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteRole(i) {
     RoleBackend.deleteRole(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "Role deleted successfully");
-        this.setState({
-          data: Setting.deleteRow(this.state.data, i),
-          pagination: {total: this.state.pagination.total - 1},
-        });
-      }
-      )
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully deleted"));
+          this.setState({
+            data: Setting.deleteRow(this.state.data, i),
+            pagination: {total: this.state.pagination.total - 1},
+          });
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
       .catch(error => {
-        Setting.showMessage("error", `Role failed to delete: ${error}`);
+
       });
   }
 

--- a/web/src/SyncerEditPage.js
+++ b/web/src/SyncerEditPage.js
@@ -298,8 +298,8 @@ class SyncerEditPage extends React.Component {
     const syncer = Setting.deepCopy(this.state.syncer);
     SyncerBackend.updateSyncer(this.state.syncer.owner, this.state.syncerName, syncer)
       .then((res) => {
-        if (res.msg === "") {
-          Setting.showMessage("success", "Successfully saved");
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
             syncerName: this.state.syncer.name,
           });
@@ -315,7 +315,7 @@ class SyncerEditPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/SyncerEditPage.js
+++ b/web/src/SyncerEditPage.js
@@ -310,22 +310,26 @@ class SyncerEditPage extends React.Component {
             this.props.history.push(`/syncers/${this.state.syncer.name}`);
           }
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
           this.updateSyncerField("name", this.state.syncerName);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteSyncer() {
     SyncerBackend.deleteSyncer(this.state.syncer)
-      .then(() => {
-        this.props.history.push("/syncers");
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/syncers");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
       })
       .catch(error => {
-        Setting.showMessage("error", `Syncer failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/SyncerListPage.js
+++ b/web/src/SyncerListPage.js
@@ -51,27 +51,31 @@ class SyncerListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           this.props.history.push({pathname: `/syncers/${newSyncer.name}`, mode: "add"});
+          Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
-          Setting.showMessage("error", `Syncer failed to add: ${res.msg}`);
+          Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Syncer failed to add: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteSyncer(i) {
     SyncerBackend.deleteSyncer(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "Syncer deleted successfully");
-        this.setState({
-          data: Setting.deleteRow(this.state.data, i),
-          pagination: {total: this.state.pagination.total - 1},
-        });
-      }
-      )
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully deleted"));
+          this.setState({
+            data: Setting.deleteRow(this.state.data, i),
+            pagination: {total: this.state.pagination.total - 1},
+          });
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
       .catch(error => {
-        Setting.showMessage("error", `Syncer failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/TestEmailWidget.js
+++ b/web/src/TestEmailWidget.js
@@ -13,32 +13,33 @@
 // limitations under the License.
 
 import * as Setting from "./Setting";
+import i18next from "i18next";
 
 export function sendTestEmail(provider, email) {
   testEmailProvider(provider, email)
     .then((res) => {
-      if (res.msg === "") {
+      if (res.status === "ok") {
         Setting.showMessage("success", "Successfully send email");
       } else {
         Setting.showMessage("error", res.msg);
       }
     })
     .catch(error => {
-      Setting.showMessage("error", `Failed to connect to server: ${error}`);
+      Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
     });
 }
 
 export function connectSmtpServer(provider) {
   testEmailProvider(provider)
     .then((res) => {
-      if (res.msg === "") {
+      if (res.status === "ok") {
         Setting.showMessage("success", "Successfully connecting smtp server");
       } else {
         Setting.showMessage("error", res.msg);
       }
     })
     .catch(error => {
-      Setting.showMessage("error", `Failed to connect to server: ${error}`);
+      Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
     });
 }
 

--- a/web/src/TestEmailWidget.js
+++ b/web/src/TestEmailWidget.js
@@ -25,7 +25,7 @@ export function sendTestEmail(provider, email) {
       }
     })
     .catch(error => {
-      Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+      Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
     });
 }
 
@@ -39,7 +39,7 @@ export function connectSmtpServer(provider) {
       }
     })
     .catch(error => {
-      Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+      Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
     });
 }
 

--- a/web/src/TokenEditPage.js
+++ b/web/src/TokenEditPage.js
@@ -167,8 +167,8 @@ class TokenEditPage extends React.Component {
     const token = Setting.deepCopy(this.state.token);
     TokenBackend.updateToken(this.state.token.owner, this.state.tokenName, token)
       .then((res) => {
-        if (res.msg === "") {
-          Setting.showMessage("success", "Successfully saved");
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
             tokenName: this.state.token.name,
           });
@@ -184,7 +184,7 @@ class TokenEditPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/TokenEditPage.js
+++ b/web/src/TokenEditPage.js
@@ -179,22 +179,26 @@ class TokenEditPage extends React.Component {
             this.props.history.push(`/tokens/${this.state.token.name}`);
           }
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
           this.updateTokenField("name", this.state.tokenName);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteToken() {
     TokenBackend.deleteToken(this.state.token)
-      .then(() => {
-        this.props.history.push("/tokens");
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/tokens");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
       })
       .catch(error => {
-        Setting.showMessage("error", `Token failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/TokenListPage.js
+++ b/web/src/TokenListPage.js
@@ -44,27 +44,31 @@ class TokenListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           this.props.history.push({pathname: `/tokens/${newToken.name}`, mode: "add"});
+          Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
-          Setting.showMessage("error", `Token failed to add: ${res.msg}`);
+          Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Token failed to add: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteToken(i) {
     TokenBackend.deleteToken(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "Token deleted successfully");
-        this.setState({
-          data: Setting.deleteRow(this.state.data, i),
-          pagination: {total: this.state.pagination.total - 1},
-        });
-      }
-      )
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully deleted"));
+          this.setState({
+            data: Setting.deleteRow(this.state.data, i),
+            pagination: {total: this.state.pagination.total - 1},
+          });
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
       .catch(error => {
-        Setting.showMessage("error", `Token failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/UserEditPage.js
+++ b/web/src/UserEditPage.js
@@ -612,7 +612,7 @@ class UserEditPage extends React.Component {
     UserBackend.updateUser(this.state.organizationName, this.state.userName, user)
       .then((res) => {
         if (res.status === "ok") {
-          Setting.showMessage("success", "Successfully saved");
+          Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
             organizationName: this.state.user.owner,
             userName: this.state.user.name,
@@ -638,7 +638,7 @@ class UserEditPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/UserEditPage.js
+++ b/web/src/UserEditPage.js
@@ -632,23 +632,27 @@ class UserEditPage extends React.Component {
             }
           }
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
           this.updateUserField("owner", this.state.organizationName);
           this.updateUserField("name", this.state.userName);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteUser() {
     UserBackend.deleteUser(this.state.user)
-      .then(() => {
-        this.props.history.push("/users");
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/users");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
       })
       .catch(error => {
-        Setting.showMessage("error", `User failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/UserListPage.js
+++ b/web/src/UserListPage.js
@@ -74,27 +74,31 @@ class UserListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           this.props.history.push({pathname: `/users/${newUser.owner}/${newUser.name}`, mode: "add"});
+          Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
-          Setting.showMessage("error", `User failed to add: ${res.msg}`);
+          Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `User failed to add: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteUser(i) {
     UserBackend.deleteUser(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "User deleted successfully");
-        this.setState({
-          data: Setting.deleteRow(this.state.data, i),
-          pagination: {total: this.state.pagination.total - 1},
-        });
-      }
-      )
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully deleted"));
+          this.setState({
+            data: Setting.deleteRow(this.state.data, i),
+            pagination: {total: this.state.pagination.total - 1},
+          });
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
       .catch(error => {
-        Setting.showMessage("error", `User failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/WebauthnCredentialTable.js
+++ b/web/src/WebauthnCredentialTable.js
@@ -34,7 +34,7 @@ class WebAuthnCredentialTable extends React.Component {
 
       this.props.refresh();
     }).catch(error => {
-      Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+      Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
     });
   }
 

--- a/web/src/WebauthnCredentialTable.js
+++ b/web/src/WebauthnCredentialTable.js
@@ -26,7 +26,7 @@ class WebAuthnCredentialTable extends React.Component {
 
   registerWebAuthn() {
     UserWebauthnBackend.registerWebauthnCredential().then((res) => {
-      if (res.msg === "") {
+      if (res.status === "ok") {
         Setting.showMessage("success", "Successfully added webauthn credentials");
       } else {
         Setting.showMessage("error", res.msg);
@@ -34,7 +34,7 @@ class WebAuthnCredentialTable extends React.Component {
 
       this.props.refresh();
     }).catch(error => {
-      Setting.showMessage("error", `Failed to connect to server: ${error}`);
+      Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
     });
   }
 

--- a/web/src/WebhookEditPage.js
+++ b/web/src/WebhookEditPage.js
@@ -296,8 +296,8 @@ class WebhookEditPage extends React.Component {
     const webhook = Setting.deepCopy(this.state.webhook);
     WebhookBackend.updateWebhook(this.state.webhook.owner, this.state.webhookName, webhook)
       .then((res) => {
-        if (res.msg === "") {
-          Setting.showMessage("success", "Successfully saved");
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
             webhookName: this.state.webhook.name,
           });
@@ -313,7 +313,7 @@ class WebhookEditPage extends React.Component {
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Failed to connect to server: ${error}`);
+        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
       });
   }
 

--- a/web/src/WebhookEditPage.js
+++ b/web/src/WebhookEditPage.js
@@ -308,22 +308,26 @@ class WebhookEditPage extends React.Component {
             this.props.history.push(`/webhooks/${this.state.webhook.name}`);
           }
         } else {
-          Setting.showMessage("error", res.msg);
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
           this.updateWebhookField("name", this.state.webhookName);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteWebhook() {
     WebhookBackend.deleteWebhook(this.state.webhook)
-      .then(() => {
-        this.props.history.push("/webhooks");
+      .then((res) => {
+        if (res.status === "ok") {
+          this.props.history.push("/webhooks");
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
       })
       .catch(error => {
-        Setting.showMessage("error", `Webhook failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/WebhookListPage.js
+++ b/web/src/WebhookListPage.js
@@ -44,27 +44,31 @@ class WebhookListPage extends BaseListPage {
       .then((res) => {
         if (res.status === "ok") {
           this.props.history.push({pathname: `/webhooks/${newWebhook.name}`, mode: "add"});
+          Setting.showMessage("success", i18next.t("general:Successfully added"));
         } else {
-          Setting.showMessage("error", `Webhook failed to add: ${res.msg}`);
+          Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
         }
       })
       .catch(error => {
-        Setting.showMessage("error", `Webhook failed to add: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
   deleteWebhook(i) {
     WebhookBackend.deleteWebhook(this.state.data[i])
       .then((res) => {
-        Setting.showMessage("success", "Webhook deleted successfully");
-        this.setState({
-          data: Setting.deleteRow(this.state.data, i),
-          pagination: {total: this.state.pagination.total - 1},
-        });
-      }
-      )
+        if (res.status === "ok") {
+          Setting.showMessage("success", i18next.t("general:Successfully deleted"));
+          this.setState({
+            data: Setting.deleteRow(this.state.data, i),
+            pagination: {total: this.state.pagination.total - 1},
+          });
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to delete")}: ${res.msg}`);
+        }
+      })
       .catch(error => {
-        Setting.showMessage("error", `Webhook failed to delete: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 

--- a/web/src/auth/AuthCallback.js
+++ b/web/src/auth/AuthCallback.js
@@ -126,7 +126,7 @@ class AuthCallback extends React.Component {
             // If service was not specified, Casdoor must display a message notifying the client that it has successfully initiated a single sign-on session.
             msg += "Now you can visit apps protected by Casdoor.";
           }
-          Util.showMessage("success", msg);
+          Setting.showMessage("success", msg);
 
           if (casService !== "") {
             const st = res.data;
@@ -135,7 +135,7 @@ class AuthCallback extends React.Component {
             window.location.href = newUrl.toString();
           }
         } else {
-          Util.showMessage("error", `Failed to log in: ${res.msg}`);
+          Setting.showMessage("error", `Failed to log in: ${res.msg}`);
         }
       });
       return;
@@ -148,7 +148,7 @@ class AuthCallback extends React.Component {
         if (res.status === "ok") {
           const responseType = this.getResponseType();
           if (responseType === "login") {
-            Util.showMessage("success", "Logged in successfully");
+            Setting.showMessage("success", "Logged in successfully");
             // Setting.goToLinkSoft(this, "/");
 
             const link = Setting.getFromLink();
@@ -156,7 +156,7 @@ class AuthCallback extends React.Component {
           } else if (responseType === "code") {
             const code = res.data;
             Setting.goToLink(`${oAuthParams.redirectUri}${concatChar}code=${code}&state=${oAuthParams.state}`);
-            // Util.showMessage("success", `Authorization code: ${res.data}`);
+            // Setting.showMessage("success", `Authorization code: ${res.data}`);
           } else if (responseType === "token" || responseType === "id_token") {
             const token = res.data;
             Setting.goToLink(`${oAuthParams.redirectUri}${concatChar}${responseType}=${token}&state=${oAuthParams.state}&token_type=bearer`);

--- a/web/src/auth/ForgetPage.js
+++ b/web/src/auth/ForgetPage.js
@@ -61,10 +61,7 @@ class ForgetPage extends React.Component {
     if (this.state.applicationName !== undefined) {
       this.getApplication();
     } else {
-      Util.showMessage(
-        "error",
-        i18next.t("forget:Unknown forget type: ") + this.state.type
-      );
+      Setting.showMessage("error", i18next.t("forget:Unknown forget type: ") + this.state.type);
     }
   }
 

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -673,7 +673,7 @@ class LoginPage extends React.Component {
           }),
         })
           .then(res => res.json()).then((res) => {
-            if (res.msg === "") {
+            if (res.status === "ok") {
               const responseType = values["type"];
               if (responseType === "code") {
                 this.postCodeLoginAction(res);

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -67,7 +67,7 @@ class LoginPage extends React.Component {
     } else if (this.state.type === "saml") {
       this.getSamlApplication();
     } else {
-      Util.showMessage("error", `Unknown authentication type: ${this.state.type}`);
+      Setting.showMessage("error", `Unknown authentication type: ${this.state.type}`);
     }
   }
 
@@ -92,7 +92,7 @@ class LoginPage extends React.Component {
             application: res.data,
           });
         } else {
-          // Util.showMessage("error", res.msg);
+          // Setting.showMessage("error", res.msg);
           this.setState({
             application: res.data,
             msg: res.msg,
@@ -122,7 +122,7 @@ class LoginPage extends React.Component {
               applicationName: res.data.name,
             });
           } else {
-            Util.showMessage("error", res.msg);
+            Setting.showMessage("error", res.msg);
           }
         });
     }
@@ -269,7 +269,7 @@ class LoginPage extends React.Component {
             // If service was not specified, Casdoor must display a message notifying the client that it has successfully initiated a single sign-on session.
             msg += "Now you can visit apps protected by Casdoor.";
           }
-          Util.showMessage("success", msg);
+          Setting.showMessage("success", msg);
 
           this.setState({openCaptchaModal: false});
 
@@ -281,7 +281,7 @@ class LoginPage extends React.Component {
           }
         } else {
           this.setState({openCaptchaModal: false});
-          Util.showMessage("error", `Failed to log in: ${res.msg}`);
+          Setting.showMessage("error", `Failed to log in: ${res.msg}`);
         }
       });
     } else {
@@ -295,13 +295,13 @@ class LoginPage extends React.Component {
             const responseType = values["type"];
 
             if (responseType === "login") {
-              Util.showMessage("success", "Logged in successfully");
+              Setting.showMessage("success", "Logged in successfully");
 
               const link = Setting.getFromLink();
               Setting.goToLink(link);
             } else if (responseType === "code") {
               this.postCodeLoginAction(res);
-              // Util.showMessage("success", `Authorization code: ${res.data}`);
+              // Setting.showMessage("success", `Authorization code: ${res.data}`);
             } else if (responseType === "token" || responseType === "id_token") {
               const accessToken = res.data;
               Setting.goToLink(`${oAuthParams.redirectUri}#${responseType}=${accessToken}?state=${oAuthParams.state}&token_type=bearer`);
@@ -312,7 +312,7 @@ class LoginPage extends React.Component {
             }
           } else {
             this.setState({openCaptchaModal: false});
-            Util.showMessage("error", `Failed to log in: ${res.msg}`);
+            Setting.showMessage("error", `Failed to log in: ${res.msg}`);
           }
         });
     }
@@ -689,7 +689,7 @@ class LoginPage extends React.Component {
             }
           })
           .catch(error => {
-            Setting.showMessage("error", `${i18next.t("application:Failed to connect to server: ")}${error}`);
+            Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}${error}`);
           });
       });
   }

--- a/web/src/auth/PromptPage.js
+++ b/web/src/auth/PromptPage.js
@@ -217,7 +217,7 @@ class PromptPage extends React.Component {
       })
       .catch(error => {
         if (isFinal) {
-          Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
+          Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
         }
       });
   }

--- a/web/src/auth/PromptPage.js
+++ b/web/src/auth/PromptPage.js
@@ -203,9 +203,9 @@ class PromptPage extends React.Component {
     const user = Setting.deepCopy(this.state.user);
     UserBackend.updateUser(this.state.user.owner, this.state.user.name, user)
       .then((res) => {
-        if (res.msg === "") {
+        if (res.status === "ok") {
           if (isFinal) {
-            Setting.showMessage("success", "Successfully saved");
+            Setting.showMessage("success", i18next.t("general:Successfully saved"));
 
             this.logout();
           }
@@ -217,7 +217,7 @@ class PromptPage extends React.Component {
       })
       .catch(error => {
         if (isFinal) {
-          Setting.showMessage("error", `Failed to connect to server: ${error}`);
+          Setting.showMessage("error", i18next.t("general:Failed to connect to server") + error);
         }
       });
   }

--- a/web/src/auth/ResultPage.js
+++ b/web/src/auth/ResultPage.js
@@ -16,7 +16,6 @@ import React from "react";
 import {Button, Result} from "antd";
 import i18next from "i18next";
 import {authConfig} from "./Auth";
-import * as Util from "./Util";
 import * as ApplicationBackend from "../backend/ApplicationBackend";
 import * as Setting from "../Setting";
 
@@ -34,7 +33,7 @@ class ResultPage extends React.Component {
     if (this.state.applicationName !== undefined) {
       this.getApplication();
     } else {
-      Util.showMessage("error", `Unknown application name: ${this.state.applicationName}`);
+      Setting.showMessage("error", `Unknown application name: ${this.state.applicationName}`);
     }
   }
 

--- a/web/src/auth/SamlCallback.js
+++ b/web/src/auth/SamlCallback.js
@@ -79,7 +79,7 @@ class SamlCallback extends React.Component {
         if (res.status === "ok") {
           const responseType = this.getResponseType(redirectUri);
           if (responseType === "login") {
-            Util.showMessage("success", "Logged in successfully");
+            Setting.showMessage("success", "Logged in successfully");
             Setting.goToLink("/");
           } else if (responseType === "code") {
             const code = res.data;

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -94,7 +94,7 @@ class SignupPage extends React.Component {
     if (applicationName !== undefined) {
       this.getApplication(applicationName);
     } else {
-      Util.showMessage("error", `Unknown application name: ${applicationName}`);
+      Setting.showMessage("error", `Unknown application name: ${applicationName}`);
     }
   }
 

--- a/web/src/auth/Util.js
+++ b/web/src/auth/Util.js
@@ -13,18 +13,10 @@
 // limitations under the License.
 
 import React from "react";
-import {Alert, Button, Result, message} from "antd";
+import {Alert, Button, Result} from "antd";
 import {getWechatMessageEvent} from "./AuthBackend";
 import * as Setting from "../Setting";
 import * as Provider from "./Provider";
-
-export function showMessage(type, text) {
-  if (type === "success") {
-    message.success(text);
-  } else if (type === "error") {
-    message.error(text);
-  }
-}
 
 export function renderMessage(msg) {
   if (msg !== null) {

--- a/web/src/common/PoliciyTable.js
+++ b/web/src/common/PoliciyTable.js
@@ -90,16 +90,15 @@ class PolicyTable extends React.Component {
     this.setState({loading: true});
     AdapterBackend.syncPolicies(this.props.owner, this.props.name)
       .then((res) => {
-        if (res.status !== "error") {
-          this.setState({loading: false, policyLists: res});
+        if (res.status === "ok") {
+          this.setState({policyLists: res});
         } else {
-          this.setState({loading: false});
-          Setting.showMessage("error", `Adapter failed to get policies, ${res.msg}`);
+          Setting.showMessage("error", i18next.t("adapter:Failed to sync policies: ") + res.msg);
         }
+        this.setState({loading: false});
       })
       .catch(error => {
-        this.setState({loading: false});
-        Setting.showMessage("error", `Adapter failed to get policies, ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Failed to connect to server")}: ${error}`);
       });
   }
 
@@ -107,9 +106,9 @@ class PolicyTable extends React.Component {
     AdapterBackend.UpdatePolicy(this.props.owner, this.props.name, [this.state.oldPolicy, table[i]]).then(res => {
       if (res.status === "ok") {
         this.setState({editingIndex: "", oldPolicy: ""});
-        Setting.showMessage("success", i18next.t("adapter:Update policy successfully"));
+        Setting.showMessage("success", i18next.t("general:Successfully saved"));
       } else {
-        Setting.showMessage("error", i18next.t("adapter:Update policy failed") + res.msg);
+        Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
       }
     });
   }
@@ -119,12 +118,12 @@ class PolicyTable extends React.Component {
       if (res.status === "ok") {
         this.setState({editingIndex: "", oldPolicy: "", add: false});
         if (res.data !== "Affected") {
-          Setting.showMessage("info", i18next.t("adapter:Repeated policy"));
+          Setting.showMessage("info", i18next.t("adapter:Repeated policy rules"));
         } else {
-          Setting.showMessage("success", i18next.t("adapter:Add policy successfully"));
+          Setting.showMessage("success", i18next.t("general:Successfully added"));
         }
       } else {
-        Setting.showMessage("error", i18next.t("adapter:Add policy failed") + res.msg);
+        Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
       }
     });
   }
@@ -134,9 +133,9 @@ class PolicyTable extends React.Component {
       if (res.status === "ok") {
         table = Setting.deleteRow(table, i);
         this.updateTable(table);
-        Setting.showMessage("success", i18next.t("adapter:Delete policy successfully"));
+        Setting.showMessage("success", i18next.t("general:Successfully deleted"));
       } else {
-        Setting.showMessage("error", i18next.t("adapter:Delete policy failed, {{error}}", {error: res.msg}));
+        Setting.showMessage("error", i18next.t("general:Failed to delete"));
       }
     });
   }

--- a/web/src/common/PoliciyTable.js
+++ b/web/src/common/PoliciyTable.js
@@ -109,7 +109,7 @@ class PolicyTable extends React.Component {
         this.setState({editingIndex: "", oldPolicy: ""});
         Setting.showMessage("success", i18next.t("adapter:Update policy successfully"));
       } else {
-        Setting.showMessage("error", i18next.t(`adapter:Update policy failed, ${res.msg}`));
+        Setting.showMessage("error", i18next.t("adapter:Update policy failed") + res.msg);
       }
     });
   }
@@ -124,7 +124,7 @@ class PolicyTable extends React.Component {
           Setting.showMessage("success", i18next.t("adapter:Add policy successfully"));
         }
       } else {
-        Setting.showMessage("error", i18next.t(`adapter:Add policy failed, ${res.msg}`));
+        Setting.showMessage("error", i18next.t("adapter:Add policy failed") + res.msg);
       }
     });
   }
@@ -136,7 +136,7 @@ class PolicyTable extends React.Component {
         this.updateTable(table);
         Setting.showMessage("success", i18next.t("adapter:Delete policy successfully"));
       } else {
-        Setting.showMessage("error", i18next.t(`adapter:Delete policy failed, ${res.msg}`));
+        Setting.showMessage("error", i18next.t("adapter:Delete policy failed, {{error}}", {error: res.msg}));
       }
     });
   }

--- a/web/src/i18n.js
+++ b/web/src/i18n.js
@@ -89,7 +89,7 @@ i18n.use(initReactI18next).init({
   keySeparator: false,
 
   interpolation: {
-    escapeValue: false,
+    escapeValue: true,
   },
   // debug: true,
   saveMissing: true,

--- a/web/src/locales/de/data.json
+++ b/web/src/locales/de/data.json
@@ -6,14 +6,17 @@
     "Sign Up": "Registrieren"
   },
   "adapter": {
+    "Add policy failed": "Add policy failed",
     "Add policy successfully": "Add policy successfully",
     "Delete policy successfully": "Delete policy successfully",
     "Edit Adapter": "Edit Adapter",
+    "Failed to add the adapter": "Failed to add the adapter",
     "New Adapter": "New Adapter",
     "Policies": "Policies",
     "Policies - Tooltip": "Policies - Tooltip",
     "Repeated policy": "Repeated policy",
     "Sync": "Sync",
+    "Update policy failed": "Update policy failed",
     "Update policy successfully": "Update policy successfully"
   },
   "application": {
@@ -167,6 +170,7 @@
     "Edit": "Bearbeiten",
     "Email": "E-Mail",
     "Email - Tooltip": "email",
+    "Failed to connect to server": "Failed to connect to server",
     "Favicon": "Favicon",
     "Favicon - Tooltip": "Application icon",
     "First name": "First name",
@@ -237,6 +241,7 @@
     "Sorry, you do not have permission to access this page.": "Sorry, you do not have permission to access this page.",
     "State": "State",
     "State - Tooltip": "State - Tooltip",
+    "Successfully saved": "Successfully saved",
     "Swagger": "Swagger",
     "Sync": "Sync",
     "Syncers": "Syncers",

--- a/web/src/locales/de/data.json
+++ b/web/src/locales/de/data.json
@@ -6,18 +6,13 @@
     "Sign Up": "Registrieren"
   },
   "adapter": {
-    "Add policy failed": "Add policy failed",
-    "Add policy successfully": "Add policy successfully",
-    "Delete policy successfully": "Delete policy successfully",
     "Edit Adapter": "Edit Adapter",
-    "Failed to add the adapter": "Failed to add the adapter",
+    "Failed to sync policies: ": "Failed to sync policies: ",
     "New Adapter": "New Adapter",
     "Policies": "Policies",
     "Policies - Tooltip": "Policies - Tooltip",
-    "Repeated policy": "Repeated policy",
-    "Sync": "Sync",
-    "Update policy failed": "Update policy failed",
-    "Update policy successfully": "Update policy successfully"
+    "Repeated policy rules": "Repeated policy rules",
+    "Sync": "Sync"
   },
   "application": {
     "Always": "Always",
@@ -41,7 +36,6 @@
     "Enable signin session - Tooltip": "Aktiviere Anmeldesession - Tooltip",
     "Enable signup": "Anmeldung aktivieren",
     "Enable signup - Tooltip": "Whether to allow users to sign up",
-    "Failed to connect to server": "Failed to connect to server",
     "File uploaded successfully": "Datei erfolgreich hochgeladen",
     "Form CSS": "Form CSS",
     "Form CSS - Edit": "Form CSS - Edit",
@@ -131,7 +125,7 @@
     "Please input your username!": "Bitte geben Sie Ihren Benutzernamen ein!",
     "Reset": "Reset",
     "Retrieve password": "Passwort abrufen",
-    "Unknown forget type": "Unknown forget type",
+    "Unknown forget type: ": "Unknown forget type: ",
     "Verify": "Überprüfen"
   },
   "general": {
@@ -170,7 +164,10 @@
     "Edit": "Bearbeiten",
     "Email": "E-Mail",
     "Email - Tooltip": "email",
+    "Failed to add": "Failed to add",
     "Failed to connect to server": "Failed to connect to server",
+    "Failed to delete": "Failed to delete",
+    "Failed to save": "Failed to save",
     "Favicon": "Favicon",
     "Favicon - Tooltip": "Application icon",
     "First name": "First name",
@@ -241,6 +238,8 @@
     "Sorry, you do not have permission to access this page.": "Sorry, you do not have permission to access this page.",
     "State": "State",
     "State - Tooltip": "State - Tooltip",
+    "Successfully added": "Successfully added",
+    "Successfully deleted": "Successfully deleted",
     "Successfully saved": "Successfully saved",
     "Swagger": "Swagger",
     "Sync": "Sync",

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -6,14 +6,17 @@
     "Sign Up": "Sign Up"
   },
   "adapter": {
+    "Add policy failed": "Add policy failed",
     "Add policy successfully": "Add policy successfully",
     "Delete policy successfully": "Delete policy successfully",
     "Edit Adapter": "Edit Adapter",
+    "Failed to add the adapter": "Failed to add the adapter",
     "New Adapter": "New Adapter",
     "Policies": "Policies",
     "Policies - Tooltip": "Policies - Tooltip",
     "Repeated policy": "Repeated policy",
     "Sync": "Sync",
+    "Update policy failed": "Update policy failed",
     "Update policy successfully": "Update policy successfully"
   },
   "application": {
@@ -167,6 +170,7 @@
     "Edit": "Edit",
     "Email": "Email",
     "Email - Tooltip": "Email - Tooltip",
+    "Failed to connect to server": "Failed to connect to server",
     "Favicon": "Favicon",
     "Favicon - Tooltip": "Favicon - Tooltip",
     "First name": "First name",
@@ -237,6 +241,7 @@
     "Sorry, you do not have permission to access this page.": "Sorry, you do not have permission to access this page.",
     "State": "State",
     "State - Tooltip": "State - Tooltip",
+    "Successfully saved": "Successfully saved",
     "Swagger": "Swagger",
     "Sync": "Sync",
     "Syncers": "Syncers",

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -6,18 +6,13 @@
     "Sign Up": "Sign Up"
   },
   "adapter": {
-    "Add policy failed": "Add policy failed",
-    "Add policy successfully": "Add policy successfully",
-    "Delete policy successfully": "Delete policy successfully",
     "Edit Adapter": "Edit Adapter",
-    "Failed to add the adapter": "Failed to add the adapter",
+    "Failed to sync policies: ": "Failed to sync policies: ",
     "New Adapter": "New Adapter",
     "Policies": "Policies",
     "Policies - Tooltip": "Policies - Tooltip",
-    "Repeated policy": "Repeated policy",
-    "Sync": "Sync",
-    "Update policy failed": "Update policy failed",
-    "Update policy successfully": "Update policy successfully"
+    "Repeated policy rules": "Repeated policy rules",
+    "Sync": "Sync"
   },
   "application": {
     "Always": "Always",
@@ -41,7 +36,6 @@
     "Enable signin session - Tooltip": "Enable signin session - Tooltip",
     "Enable signup": "Enable signup",
     "Enable signup - Tooltip": "Enable signup - Tooltip",
-    "Failed to connect to server": "Failed to connect to server",
     "File uploaded successfully": "File uploaded successfully",
     "Form CSS": "Form CSS",
     "Form CSS - Edit": "Form CSS - Edit",
@@ -131,7 +125,7 @@
     "Please input your username!": "Please input your username!",
     "Reset": "Reset",
     "Retrieve password": "Retrieve password",
-    "Unknown forget type": "Unknown forget type",
+    "Unknown forget type: ": "Unknown forget type: ",
     "Verify": "Verify"
   },
   "general": {
@@ -170,7 +164,10 @@
     "Edit": "Edit",
     "Email": "Email",
     "Email - Tooltip": "Email - Tooltip",
+    "Failed to add": "Failed to add",
     "Failed to connect to server": "Failed to connect to server",
+    "Failed to delete": "Failed to delete",
+    "Failed to save": "Failed to save",
     "Favicon": "Favicon",
     "Favicon - Tooltip": "Favicon - Tooltip",
     "First name": "First name",
@@ -241,6 +238,8 @@
     "Sorry, you do not have permission to access this page.": "Sorry, you do not have permission to access this page.",
     "State": "State",
     "State - Tooltip": "State - Tooltip",
+    "Successfully added": "Successfully added",
+    "Successfully deleted": "Successfully deleted",
     "Successfully saved": "Successfully saved",
     "Swagger": "Swagger",
     "Sync": "Sync",

--- a/web/src/locales/fr/data.json
+++ b/web/src/locales/fr/data.json
@@ -6,14 +6,17 @@
     "Sign Up": "S'inscrire"
   },
   "adapter": {
+    "Add policy failed": "Add policy failed",
     "Add policy successfully": "Add policy successfully",
     "Delete policy successfully": "Delete policy successfully",
     "Edit Adapter": "Edit Adapter",
+    "Failed to add the adapter": "Failed to add the adapter",
     "New Adapter": "New Adapter",
     "Policies": "Policies",
     "Policies - Tooltip": "Policies - Tooltip",
     "Repeated policy": "Repeated policy",
     "Sync": "Sync",
+    "Update policy failed": "Update policy failed",
     "Update policy successfully": "Update policy successfully"
   },
   "application": {
@@ -167,6 +170,7 @@
     "Edit": "Editer",
     "Email": "Courriel",
     "Email - Tooltip": "email",
+    "Failed to connect to server": "Failed to connect to server",
     "Favicon": "Favicon",
     "Favicon - Tooltip": "Application icon",
     "First name": "First name",
@@ -237,6 +241,7 @@
     "Sorry, you do not have permission to access this page.": "Désolé, vous n'avez pas la permission d'accéder à cette page.",
     "State": "State",
     "State - Tooltip": "State - Tooltip",
+    "Successfully saved": "Successfully saved",
     "Swagger": "Swagger",
     "Sync": "Sync",
     "Syncers": "Synchronisateurs",

--- a/web/src/locales/fr/data.json
+++ b/web/src/locales/fr/data.json
@@ -6,18 +6,13 @@
     "Sign Up": "S'inscrire"
   },
   "adapter": {
-    "Add policy failed": "Add policy failed",
-    "Add policy successfully": "Add policy successfully",
-    "Delete policy successfully": "Delete policy successfully",
     "Edit Adapter": "Edit Adapter",
-    "Failed to add the adapter": "Failed to add the adapter",
+    "Failed to sync policies: ": "Failed to sync policies: ",
     "New Adapter": "New Adapter",
     "Policies": "Policies",
     "Policies - Tooltip": "Policies - Tooltip",
-    "Repeated policy": "Repeated policy",
-    "Sync": "Sync",
-    "Update policy failed": "Update policy failed",
-    "Update policy successfully": "Update policy successfully"
+    "Repeated policy rules": "Repeated policy rules",
+    "Sync": "Sync"
   },
   "application": {
     "Always": "Always",
@@ -41,7 +36,6 @@
     "Enable signin session - Tooltip": "Activer la session de connexion - infobulle",
     "Enable signup": "Activer l'inscription",
     "Enable signup - Tooltip": "Whether to allow users to sign up",
-    "Failed to connect to server": "Failed to connect to server",
     "File uploaded successfully": "Fichier téléchargé avec succès",
     "Form CSS": "Form CSS",
     "Form CSS - Edit": "Form CSS - Edit",
@@ -131,7 +125,7 @@
     "Please input your username!": "Veuillez entrer votre nom d'utilisateur !",
     "Reset": "Reset",
     "Retrieve password": "Récupérer le mot de passe",
-    "Unknown forget type": "Unknown forget type",
+    "Unknown forget type: ": "Unknown forget type: ",
     "Verify": "Vérifier"
   },
   "general": {
@@ -170,7 +164,10 @@
     "Edit": "Editer",
     "Email": "Courriel",
     "Email - Tooltip": "email",
+    "Failed to add": "Failed to add",
     "Failed to connect to server": "Failed to connect to server",
+    "Failed to delete": "Failed to delete",
+    "Failed to save": "Failed to save",
     "Favicon": "Favicon",
     "Favicon - Tooltip": "Application icon",
     "First name": "First name",
@@ -241,6 +238,8 @@
     "Sorry, you do not have permission to access this page.": "Désolé, vous n'avez pas la permission d'accéder à cette page.",
     "State": "State",
     "State - Tooltip": "State - Tooltip",
+    "Successfully added": "Successfully added",
+    "Successfully deleted": "Successfully deleted",
     "Successfully saved": "Successfully saved",
     "Swagger": "Swagger",
     "Sync": "Sync",

--- a/web/src/locales/ja/data.json
+++ b/web/src/locales/ja/data.json
@@ -6,18 +6,13 @@
     "Sign Up": "新規登録"
   },
   "adapter": {
-    "Add policy failed": "Add policy failed",
-    "Add policy successfully": "Add policy successfully",
-    "Delete policy successfully": "Delete policy successfully",
     "Edit Adapter": "Edit Adapter",
-    "Failed to add the adapter": "Failed to add the adapter",
+    "Failed to sync policies: ": "Failed to sync policies: ",
     "New Adapter": "New Adapter",
     "Policies": "Policies",
     "Policies - Tooltip": "Policies - Tooltip",
-    "Repeated policy": "Repeated policy",
-    "Sync": "Sync",
-    "Update policy failed": "Update policy failed",
-    "Update policy successfully": "Update policy successfully"
+    "Repeated policy rules": "Repeated policy rules",
+    "Sync": "Sync"
   },
   "application": {
     "Always": "Always",
@@ -41,7 +36,6 @@
     "Enable signin session - Tooltip": "Enable signin session - Tooltip",
     "Enable signup": "サインアップを有効にする",
     "Enable signup - Tooltip": "Whether to allow users to sign up",
-    "Failed to connect to server": "Failed to connect to server",
     "File uploaded successfully": "ファイルが正常にアップロードされました",
     "Form CSS": "Form CSS",
     "Form CSS - Edit": "Form CSS - Edit",
@@ -131,7 +125,7 @@
     "Please input your username!": "ユーザー名を入力してください！",
     "Reset": "Reset",
     "Retrieve password": "パスワードの取得",
-    "Unknown forget type": "Unknown forget type",
+    "Unknown forget type: ": "Unknown forget type: ",
     "Verify": "確認する"
   },
   "general": {
@@ -170,7 +164,10 @@
     "Edit": "編集",
     "Email": "Eメールアドレス",
     "Email - Tooltip": "email",
+    "Failed to add": "Failed to add",
     "Failed to connect to server": "Failed to connect to server",
+    "Failed to delete": "Failed to delete",
+    "Failed to save": "Failed to save",
     "Favicon": "Favicon",
     "Favicon - Tooltip": "Application icon",
     "First name": "First name",
@@ -241,6 +238,8 @@
     "Sorry, you do not have permission to access this page.": "申し訳ありませんが、このページにアクセスする権限がありません。",
     "State": "State",
     "State - Tooltip": "State - Tooltip",
+    "Successfully added": "Successfully added",
+    "Successfully deleted": "Successfully deleted",
     "Successfully saved": "Successfully saved",
     "Swagger": "Swagger",
     "Sync": "Sync",

--- a/web/src/locales/ja/data.json
+++ b/web/src/locales/ja/data.json
@@ -6,14 +6,17 @@
     "Sign Up": "新規登録"
   },
   "adapter": {
+    "Add policy failed": "Add policy failed",
     "Add policy successfully": "Add policy successfully",
     "Delete policy successfully": "Delete policy successfully",
     "Edit Adapter": "Edit Adapter",
+    "Failed to add the adapter": "Failed to add the adapter",
     "New Adapter": "New Adapter",
     "Policies": "Policies",
     "Policies - Tooltip": "Policies - Tooltip",
     "Repeated policy": "Repeated policy",
     "Sync": "Sync",
+    "Update policy failed": "Update policy failed",
     "Update policy successfully": "Update policy successfully"
   },
   "application": {
@@ -167,6 +170,7 @@
     "Edit": "編集",
     "Email": "Eメールアドレス",
     "Email - Tooltip": "email",
+    "Failed to connect to server": "Failed to connect to server",
     "Favicon": "Favicon",
     "Favicon - Tooltip": "Application icon",
     "First name": "First name",
@@ -237,6 +241,7 @@
     "Sorry, you do not have permission to access this page.": "申し訳ありませんが、このページにアクセスする権限がありません。",
     "State": "State",
     "State - Tooltip": "State - Tooltip",
+    "Successfully saved": "Successfully saved",
     "Swagger": "Swagger",
     "Sync": "Sync",
     "Syncers": "Syncers",

--- a/web/src/locales/ko/data.json
+++ b/web/src/locales/ko/data.json
@@ -6,18 +6,13 @@
     "Sign Up": "Sign Up"
   },
   "adapter": {
-    "Add policy failed": "Add policy failed",
-    "Add policy successfully": "Add policy successfully",
-    "Delete policy successfully": "Delete policy successfully",
     "Edit Adapter": "Edit Adapter",
-    "Failed to add the adapter": "Failed to add the adapter",
+    "Failed to sync policies: ": "Failed to sync policies: ",
     "New Adapter": "New Adapter",
     "Policies": "Policies",
     "Policies - Tooltip": "Policies - Tooltip",
-    "Repeated policy": "Repeated policy",
-    "Sync": "Sync",
-    "Update policy failed": "Update policy failed",
-    "Update policy successfully": "Update policy successfully"
+    "Repeated policy rules": "Repeated policy rules",
+    "Sync": "Sync"
   },
   "application": {
     "Always": "Always",
@@ -41,7 +36,6 @@
     "Enable signin session - Tooltip": "Enable signin session - Tooltip",
     "Enable signup": "Enable signup",
     "Enable signup - Tooltip": "Whether to allow users to sign up",
-    "Failed to connect to server": "Failed to connect to server",
     "File uploaded successfully": "File uploaded successfully",
     "Form CSS": "Form CSS",
     "Form CSS - Edit": "Form CSS - Edit",
@@ -131,7 +125,7 @@
     "Please input your username!": "Please input your username!",
     "Reset": "Reset",
     "Retrieve password": "Retrieve password",
-    "Unknown forget type": "Unknown forget type",
+    "Unknown forget type: ": "Unknown forget type: ",
     "Verify": "Verify"
   },
   "general": {
@@ -170,7 +164,10 @@
     "Edit": "Edit",
     "Email": "Email",
     "Email - Tooltip": "email",
+    "Failed to add": "Failed to add",
     "Failed to connect to server": "Failed to connect to server",
+    "Failed to delete": "Failed to delete",
+    "Failed to save": "Failed to save",
     "Favicon": "Favicon",
     "Favicon - Tooltip": "Application icon",
     "First name": "First name",
@@ -241,6 +238,8 @@
     "Sorry, you do not have permission to access this page.": "Sorry, you do not have permission to access this page.",
     "State": "State",
     "State - Tooltip": "State - Tooltip",
+    "Successfully added": "Successfully added",
+    "Successfully deleted": "Successfully deleted",
     "Successfully saved": "Successfully saved",
     "Swagger": "Swagger",
     "Sync": "Sync",

--- a/web/src/locales/ko/data.json
+++ b/web/src/locales/ko/data.json
@@ -6,14 +6,17 @@
     "Sign Up": "Sign Up"
   },
   "adapter": {
+    "Add policy failed": "Add policy failed",
     "Add policy successfully": "Add policy successfully",
     "Delete policy successfully": "Delete policy successfully",
     "Edit Adapter": "Edit Adapter",
+    "Failed to add the adapter": "Failed to add the adapter",
     "New Adapter": "New Adapter",
     "Policies": "Policies",
     "Policies - Tooltip": "Policies - Tooltip",
     "Repeated policy": "Repeated policy",
     "Sync": "Sync",
+    "Update policy failed": "Update policy failed",
     "Update policy successfully": "Update policy successfully"
   },
   "application": {
@@ -167,6 +170,7 @@
     "Edit": "Edit",
     "Email": "Email",
     "Email - Tooltip": "email",
+    "Failed to connect to server": "Failed to connect to server",
     "Favicon": "Favicon",
     "Favicon - Tooltip": "Application icon",
     "First name": "First name",
@@ -237,6 +241,7 @@
     "Sorry, you do not have permission to access this page.": "Sorry, you do not have permission to access this page.",
     "State": "State",
     "State - Tooltip": "State - Tooltip",
+    "Successfully saved": "Successfully saved",
     "Swagger": "Swagger",
     "Sync": "Sync",
     "Syncers": "Syncers",

--- a/web/src/locales/ru/data.json
+++ b/web/src/locales/ru/data.json
@@ -6,18 +6,13 @@
     "Sign Up": "Регистрация"
   },
   "adapter": {
-    "Add policy failed": "Add policy failed",
-    "Add policy successfully": "Add policy successfully",
-    "Delete policy successfully": "Delete policy successfully",
     "Edit Adapter": "Edit Adapter",
-    "Failed to add the adapter": "Failed to add the adapter",
+    "Failed to sync policies: ": "Failed to sync policies: ",
     "New Adapter": "New Adapter",
     "Policies": "Policies",
     "Policies - Tooltip": "Policies - Tooltip",
-    "Repeated policy": "Repeated policy",
-    "Sync": "Sync",
-    "Update policy failed": "Update policy failed",
-    "Update policy successfully": "Update policy successfully"
+    "Repeated policy rules": "Repeated policy rules",
+    "Sync": "Sync"
   },
   "application": {
     "Always": "Always",
@@ -41,7 +36,6 @@
     "Enable signin session - Tooltip": "Включить сеанс входа - Подсказка",
     "Enable signup": "Включить регистрацию",
     "Enable signup - Tooltip": "Whether to allow users to sign up",
-    "Failed to connect to server": "Failed to connect to server",
     "File uploaded successfully": "Файл успешно загружен",
     "Form CSS": "Form CSS",
     "Form CSS - Edit": "Form CSS - Edit",
@@ -131,7 +125,7 @@
     "Please input your username!": "Пожалуйста, введите ваше имя пользователя!",
     "Reset": "Сбросить",
     "Retrieve password": "Получить пароль",
-    "Unknown forget type": "Неизвестный тип",
+    "Unknown forget type: ": "Unknown forget type: ",
     "Verify": "Подтвердить"
   },
   "general": {
@@ -170,7 +164,10 @@
     "Edit": "Редактирование",
     "Email": "Почта",
     "Email - Tooltip": "email",
+    "Failed to add": "Failed to add",
     "Failed to connect to server": "Failed to connect to server",
+    "Failed to delete": "Failed to delete",
+    "Failed to save": "Failed to save",
     "Favicon": "Иконка",
     "Favicon - Tooltip": "Application icon",
     "First name": "Имя",
@@ -241,6 +238,8 @@
     "Sorry, you do not have permission to access this page.": "Извините, вы не имеете права доступа к этой странице.",
     "State": "State",
     "State - Tooltip": "State - Tooltip",
+    "Successfully added": "Successfully added",
+    "Successfully deleted": "Successfully deleted",
     "Successfully saved": "Successfully saved",
     "Swagger": "Swagger",
     "Sync": "Sync",

--- a/web/src/locales/ru/data.json
+++ b/web/src/locales/ru/data.json
@@ -6,14 +6,17 @@
     "Sign Up": "Регистрация"
   },
   "adapter": {
+    "Add policy failed": "Add policy failed",
     "Add policy successfully": "Add policy successfully",
     "Delete policy successfully": "Delete policy successfully",
     "Edit Adapter": "Edit Adapter",
+    "Failed to add the adapter": "Failed to add the adapter",
     "New Adapter": "New Adapter",
     "Policies": "Policies",
     "Policies - Tooltip": "Policies - Tooltip",
     "Repeated policy": "Repeated policy",
     "Sync": "Sync",
+    "Update policy failed": "Update policy failed",
     "Update policy successfully": "Update policy successfully"
   },
   "application": {
@@ -167,6 +170,7 @@
     "Edit": "Редактирование",
     "Email": "Почта",
     "Email - Tooltip": "email",
+    "Failed to connect to server": "Failed to connect to server",
     "Favicon": "Иконка",
     "Favicon - Tooltip": "Application icon",
     "First name": "Имя",
@@ -237,6 +241,7 @@
     "Sorry, you do not have permission to access this page.": "Извините, вы не имеете права доступа к этой странице.",
     "State": "State",
     "State - Tooltip": "State - Tooltip",
+    "Successfully saved": "Successfully saved",
     "Swagger": "Swagger",
     "Sync": "Sync",
     "Syncers": "Синхронизаторы",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -6,14 +6,17 @@
     "Sign Up": "注册"
   },
   "adapter": {
+    "Add policy failed": "添加策略失败",
     "Add policy successfully": "添加策略成功",
     "Delete policy successfully": "删除策略成功",
     "Edit Adapter": "编辑适配器",
+    "Failed to add the adapter": "添加适配器失败",
     "New Adapter": "添加适配器",
     "Policies": "策略",
     "Policies - Tooltip": "策略",
     "Repeated policy": "策略重复",
     "Sync": "同步",
+    "Update policy failed": "更新策略失败",
     "Update policy successfully": "更新策略成功"
   },
   "application": {
@@ -167,6 +170,7 @@
     "Edit": "编辑",
     "Email": "电子邮箱",
     "Email - Tooltip": "电子邮件：",
+    "Failed to connect to server": "服务器出错",
     "Favicon": "网站图标",
     "Favicon - Tooltip": "网站的Favicon图标",
     "First name": "名字",
@@ -237,6 +241,7 @@
     "Sorry, you do not have permission to access this page.": "抱歉，您无权访问该页面",
     "State": "状态",
     "State - Tooltip": "状态",
+    "Successfully saved": "保存成功",
     "Swagger": "API文档",
     "Sync": "同步",
     "Syncers": "同步器",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -6,18 +6,13 @@
     "Sign Up": "注册"
   },
   "adapter": {
-    "Add policy failed": "添加策略失败",
-    "Add policy successfully": "添加策略成功",
-    "Delete policy successfully": "删除策略成功",
     "Edit Adapter": "编辑适配器",
-    "Failed to add the adapter": "添加适配器失败",
+    "Failed to sync policies: ": "同步策略失败: ",
     "New Adapter": "添加适配器",
     "Policies": "策略",
     "Policies - Tooltip": "策略",
-    "Repeated policy": "策略重复",
-    "Sync": "同步",
-    "Update policy failed": "更新策略失败",
-    "Update policy successfully": "更新策略成功"
+    "Repeated policy rules": "重复的策略",
+    "Sync": "同步"
   },
   "application": {
     "Always": "始终开启",
@@ -41,7 +36,6 @@
     "Enable signin session - Tooltip": "从应用登录Casdoor后，Casdoor是否保持会话",
     "Enable signup": "启用注册",
     "Enable signup - Tooltip": "是否允许用户注册",
-    "Failed to connect to server": "无法连接服务器",
     "File uploaded successfully": "文件上传成功",
     "Form CSS": "表单CSS",
     "Form CSS - Edit": "编辑表单CSS",
@@ -131,7 +125,7 @@
     "Please input your username!": "请输入您的用户名！",
     "Reset": "重置",
     "Retrieve password": "找回密码",
-    "Unknown forget type": "未知的忘记密码类型",
+    "Unknown forget type: ": "未知的忘记密码类型: ",
     "Verify": "验证"
   },
   "general": {
@@ -170,7 +164,10 @@
     "Edit": "编辑",
     "Email": "电子邮箱",
     "Email - Tooltip": "电子邮件：",
-    "Failed to connect to server": "服务器出错",
+    "Failed to add": "添加失败",
+    "Failed to connect to server": "连接服务器失败",
+    "Failed to delete": "删除失败",
+    "Failed to save": "保存失败",
     "Favicon": "网站图标",
     "Favicon - Tooltip": "网站的Favicon图标",
     "First name": "名字",
@@ -241,6 +238,8 @@
     "Sorry, you do not have permission to access this page.": "抱歉，您无权访问该页面",
     "State": "状态",
     "State - Tooltip": "状态",
+    "Successfully added": "添加成功",
+    "Successfully deleted": "删除成功",
     "Successfully saved": "保存成功",
     "Swagger": "API文档",
     "Sync": "同步",


### PR DESCRIPTION
Some place use template expression  \`  \` to translate. But i18 not support it. And the script `generate_test.go` can not generate these string. 

i18 supports [interpolation](https://www.i18next.com/translation-function/interpolation)  to escaping values and mitigate XSS attacks.  I'll try modifying the script `generate_test.go`  to support the function.
