### PR TITLE
fix: remove "Agreement" in application edit page error

### DIFF
--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -520,10 +520,10 @@ export function getTermsOfUseContent(url, setTermsOfUseContent) {
 export function isAgreementRequired(application) {
   if (application) {
     const agreementItem = application.signupItems.find(item => item.name === "Agreement");
-    if (agreementItem.rule === "None" || !agreementItem.rule) {
+    if (!agreementItem || agreementItem.rule === "None" || !agreementItem.rule) {
       return false;
     }
-    if (agreementItem && agreementItem.required) {
+    if (agreementItem.required) {
       return true;
     }
   }


### PR DESCRIPTION
Fix: #1501

Error caused by:
![image](https://user-images.githubusercontent.com/41513919/215788337-437c2b14-52fa-4c22-9eba-728ca6710999.png)

Determine whether the variable is empty before accessing the property.

After Fix:

https://user-images.githubusercontent.com/41513919/215789490-779fec5d-a851-455e-a1e2-a592a27a74a2.mp4


