### PR TITLE
feat: fix login with password bug when feature is disabled

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -265,6 +265,10 @@ func (c *ApiController) Login() {
 				c.ResponseError(fmt.Sprintf(c.T("auth:The application: %s does not exist"), form.Application))
 				return
 			}
+			if !application.EnablePassword {
+				c.ResponseError(c.T("auth:The login method: login with password is not enabled for the application"))
+				return
+			}
 
 			if object.CheckToEnableCaptcha(application) {
 				isHuman, err := captcha.VerifyCaptchaByCaptchaType(form.CaptchaType, form.CaptchaToken, form.ClientSecret)

--- a/i18n/locales/de/data.json
+++ b/i18n/locales/de/data.json
@@ -25,6 +25,7 @@
     "The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support": "The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support",
     "The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)": "The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)",
     "The application: %s does not exist": "The application: %s does not exist",
+    "The login method: login with password is not enabled for the application": "The login method: login with password is not enabled for the application",
     "The provider type: %s is not supported": "The provider type: %s is not supported",
     "The provider: %s is not enabled for the application": "The provider: %s is not enabled for the application",
     "The user is forbidden to sign in, please contact the administrator": "The user is forbidden to sign in, please contact the administrator",

--- a/i18n/locales/en/data.json
+++ b/i18n/locales/en/data.json
@@ -25,6 +25,7 @@
     "The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support": "The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support",
     "The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)": "The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)",
     "The application: %s does not exist": "The application: %s does not exist",
+    "The login method: login with password is not enabled for the application": "The login method: login with password is not enabled for the application",
     "The provider type: %s is not supported": "The provider type: %s is not supported",
     "The provider: %s is not enabled for the application": "The provider: %s is not enabled for the application",
     "The user is forbidden to sign in, please contact the administrator": "The user is forbidden to sign in, please contact the administrator",

--- a/i18n/locales/es/data.json
+++ b/i18n/locales/es/data.json
@@ -25,6 +25,7 @@
     "The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support": "The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support",
     "The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)": "The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)",
     "The application: %s does not exist": "The application: %s does not exist",
+    "The login method: login with password is not enabled for the application": "The login method: login with password is not enabled for the application",
     "The provider type: %s is not supported": "The provider type: %s is not supported",
     "The provider: %s is not enabled for the application": "The provider: %s is not enabled for the application",
     "The user is forbidden to sign in, please contact the administrator": "The user is forbidden to sign in, please contact the administrator",

--- a/i18n/locales/fr/data.json
+++ b/i18n/locales/fr/data.json
@@ -25,6 +25,7 @@
     "The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support": "The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support",
     "The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)": "The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)",
     "The application: %s does not exist": "The application: %s does not exist",
+    "The login method: login with password is not enabled for the application": "The login method: login with password is not enabled for the application",
     "The provider type: %s is not supported": "The provider type: %s is not supported",
     "The provider: %s is not enabled for the application": "The provider: %s is not enabled for the application",
     "The user is forbidden to sign in, please contact the administrator": "The user is forbidden to sign in, please contact the administrator",

--- a/i18n/locales/ja/data.json
+++ b/i18n/locales/ja/data.json
@@ -25,6 +25,7 @@
     "The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support": "The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support",
     "The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)": "The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)",
     "The application: %s does not exist": "The application: %s does not exist",
+    "The login method: login with password is not enabled for the application": "The login method: login with password is not enabled for the application",
     "The provider type: %s is not supported": "The provider type: %s is not supported",
     "The provider: %s is not enabled for the application": "The provider: %s is not enabled for the application",
     "The user is forbidden to sign in, please contact the administrator": "The user is forbidden to sign in, please contact the administrator",

--- a/i18n/locales/ko/data.json
+++ b/i18n/locales/ko/data.json
@@ -25,6 +25,7 @@
     "The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support": "The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support",
     "The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)": "The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)",
     "The application: %s does not exist": "The application: %s does not exist",
+    "The login method: login with password is not enabled for the application": "The login method: login with password is not enabled for the application",
     "The provider type: %s is not supported": "The provider type: %s is not supported",
     "The provider: %s is not enabled for the application": "The provider: %s is not enabled for the application",
     "The user is forbidden to sign in, please contact the administrator": "The user is forbidden to sign in, please contact the administrator",

--- a/i18n/locales/ru/data.json
+++ b/i18n/locales/ru/data.json
@@ -25,6 +25,7 @@
     "The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support": "The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support",
     "The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)": "The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)",
     "The application: %s does not exist": "The application: %s does not exist",
+    "The login method: login with password is not enabled for the application": "The login method: login with password is not enabled for the application",
     "The provider type: %s is not supported": "The provider type: %s is not supported",
     "The provider: %s is not enabled for the application": "The provider: %s is not enabled for the application",
     "The user is forbidden to sign in, please contact the administrator": "The user is forbidden to sign in, please contact the administrator",

--- a/i18n/locales/zh/data.json
+++ b/i18n/locales/zh/data.json
@@ -25,6 +25,7 @@
     "The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support": "提供商账户: %s 与用户名: %s (%s) 不存在且 不允许注册新账户, 请联系IT支持",
     "The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)": "提供商账户: %s 与用户名: %s (%s) 已经与其他账户绑定: %s (%s)",
     "The application: %s does not exist": "应用 %s 不存在",
+    "The login method: login with password is not enabled for the application": "The login method: login with password is not enabled for the application",
     "The provider type: %s is not supported": "不支持该类型的提供商: %s",
     "The provider: %s is not enabled for the application": "提供商: %s 未被启用",
     "The user is forbidden to sign in, please contact the administrator": "该用户被禁止登陆，请联系管理员",


### PR DESCRIPTION
Prevent users from logging in with a password through the API when the login with password feature is disabled. 
This enhances security on the backend server.