### PR TITLE
fix: OIDC Userinfo API response for scope profile

### DIFF
--- a/object/user.go
+++ b/object/user.go
@@ -172,8 +172,8 @@ type Userinfo struct {
 	Sub         string `json:"sub"`
 	Iss         string `json:"iss"`
 	Aud         string `json:"aud"`
-	Name        string `json:"name,omitempty"`
-	DisplayName string `json:"preferred_username,omitempty"`
+	Name        string `json:"preferred_username,omitempty"`
+	DisplayName string `json:"name,omitempty"`
 	Email       string `json:"email,omitempty"`
 	Avatar      string `json:"picture,omitempty"`
 	Address     string `json:"address,omitempty"`


### PR DESCRIPTION
Hi, 
  When I use Casdoor as the OIDC Provider of Gitlab, I found that the name and preferred_username in the userinfo endpoint obtained by Gitlab are reversed.
  I also read the [OIDC standard](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse) and confirmed that "preferred_username" defined in the specification is the username, and name is the full name.