### PR TITLE
fix: convert line endings to LF on checkout for all envs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
 *.go linguist-detectable=true
 *.js linguist-detectable=false
-
 # Declare files that will always have LF line endings on checkout.
 # Git will always convert line endings to LF on checkout. You should use this for files that must keep LF endings, even on Windows.
 *.sh text eol=lf


### PR DESCRIPTION
Fix #1447 

The fix is similar to https://github.com/kubernetes-up-and-running/kuard/issues/30

Fix line endings for windows users. Do not allow user core.autocrlf to change the line endings for *.sh files. This will fix issues building the container by removing the line endings on the shebang of the copied bash files.

References:
https://github.com/kubernetes-up-and-running/kuard/issues/30
https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#per-repository-settings