### PR TITLE
Fix API panic error in "/api/enforce" and "/api/batch_enforce"

### DIFF
--- a/object/permission_enforcer.go
+++ b/object/permission_enforcer.go
@@ -290,8 +290,12 @@ m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act`
 		}
 		policyDefinition = append(policyDefinition, "permissionId")
 
+		requestDefinition := strings.Split(cfg.String("request_definition::r"), ",")
+		requestDefinition = append(requestDefinition, "permissionId")
+
 		m, _ := model.NewModelFromString(modelText)
 		m.AddDef("p", "p", strings.Join(policyDefinition, ","))
+		m.AddDef("r", "r", strings.Join(requestDefinition, ","))
 
 		return m, err
 	}

--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -36,10 +36,72 @@ type UserShort struct {
 	Name  string `xorm:"varchar(100) notnull pk" json:"name"`
 }
 
+type UserWithoutThirdIdp struct {
+	Owner               string        `xorm:"varchar(100) notnull pk" json:"owner"`
+	Name                string        `xorm:"varchar(100) notnull pk" json:"name"`
+	CreatedTime         string        `xorm:"varchar(100)" json:"createdTime"`
+	UpdatedTime         string        `xorm:"varchar(100)" json:"updatedTime"`
+	Id                  string        `xorm:"varchar(100) index" json:"id"`
+	Type                string        `xorm:"varchar(100)" json:"type"`
+	Password            string        `xorm:"varchar(100)" json:"password"`
+	PasswordSalt        string        `xorm:"varchar(100)" json:"passwordSalt"`
+	DisplayName         string        `xorm:"varchar(100)" json:"displayName"`
+	FirstName           string        `xorm:"varchar(100)" json:"firstName"`
+	LastName            string        `xorm:"varchar(100)" json:"lastName"`
+	Avatar              string        `xorm:"varchar(500)" json:"avatar"`
+	PermanentAvatar     string        `xorm:"varchar(500)" json:"permanentAvatar"`
+	Email               string        `xorm:"varchar(100) index" json:"email"`
+	EmailVerified       bool          `json:"emailVerified"`
+	Phone               string        `xorm:"varchar(100) index" json:"phone"`
+	Location            string        `xorm:"varchar(100)" json:"location"`
+	Address             []string      `json:"address"`
+	Affiliation         string        `xorm:"varchar(100)" json:"affiliation"`
+	Title               string        `xorm:"varchar(100)" json:"title"`
+	IdCardType          string        `xorm:"varchar(100)" json:"idCardType"`
+	IdCard              string        `xorm:"varchar(100) index" json:"idCard"`
+	Homepage            string        `xorm:"varchar(100)" json:"homepage"`
+	Bio                 string        `xorm:"varchar(100)" json:"bio"`
+	Tag                 string        `xorm:"varchar(100)" json:"tag"`
+	Region              string        `xorm:"varchar(100)" json:"region"`
+	Language            string        `xorm:"varchar(100)" json:"language"`
+	Gender              string        `xorm:"varchar(100)" json:"gender"`
+	Birthday            string        `xorm:"varchar(100)" json:"birthday"`
+	Education           string        `xorm:"varchar(100)" json:"education"`
+	Score               int           `json:"score"`
+	Karma               int           `json:"karma"`
+	Ranking             int           `json:"ranking"`
+	IsDefaultAvatar     bool          `json:"isDefaultAvatar"`
+	IsOnline            bool          `json:"isOnline"`
+	IsAdmin             bool          `json:"isAdmin"`
+	IsGlobalAdmin       bool          `json:"isGlobalAdmin"`
+	IsForbidden         bool          `json:"isForbidden"`
+	IsDeleted           bool          `json:"isDeleted"`
+	SignupApplication   string        `xorm:"varchar(100)" json:"signupApplication"`
+	Hash                string        `xorm:"varchar(100)" json:"hash"`
+	PreHash             string        `xorm:"varchar(100)" json:"preHash"`
+	CreatedIp           string        `xorm:"varchar(100)" json:"createdIp"`
+	LastSigninTime      string        `xorm:"varchar(100)" json:"lastSigninTime"`
+	LastSigninIp        string        `xorm:"varchar(100)" json:"lastSigninIp"`
+	Ldap                string        `xorm:"ldap varchar(100)" json:"ldap"`
+	Roles               []*Role       `xorm:"-" json:"roles"`
+	Permissions         []*Permission `xorm:"-" json:"permissions"`
+	LastSigninWrongTime string        `xorm:"varchar(100)" json:"lastSigninWrongTime"`
+	SigninWrongTimes    int           `json:"signinWrongTimes"`
+}
+
 type ClaimsShort struct {
 	*UserShort
 	TokenType string `json:"tokenType,omitempty"`
 	Nonce     string `json:"nonce,omitempty"`
+	Scope     string `json:"scope,omitempty"`
+	jwt.RegisteredClaims
+}
+
+type ClaimsWithoutThirdIdp struct {
+	*UserWithoutThirdIdp
+	TokenType string `json:"tokenType,omitempty"`
+	Nonce     string `json:"nonce,omitempty"`
+	Tag       string `json:"tag,omitempty"`
 	Scope     string `json:"scope,omitempty"`
 	jwt.RegisteredClaims
 }
@@ -52,6 +114,62 @@ func getShortUser(user *User) *UserShort {
 	return res
 }
 
+func getUserWithoutThirdIdp(user *User) *UserWithoutThirdIdp {
+	res := &UserWithoutThirdIdp{
+		Owner:               user.Owner,
+		Name:                user.Name,
+		CreatedTime:         user.CreatedTime,
+		UpdatedTime:         user.UpdatedTime,
+		Id:                  user.Id,
+		Type:                user.Type,
+		Password:            user.Password,
+		PasswordSalt:        user.PasswordSalt,
+		DisplayName:         user.DisplayName,
+		FirstName:           user.FirstName,
+		LastName:            user.LastName,
+		Avatar:              user.Avatar,
+		PermanentAvatar:     user.PermanentAvatar,
+		Email:               user.Email,
+		EmailVerified:       user.EmailVerified,
+		Phone:               user.Phone,
+		Location:            user.Location,
+		Address:             user.Address,
+		Affiliation:         user.Affiliation,
+		Title:               user.Title,
+		IdCardType:          user.IdCardType,
+		IdCard:              user.IdCard,
+		Homepage:            user.Homepage,
+		Bio:                 user.Bio,
+		Tag:                 user.Tag,
+		Region:              user.Region,
+		Language:            user.Language,
+		Gender:              user.Gender,
+		Birthday:            user.Birthday,
+		Education:           user.Education,
+		Score:               user.Score,
+		Karma:               user.Karma,
+		Ranking:             user.Ranking,
+		IsDefaultAvatar:     user.IsDefaultAvatar,
+		IsOnline:            user.IsOnline,
+		IsAdmin:             user.IsAdmin,
+		IsGlobalAdmin:       user.IsGlobalAdmin,
+		IsForbidden:         user.IsForbidden,
+		IsDeleted:           user.IsDeleted,
+		SignupApplication:   user.SignupApplication,
+		Hash:                user.Hash,
+		PreHash:             user.PreHash,
+		CreatedIp:           user.CreatedIp,
+		LastSigninTime:      user.LastSigninTime,
+		LastSigninIp:        user.LastSigninIp,
+		Ldap:                user.Ldap,
+		Roles:               user.Roles,
+		Permissions:         user.Permissions,
+		LastSigninWrongTime: user.LastSigninWrongTime,
+		SigninWrongTimes:    user.SigninWrongTimes,
+	}
+	return res
+}
+
 func getShortClaims(claims Claims) ClaimsShort {
 	res := ClaimsShort{
 		UserShort:        getShortUser(claims.User),
@@ -59,6 +177,18 @@ func getShortClaims(claims Claims) ClaimsShort {
 		Nonce:            claims.Nonce,
 		Scope:            claims.Scope,
 		RegisteredClaims: claims.RegisteredClaims,
+	}
+	return res
+}
+
+func getClaimsWithoutThirdIdp(claims Claims) ClaimsWithoutThirdIdp {
+	res := ClaimsWithoutThirdIdp{
+		UserWithoutThirdIdp: getUserWithoutThirdIdp(claims.User),
+		TokenType:           claims.TokenType,
+		Nonce:               claims.Nonce,
+		Tag:                 claims.Tag,
+		Scope:               claims.Scope,
+		RegisteredClaims:    claims.RegisteredClaims,
 	}
 	return res
 }
@@ -104,10 +234,12 @@ func generateJwtToken(application *Application, user *User, nonce string, scope 
 		claimsShort.TokenType = "refresh-token"
 		refreshToken = jwt.NewWithClaims(jwt.SigningMethodRS256, claimsShort)
 	} else {
-		token = jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		claimsWithoutThirdIdp := getClaimsWithoutThirdIdp(claims)
+
+		token = jwt.NewWithClaims(jwt.SigningMethodRS256, claimsWithoutThirdIdp)
 		claims.ExpiresAt = jwt.NewNumericDate(refreshExpireTime)
 		claims.TokenType = "refresh-token"
-		refreshToken = jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		refreshToken = jwt.NewWithClaims(jwt.SigningMethodRS256, claimsWithoutThirdIdp)
 	}
 
 	cert := getCertByApplication(application)


### PR DESCRIPTION
append permissionId on field r to resolve  panic error in casbin package:
invalid request size: expected 3,got 4, rvals:[...]

because of permission.go:69 GetRequest func, always return request object which lenth is at least 4.

before to merge, you can reoccurrence this phenomenon on default db(built-in) to see this case.