### PR TITLE
feat: fix React incorrect usage to fix issue that verification code must be submitted twice to succeed

### DIFF
--- a/web/src/auth/ForgetPage.js
+++ b/web/src/auth/ForgetPage.js
@@ -99,6 +99,13 @@ class ForgetPage extends React.Component {
         if (res.status === "ok") {
           const phone = res.data.phone;
           const email = res.data.email;
+          const saveFields = () => {
+            if (this.state.isFixed) {
+              forms.step2.setFieldsValue({email: this.state.fixedContent});
+              this.setState({username: this.state.fixedContent});
+            }
+            this.setState({current: 1});
+          };
           this.setState({phone: phone, email: email, username: res.data.name, name: res.data.name});
 
           if (phone !== "" && email === "") {
@@ -113,19 +120,15 @@ class ForgetPage extends React.Component {
 
           switch (res.data2) {
           case "email":
-            this.setState({isFixed: true, fixedContent: email, verifyType: "email"});
+            this.setState({isFixed: true, fixedContent: email, verifyType: "email"}, () => {saveFields();});
             break;
           case "phone":
-            this.setState({isFixed: true, fixedContent: phone, verifyType: "phone"});
+            this.setState({isFixed: true, fixedContent: phone, verifyType: "phone"}, () => {saveFields();});
             break;
           default:
+            saveFields();
             break;
           }
-          if (this.state.isFixed) {
-            forms.step2.setFieldsValue({email: this.state.fixedContent});
-            this.setState({username: this.state.fixedContent});
-          }
-          this.setState({current: 1});
         } else {
           Setting.showMessage("error", i18next.t(`signup:${res.msg}`));
         }
@@ -133,26 +136,28 @@ class ForgetPage extends React.Component {
       break;
     case "step2":
       const oAuthParams = Util.getOAuthGetParameters();
+      const login = () => {
+        AuthBackend.login({
+          application: forms.step2.getFieldValue("application"),
+          organization: forms.step2.getFieldValue("organization"),
+          username: this.state.username,
+          name: this.state.name,
+          code: forms.step2.getFieldValue("emailCode"),
+          phonePrefix: this.state.application?.organizationObj.phonePrefix,
+          type: "login",
+        }, oAuthParams).then(res => {
+          if (res.status === "ok") {
+            this.setState({current: 2, userId: res.data, username: res.data.split("/")[1]});
+          } else {
+            Setting.showMessage("error", i18next.t(`signup:${res.msg}`));
+          }
+        });
+      };
       if (this.state.verifyType === "email") {
-        this.setState({username: this.state.email});
+        this.setState({username: this.state.email}, () => {login();});
       } else if (this.state.verifyType === "phone") {
-        this.setState({username: this.state.phone});
+        this.setState({username: this.state.phone}, () => {login();});
       }
-      AuthBackend.login({
-        application: forms.step2.getFieldValue("application"),
-        organization: forms.step2.getFieldValue("organization"),
-        username: this.state.username,
-        name: this.state.name,
-        code: forms.step2.getFieldValue("emailCode"),
-        phonePrefix: this.state.application?.organizationObj.phonePrefix,
-        type: "login",
-      }, oAuthParams).then(res => {
-        if (res.status === "ok") {
-          this.setState({current: 2, userId: res.data, username: res.data.split("/")[1]});
-        } else {
-          Setting.showMessage("error", i18next.t(`signup:${res.msg}`));
-        }
-      });
       break;
     default:
       break;

--- a/web/src/auth/ForgetPage.js
+++ b/web/src/auth/ForgetPage.js
@@ -35,11 +35,11 @@ class ForgetPage extends React.Component {
       classes: props,
       account: props.account,
       applicationName:
-          props.applicationName !== undefined
-            ? props.applicationName
-            : props.match === undefined
-              ? null
-              : props.match.params.applicationName,
+        props.applicationName !== undefined
+          ? props.applicationName
+          : props.match === undefined
+            ? null
+            : props.match.params.applicationName,
       application: null,
       msg: null,
       userId: "",
@@ -61,10 +61,7 @@ class ForgetPage extends React.Component {
     if (this.state.applicationName !== undefined) {
       this.getApplication();
     } else {
-      Util.showMessage(
-        "error",
-        i18next.t("forget:Unknown forget type: ") + this.state.type
-      );
+      Setting.showMessage("error", i18next.t("forget:Unknown forget type: ") + this.state.type);
     }
   }
 
@@ -102,13 +99,6 @@ class ForgetPage extends React.Component {
         if (res.status === "ok") {
           const phone = res.data.phone;
           const email = res.data.email;
-          const saveFields = () => {
-            if (this.state.isFixed) {
-              forms.step2.setFieldsValue({email: this.state.fixedContent});
-              this.setState({username: this.state.fixedContent});
-              this.setState({current: 1});
-            }
-          };
           this.setState({phone: phone, email: email, username: res.data.name, name: res.data.name});
 
           if (phone !== "" && email === "") {
@@ -123,15 +113,19 @@ class ForgetPage extends React.Component {
 
           switch (res.data2) {
           case "email":
-            this.setState({isFixed: true, fixedContent: email, verifyType: "email"}, () => {saveFields();});
+            this.setState({isFixed: true, fixedContent: email, verifyType: "email"});
             break;
           case "phone":
-            this.setState({isFixed: true, fixedContent: phone, verifyType: "phone"}, () => {saveFields();});
+            this.setState({isFixed: true, fixedContent: phone, verifyType: "phone"});
             break;
           default:
-            saveFields();
             break;
           }
+          if (this.state.isFixed) {
+            forms.step2.setFieldsValue({email: this.state.fixedContent});
+            this.setState({username: this.state.fixedContent});
+          }
+          this.setState({current: 1});
         } else {
           Setting.showMessage("error", i18next.t(`signup:${res.msg}`));
         }

--- a/web/src/auth/ForgetPage.js
+++ b/web/src/auth/ForgetPage.js
@@ -106,6 +106,7 @@ class ForgetPage extends React.Component {
             if (this.state.isFixed) {
               forms.step2.setFieldsValue({email: this.state.fixedContent});
               this.setState({username: this.state.fixedContent});
+              this.setState({current: 1});
             }
           };
           this.setState({phone: phone, email: email, username: res.data.name, name: res.data.name});
@@ -131,7 +132,6 @@ class ForgetPage extends React.Component {
             saveFields();
             break;
           }
-          this.setState({current: 1});
         } else {
           Setting.showMessage("error", i18next.t(`signup:${res.msg}`));
         }

--- a/web/src/auth/ForgetPage.js
+++ b/web/src/auth/ForgetPage.js
@@ -35,11 +35,11 @@ class ForgetPage extends React.Component {
       classes: props,
       account: props.account,
       applicationName:
-        props.applicationName !== undefined
-          ? props.applicationName
-          : props.match === undefined
-            ? null
-            : props.match.params.applicationName,
+          props.applicationName !== undefined
+            ? props.applicationName
+            : props.match === undefined
+              ? null
+              : props.match.params.applicationName,
       application: null,
       msg: null,
       userId: "",
@@ -61,7 +61,10 @@ class ForgetPage extends React.Component {
     if (this.state.applicationName !== undefined) {
       this.getApplication();
     } else {
-      Setting.showMessage("error", i18next.t("forget:Unknown forget type: ") + this.state.type);
+      Util.showMessage(
+        "error",
+        i18next.t("forget:Unknown forget type: ") + this.state.type
+      );
     }
   }
 

--- a/web/src/auth/ForgetPage.js
+++ b/web/src/auth/ForgetPage.js
@@ -102,6 +102,12 @@ class ForgetPage extends React.Component {
         if (res.status === "ok") {
           const phone = res.data.phone;
           const email = res.data.email;
+          const saveFields = () => {
+            if (this.state.isFixed) {
+              forms.step2.setFieldsValue({email: this.state.fixedContent});
+              this.setState({username: this.state.fixedContent});
+            }
+          };
           this.setState({phone: phone, email: email, username: res.data.name, name: res.data.name});
 
           if (phone !== "" && email === "") {
@@ -116,17 +122,14 @@ class ForgetPage extends React.Component {
 
           switch (res.data2) {
           case "email":
-            this.setState({isFixed: true, fixedContent: email, verifyType: "email"});
+            this.setState({isFixed: true, fixedContent: email, verifyType: "email"}, () => {saveFields();});
             break;
           case "phone":
-            this.setState({isFixed: true, fixedContent: phone, verifyType: "phone"});
+            this.setState({isFixed: true, fixedContent: phone, verifyType: "phone"}, () => {saveFields();});
             break;
           default:
+            saveFields();
             break;
-          }
-          if (this.state.isFixed) {
-            forms.step2.setFieldsValue({email: this.state.fixedContent});
-            this.setState({username: this.state.fixedContent});
           }
           this.setState({current: 1});
         } else {


### PR DESCRIPTION
Fix: #1344

Credential sent to backend before the credential has been updated by setState (thus senting the `username` and `name` with the value of `null` to backend at the first time).

![verification code.gif](https://s2.loli.net/2022/12/04/k2BqIjscAuSh6R7.gif)