### PR TITLE
feat: add terms of use in signin page

### DIFF
--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -509,6 +509,14 @@ export function isMobile() {
   return isMobileDevice;
 }
 
+export function getTermsOfUseContent(url, setTermsOfUseContent) {
+  fetch(url, {
+    method: "GET",
+  }).then(r => {
+    r.text().then(setTermsOfUseContent);
+  });
+}
+
 export function getFormattedDate(date) {
   if (date === undefined) {
     return null;

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -14,7 +14,7 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Tag, Tooltip, message, theme} from "antd";
+import {Checkbox, Form, Modal, Tag, Tooltip, message, theme} from "antd";
 import {QuestionCircleTwoTone} from "@ant-design/icons";
 import {isMobile as isMobileDevice} from "react-device-detect";
 import "./i18n";
@@ -515,6 +515,61 @@ export function getTermsOfUseContent(url, setTermsOfUseContent) {
   }).then(r => {
     r.text().then(setTermsOfUseContent);
   });
+}
+
+export function isAgreementRequired(application) {
+  if (application) {
+    const agreementItem = application.signupItems.find(item => item.name === "Agreement");
+    if (agreementItem.rule === "None" || !agreementItem.rule) {
+      return false;
+    }
+    if (agreementItem && agreementItem.required) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function renderAgreement(required, onClick, noStyle, layout) {
+  return (
+    <Form.Item
+      name="agreement"
+      key="agreement"
+      valuePropName="checked"
+      rules={[
+        {
+          required: required,
+          message: i18next.t("signup:Please accept the agreement!"),
+        },
+      ]}
+      {...layout}
+      noStyle={noStyle}
+    >
+      <Checkbox style={{float: "left"}}>
+        {i18next.t("signup:Accept")}&nbsp;
+        <a onClick={onClick}>
+          {i18next.t("signup:Terms of Use")}
+        </a>
+      </Checkbox>
+    </Form.Item>
+  );
+}
+
+export function renderModal(isOpen, onOk, onCancel, doc) {
+  return (
+    <Modal
+      title={i18next.t("signup:Terms of Use")}
+      open={isOpen}
+      width={"55vw"}
+      closable={false}
+      okText={i18next.t("signup:Accept")}
+      cancelText={i18next.t("signup:Decline")}
+      onOk={onOk}
+      onCancel={onCancel}
+    >
+      <iframe title={"terms"} style={{border: 0, width: "100%", height: "60vh"}} srcDoc={doc} />
+    </Modal>
+  );
 }
 
 export function getFormattedDate(date) {

--- a/web/src/SignupTable.js
+++ b/web/src/SignupTable.js
@@ -186,6 +186,11 @@ class SignupTable extends React.Component {
               {id: "Normal", name: "Normal"},
               {id: "No verification", name: "No verification"},
             ];
+          } else if (record.name === "Agreement") {
+            options = [
+              {id: "None", name: "None"},
+              {id: "Signin", name: "Signin"},
+            ];
           }
 
           if (options.length === 0) {

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -466,22 +466,24 @@ class LoginPage extends React.Component {
             }
           </Row>
           <Form.Item>
-            <Form.Item name="autoSignin" valuePropName="checked" noStyle>
-              <Checkbox style={{float: "left"}} disabled={!application.enablePassword}>
-                {i18next.t("login:Auto sign in")}
-              </Checkbox>
-            </Form.Item>
+            {
+              isAgreementRequired(application) ?
+                renderAgreement(isAgreementRequired(application), () => {
+                  this.setState({
+                    isTermsOfUseVisible: true,
+                  });
+                }) : (
+                  <Form.Item name="autoSignin" valuePropName="checked" noStyle>
+                    <Checkbox style={{float: "left"}} disabled={!application.enablePassword}>
+                      {i18next.t("login:Auto sign in")}
+                    </Checkbox>
+                  </Form.Item>
+                )
+            }
             {
               Setting.renderForgetLink(application, i18next.t("login:Forgot password?"))
             }
           </Form.Item>
-          {
-            renderAgreement(isAgreementRequired(application), () => {
-              this.setState({
-                isTermsOfUseVisible: true,
-              });
-            })
-          }
           <Form.Item>
             <Button
               type="primary"

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -30,7 +30,7 @@ import {CountDownInput} from "../common/CountDownInput";
 import SelectLanguageBox from "../SelectLanguageBox";
 import {CaptchaModal} from "../common/CaptchaModal";
 import RedirectForm from "../common/RedirectForm";
-import {getTermsOfUseContent, isAgreementRequired, renderAgreement, renderModal} from "./SignupPage";
+import {isAgreementRequired, renderAgreement, renderModal} from "./SignupPage";
 
 class LoginPage extends React.Component {
   constructor(props) {
@@ -127,7 +127,7 @@ class LoginPage extends React.Component {
           this.onUpdateApplication(application);
           this.setState({
             application: application,
-          }, () => getTermsOfUseContent(this.state.application.termsOfUse, res => {
+          }, () => Setting.getTermsOfUseContent(this.state.application.termsOfUse, res => {
             this.setState({termsOfUseContent: res});
           }));
         });
@@ -139,7 +139,7 @@ class LoginPage extends React.Component {
             this.setState({
               application: res.data,
               applicationName: res.data.name,
-            }, () => getTermsOfUseContent(this.state.application.termsOfUse, res => {
+            }, () => Setting.getTermsOfUseContent(this.state.application.termsOfUse, res => {
               this.setState({termsOfUseContent: res});
             }));
           } else {

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -468,7 +468,7 @@ class LoginPage extends React.Component {
           <Form.Item>
             {
               isAgreementRequired(application) ?
-                renderAgreement(isAgreementRequired(application), () => {
+                renderAgreement(true, () => {
                   this.setState({
                     isTermsOfUseVisible: true,
                   });

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -30,7 +30,6 @@ import {CountDownInput} from "../common/CountDownInput";
 import SelectLanguageBox from "../SelectLanguageBox";
 import {CaptchaModal} from "../common/CaptchaModal";
 import RedirectForm from "../common/RedirectForm";
-import {isAgreementRequired, renderAgreement, renderModal} from "./SignupPage";
 
 class LoginPage extends React.Component {
   constructor(props) {
@@ -467,8 +466,8 @@ class LoginPage extends React.Component {
           </Row>
           <Form.Item>
             {
-              isAgreementRequired(application) ?
-                renderAgreement(true, () => {
+              Setting.isAgreementRequired(application) ?
+                Setting.renderAgreement(true, () => {
                   this.setState({
                     isTermsOfUseVisible: true,
                   });
@@ -847,7 +846,7 @@ class LoginPage extends React.Component {
                     this.renderForm(application)
                   }
                   {
-                    renderModal(this.state.isTermsOfUseVisible, () => {
+                    Setting.renderModal(this.state.isTermsOfUseVisible, () => {
                       this.form.current.setFieldsValue({agreement: true});
                       this.setState({
                         isTermsOfUseVisible: false,

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -472,7 +472,7 @@ class LoginPage extends React.Component {
                   this.setState({
                     isTermsOfUseVisible: true,
                   });
-                }) : (
+                }, true) : (
                   <Form.Item name="autoSignin" valuePropName="checked" noStyle>
                     <Checkbox style={{float: "left"}} disabled={!application.enablePassword}>
                       {i18next.t("login:Auto sign in")}

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -657,8 +657,9 @@ export function renderAgreement(required, onClick, layout) {
         },
       ]}
       {...layout}
+      noStyle
     >
-      <Checkbox>
+      <Checkbox style={{float: "left"}}>
         {i18next.t("signup:Accept")}&nbsp;
         <a onClick={onClick}>
           {i18next.t("signup:Terms of Use")}

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import React from "react";
-import {Link} from "react-router-dom";
 import {Button, Checkbox, Form, Input, Modal, Result} from "antd";
 import * as Setting from "../Setting";
 import * as AuthBackend from "./AuthBackend";
@@ -113,7 +112,9 @@ class SignupPage extends React.Component {
         });
 
         if (application !== null && application !== undefined) {
-          this.getTermsofuseContent(application.termsOfUse);
+          getTermsOfUseContent(application.termsOfUse, res => {
+            this.setState({termsOfUseContent: res});
+          });
         }
       });
   }
@@ -132,16 +133,6 @@ class SignupPage extends React.Component {
 
   getApplicationObj() {
     return this.props.application ?? this.state.application;
-  }
-
-  getTermsofuseContent(url) {
-    fetch(url, {
-      method: "GET",
-    }).then(r => {
-      r.text().then(res => {
-        this.setState({termsOfUseContent: res});
-      });
-    });
   }
 
   onUpdateAccount(account) {
@@ -484,58 +475,28 @@ class SignupPage extends React.Component {
       );
     } else if (signupItem.name === "Agreement") {
       return (
-        <Form.Item
-          name="agreement"
-          key="agreement"
-          valuePropName="checked"
-          rules={[
-            {
-              required: required,
-              message: i18next.t("signup:Please accept the agreement!"),
-            },
-          ]}
-          {...tailFormItemLayout}
-        >
-          <Checkbox>
-            {i18next.t("signup:Accept")}&nbsp;
-            <Link onClick={() => {
-              this.setState({
-                isTermsOfUseVisible: true,
-              });
-            }}>
-              {i18next.t("signup:Terms of Use")}
-            </Link>
-          </Checkbox>
-        </Form.Item>
+        renderAgreement(isAgreementRequired(application), () => {
+          this.setState({
+            isTermsOfUseVisible: true,
+          });
+        }, tailFormItemLayout)
       );
     }
   }
 
   renderModal() {
     return (
-      <Modal
-        title={i18next.t("signup:Terms of Use")}
-        open={this.state.isTermsOfUseVisible}
-        width={"55vw"}
-        closable={false}
-        okText={i18next.t("signup:Accept")}
-        cancelText={i18next.t("signup:Decline")}
-        onOk={() => {
-          this.form.current.setFieldsValue({agreement: true});
-          this.setState({
-            isTermsOfUseVisible: false,
-          });
-        }}
-        onCancel={() => {
-          this.form.current.setFieldsValue({agreement: false});
-          this.setState({
-            isTermsOfUseVisible: false,
-          });
-          this.props.history.goBack();
-        }}
-      >
-        <iframe title={"terms"} style={{border: 0, width: "100%", height: "60vh"}} srcDoc={this.state.termsOfUseContent} />
-      </Modal>
+      renderModal(this.state.isTermsOfUseVisible, () => {
+        this.form.current.setFieldsValue({agreement: true});
+        this.setState({
+          isTermsOfUseVisible: false,
+        });
+      }, () => {
+        this.form.current.setFieldsValue({agreement: false});
+        this.setState({
+          isTermsOfUseVisible: false,
+        });
+      }, this.state.termsOfUseContent)
     );
   }
 
@@ -663,6 +624,65 @@ class SignupPage extends React.Component {
       </React.Fragment>
     );
   }
+}
+
+export function getTermsOfUseContent(url, setTermsOfUseContent) {
+  fetch(url, {
+    method: "GET",
+  }).then(r => {
+    r.text().then(setTermsOfUseContent);
+  });
+}
+
+export function isAgreementRequired(application) {
+  if (application) {
+    const agreementItem = application.signupItems.find(item => item.name === "Agreement");
+    if (agreementItem && agreementItem.required) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function renderAgreement(required, onClick, layout) {
+  return (
+    <Form.Item
+      name="agreement"
+      key="agreement"
+      valuePropName="checked"
+      rules={[
+        {
+          required: required,
+          message: i18next.t("signup:Please accept the agreement!"),
+        },
+      ]}
+      {...layout}
+    >
+      <Checkbox>
+        {i18next.t("signup:Accept")}&nbsp;
+        <a onClick={onClick}>
+          {i18next.t("signup:Terms of Use")}
+        </a>
+      </Checkbox>
+    </Form.Item>
+  );
+}
+
+export function renderModal(isOpen, onOk, onCancel, doc) {
+  return (
+    <Modal
+      title={i18next.t("signup:Terms of Use")}
+      open={isOpen}
+      width={"55vw"}
+      closable={false}
+      okText={i18next.t("signup:Accept")}
+      cancelText={i18next.t("signup:Decline")}
+      onOk={onOk}
+      onCancel={onCancel}
+    >
+      <iframe title={"terms"} style={{border: 0, width: "100%", height: "60vh"}} srcDoc={doc} />
+    </Modal>
+  );
 }
 
 export default withRouter(SignupPage);

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -479,7 +479,7 @@ class SignupPage extends React.Component {
           this.setState({
             isTermsOfUseVisible: true,
           });
-        }, tailFormItemLayout)
+        }, false, tailFormItemLayout)
       );
     }
   }
@@ -644,7 +644,7 @@ export function isAgreementRequired(application) {
   return false;
 }
 
-export function renderAgreement(required, onClick, layout) {
+export function renderAgreement(required, onClick, noStyle, layout) {
   return (
     <Form.Item
       name="agreement"
@@ -657,7 +657,7 @@ export function renderAgreement(required, onClick, layout) {
         },
       ]}
       {...layout}
-      noStyle
+      noStyle={noStyle}
     >
       <Checkbox style={{float: "left"}}>
         {i18next.t("signup:Accept")}&nbsp;

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -637,6 +637,9 @@ export function getTermsOfUseContent(url, setTermsOfUseContent) {
 export function isAgreementRequired(application) {
   if (application) {
     const agreementItem = application.signupItems.find(item => item.name === "Agreement");
+    if (agreementItem.rule === "None" || !agreementItem.rule) {
+      return false;
+    }
     if (agreementItem && agreementItem.required) {
       return true;
     }

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -112,7 +112,7 @@ class SignupPage extends React.Component {
         });
 
         if (application !== null && application !== undefined) {
-          getTermsOfUseContent(application.termsOfUse, res => {
+          Setting.getTermsOfUseContent(application.termsOfUse, res => {
             this.setState({termsOfUseContent: res});
           });
         }
@@ -624,14 +624,6 @@ class SignupPage extends React.Component {
       </React.Fragment>
     );
   }
-}
-
-export function getTermsOfUseContent(url, setTermsOfUseContent) {
-  fetch(url, {
-    method: "GET",
-  }).then(r => {
-    r.text().then(setTermsOfUseContent);
-  });
 }
 
 export function isAgreementRequired(application) {

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from "react";
-import {Button, Checkbox, Form, Input, Modal, Result} from "antd";
+import {Button, Form, Input, Result} from "antd";
 import * as Setting from "../Setting";
 import * as AuthBackend from "./AuthBackend";
 import * as ProviderButton from "./ProviderButton";
@@ -475,7 +475,7 @@ class SignupPage extends React.Component {
       );
     } else if (signupItem.name === "Agreement") {
       return (
-        renderAgreement(isAgreementRequired(application), () => {
+        Setting.renderAgreement(Setting.isAgreementRequired(application), () => {
           this.setState({
             isTermsOfUseVisible: true,
           });
@@ -486,7 +486,7 @@ class SignupPage extends React.Component {
 
   renderModal() {
     return (
-      renderModal(this.state.isTermsOfUseVisible, () => {
+      Setting.renderModal(this.state.isTermsOfUseVisible, () => {
         this.form.current.setFieldsValue({agreement: true});
         this.setState({
           isTermsOfUseVisible: false,
@@ -624,61 +624,6 @@ class SignupPage extends React.Component {
       </React.Fragment>
     );
   }
-}
-
-export function isAgreementRequired(application) {
-  if (application) {
-    const agreementItem = application.signupItems.find(item => item.name === "Agreement");
-    if (agreementItem.rule === "None" || !agreementItem.rule) {
-      return false;
-    }
-    if (agreementItem && agreementItem.required) {
-      return true;
-    }
-  }
-  return false;
-}
-
-export function renderAgreement(required, onClick, noStyle, layout) {
-  return (
-    <Form.Item
-      name="agreement"
-      key="agreement"
-      valuePropName="checked"
-      rules={[
-        {
-          required: required,
-          message: i18next.t("signup:Please accept the agreement!"),
-        },
-      ]}
-      {...layout}
-      noStyle={noStyle}
-    >
-      <Checkbox style={{float: "left"}}>
-        {i18next.t("signup:Accept")}&nbsp;
-        <a onClick={onClick}>
-          {i18next.t("signup:Terms of Use")}
-        </a>
-      </Checkbox>
-    </Form.Item>
-  );
-}
-
-export function renderModal(isOpen, onOk, onCancel, doc) {
-  return (
-    <Modal
-      title={i18next.t("signup:Terms of Use")}
-      open={isOpen}
-      width={"55vw"}
-      closable={false}
-      okText={i18next.t("signup:Accept")}
-      cancelText={i18next.t("signup:Decline")}
-      onOk={onOk}
-      onCancel={onCancel}
-    >
-      <iframe title={"terms"} style={{border: 0, width: "100%", height: "60vh"}} srcDoc={doc} />
-    </Modal>
-  );
 }
 
 export default withRouter(SignupPage);


### PR DESCRIPTION
<img width="705" alt="Screenshot 2023-01-14 at 10 51 52" src="https://user-images.githubusercontent.com/34052227/212466459-7578cdcb-0a61-40d1-8658-3cc0e2c5427f.png">

<img width="694" alt="Screenshot 2023-01-14 at 10 51 59" src="https://user-images.githubusercontent.com/34052227/212466463-71bb0017-842d-4a7a-a5fe-832fb2e66ccf.png">

<img width="1190" alt="Screenshot 2023-01-14 at 16 59 34" src="https://user-images.githubusercontent.com/34052227/212481518-d5ef583a-9693-4ab6-8608-c8e5f5c3d59b.png">


* Required to accept terms of use in signin page when they are mandatory
* Terms of use are activated only if the rule is set to `Signin`.