### PR TITLE
feat: change token ExpiresIn to second

### DIFF
--- a/object/token.go
+++ b/object/token.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	hourMinutes          = 60
+	hourSeconds          = int(time.Hour / time.Second)
 	InvalidRequest       = "invalid_request"
 	InvalidClient        = "invalid_client"
 	InvalidGrant         = "invalid_grant"
@@ -306,7 +306,7 @@ func GetOAuthCode(userId string, clientId string, responseType string, redirectU
 		Code:          util.GenerateClientId(),
 		AccessToken:   accessToken,
 		RefreshToken:  refreshToken,
-		ExpiresIn:     application.ExpireInHours * hourMinutes,
+		ExpiresIn:     application.ExpireInHours * hourSeconds,
 		Scope:         scope,
 		TokenType:     "Bearer",
 		CodeChallenge: challenge,
@@ -442,7 +442,7 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 		Code:         util.GenerateClientId(),
 		AccessToken:  newAccessToken,
 		RefreshToken: newRefreshToken,
-		ExpiresIn:    application.ExpireInHours * hourMinutes,
+		ExpiresIn:    application.ExpireInHours * hourSeconds,
 		Scope:        scope,
 		TokenType:    "Bearer",
 	}
@@ -592,7 +592,7 @@ func GetPasswordToken(application *Application, username string, password string
 		Code:         util.GenerateClientId(),
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
-		ExpiresIn:    application.ExpireInHours * hourMinutes,
+		ExpiresIn:    application.ExpireInHours * hourSeconds,
 		Scope:        scope,
 		TokenType:    "Bearer",
 		CodeIsUsed:   true,
@@ -632,7 +632,7 @@ func GetClientCredentialsToken(application *Application, clientSecret string, sc
 		User:         nullUser.Name,
 		Code:         util.GenerateClientId(),
 		AccessToken:  accessToken,
-		ExpiresIn:    application.ExpireInHours * hourMinutes,
+		ExpiresIn:    application.ExpireInHours * hourSeconds,
 		Scope:        scope,
 		TokenType:    "Bearer",
 		CodeIsUsed:   true,
@@ -659,7 +659,7 @@ func GetTokenByUser(application *Application, user *User, scope string, host str
 		Code:         util.GenerateClientId(),
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
-		ExpiresIn:    application.ExpireInHours * hourMinutes,
+		ExpiresIn:    application.ExpireInHours * hourSeconds,
 		Scope:        scope,
 		TokenType:    "Bearer",
 		CodeIsUsed:   true,

--- a/util/time.go
+++ b/util/time.go
@@ -31,6 +31,6 @@ func GetCurrentUnixTime() string {
 
 func IsTokenExpired(createdTime string, expiresIn int) bool {
 	createdTimeObj, _ := time.Parse(time.RFC3339, createdTime)
-	expiresAtObj := createdTimeObj.Add(time.Duration(expiresIn) * time.Minute)
+	expiresAtObj := createdTimeObj.Add(time.Duration(expiresIn) * time.Second)
 	return time.Now().After(expiresAtObj)
 }

--- a/util/time_test.go
+++ b/util/time_test.go
@@ -56,15 +56,15 @@ func Test_IsTokenExpired(t *testing.T) {
 			description: "Token emitted now is valid for 60 minutes",
 			input: input{
 				createdTime: time.Now().Format(time.RFC3339),
-				expiresIn:   60,
+				expiresIn:   3600,
 			},
 			expected: false,
 		},
 		{
-			description: "Token emitted 60 minutes before now is valid for 60 minutes",
+			description: "Token emitted 60 minutes before now is valid for 61 minutes",
 			input: input{
 				createdTime: time.Now().Add(-time.Minute * 60).Format(time.RFC3339),
-				expiresIn:   61,
+				expiresIn:   3660,
 			},
 			expected: false,
 		},
@@ -72,7 +72,7 @@ func Test_IsTokenExpired(t *testing.T) {
 			description: "Token emitted 2 hours before now is Expired after 60 minutes",
 			input: input{
 				createdTime: time.Now().Add(-time.Hour * 2).Format(time.RFC3339),
-				expiresIn:   60,
+				expiresIn:   3600,
 			},
 			expected: true,
 		},
@@ -80,23 +80,23 @@ func Test_IsTokenExpired(t *testing.T) {
 			description: "Token emitted 61 minutes before now is Expired after 60 minutes",
 			input: input{
 				createdTime: time.Now().Add(-time.Minute * 61).Format(time.RFC3339),
-				expiresIn:   60,
+				expiresIn:   3600,
 			},
 			expected: true,
 		},
 		{
-			description: "Token emitted 2 hours before now  is valid for 120 minutes",
+			description: "Token emitted 2 hours before now  is valid for 121 minutes",
 			input: input{
 				createdTime: time.Now().Add(-time.Hour * 2).Format(time.RFC3339),
-				expiresIn:   121,
+				expiresIn:   7260,
 			},
 			expected: false,
 		},
 		{
-			description: "Token emitted 159 minutes before now is Expired after 60 minutes",
+			description: "Token emitted 159 minutes before now is Expired after 120 minutes",
 			input: input{
 				createdTime: time.Now().Add(-time.Minute * 159).Format(time.RFC3339),
-				expiresIn:   120,
+				expiresIn:   7200,
 			},
 			expected: true,
 		},


### PR DESCRIPTION
The wrong format of ExpiresIn makes the result of casdoorsdk.GetOAuthToken (field `expiry`) wrong, too.


`expires_in`: OPTIONAL. Expiration time of the Access Token in seconds since the response was generated.

ref: https://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthResponse

in `3.2.2.5.  Successful Authentication Response`