### PR TITLE
feat: check AccessPermission in multiple permissions

### DIFF
--- a/object/check.go
+++ b/object/check.go
@@ -313,8 +313,9 @@ func CheckAccessPermission(userId string, application *Application) (bool, error
 				return true, err
 			}
 			enforcer := getEnforcer(permission)
-			allowed, err = enforcer.Enforce(userId, application.Name, "read")
-			break
+			if allowed, err = enforcer.Enforce(userId, application.Name, "read"); allowed {
+				return allowed, err
+			}
 		}
 	}
 	return allowed, err


### PR DESCRIPTION
`break` in line `317` lead to just check AccessPermission in one permissions.
When `allow` is `true` it should return, when `false` it should continue do `for loop(line 297)` to check in other permissions.