### PR TITLE
feat: check username if it's changed

### DIFF
--- a/object/check.go
+++ b/object/check.go
@@ -347,11 +347,10 @@ func CheckUpdateUser(oldUser *User, user *User, lang string) string {
 		return i18n.Translate(lang, "user:Display name cannot be empty")
 	}
 
-	if msg := CheckUsername(user.Name, lang); msg != "" {
-		return msg
-	}
-
 	if oldUser.Name != user.Name {
+		if msg := CheckUsername(user.Name, lang); msg != "" {
+			return msg
+		}
 		if HasUserByField(user.Owner, "name", user.Name) {
 			return i18n.Translate(lang, "check:Username already exists")
 		}


### PR DESCRIPTION
Cannot update user profile if login with email because of always checking username and the username's regex not allow `@`.
I think we should check username if it is changed.
<img width="1974" alt="Screenshot 2023-01-17 at 2 57 44 PM" src="https://user-images.githubusercontent.com/55494127/212849640-f73fa697-176f-44ee-8660-9e3a8f9cd944.png">
