### PR TITLE
fix: responsive certs page editor

### DIFF
--- a/web/src/CertEditPage.js
+++ b/web/src/CertEditPage.js
@@ -66,7 +66,6 @@ class CertEditPage extends React.Component {
 
   renderCert() {
     const editorWidth = Setting.isMobile() ? 22 : 9;
-
     return (
       <Card size="small" title={
         <div>

--- a/web/src/CertEditPage.js
+++ b/web/src/CertEditPage.js
@@ -65,6 +65,8 @@ class CertEditPage extends React.Component {
   }
 
   renderCert() {
+    const editorWidth = Setting.isMobile() ? 22 : 9;
+
     return (
       <Card size="small" title={
         <div>
@@ -166,7 +168,7 @@ class CertEditPage extends React.Component {
           <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
             {Setting.getLabel(i18next.t("cert:Certificate"), i18next.t("cert:Certificate - Tooltip"))} :
           </Col>
-          <Col span={9} >
+          <Col span={editorWidth} >
             <Button style={{marginRight: "10px", marginBottom: "10px"}} onClick={() => {
               copy(this.state.cert.certificate);
               Setting.showMessage("success", i18next.t("cert:Certificate copied to clipboard successfully"));
@@ -189,7 +191,7 @@ class CertEditPage extends React.Component {
           <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
             {Setting.getLabel(i18next.t("cert:Private key"), i18next.t("cert:Private key - Tooltip"))} :
           </Col>
-          <Col span={9} >
+          <Col span={editorWidth} >
             <Button style={{marginRight: "10px", marginBottom: "10px"}} onClick={() => {
               copy(this.state.cert.privateKey);
               Setting.showMessage("success", i18next.t("cert:Private key copied to clipboard successfully"));


### PR DESCRIPTION
Before

![certs page before](https://s2.loli.net/2022/12/04/WJkAKhdpe9DX3uG.png)

After

![certs page after](https://s2.loli.net/2022/12/04/okyrnjvNLApY3fx.png)