### PR TITLE
fix(secure): remove user list from roles and permissions field to avoid leaking userlist

### DIFF
--- a/object/permission.go
+++ b/object/permission.go
@@ -244,6 +244,9 @@ func GetPermissionsByUser(userId string) []*Permission {
 	if err != nil {
 		panic(err)
 	}
+	for idx := range permissions {
+		permissions[idx].Users = nil
+	}
 
 	return permissions
 }

--- a/object/permission.go
+++ b/object/permission.go
@@ -244,8 +244,9 @@ func GetPermissionsByUser(userId string) []*Permission {
 	if err != nil {
 		panic(err)
 	}
-	for idx := range permissions {
-		permissions[idx].Users = nil
+
+	for i := range permissions {
+		permissions[i].Users = nil
 	}
 
 	return permissions

--- a/object/role.go
+++ b/object/role.go
@@ -158,8 +158,9 @@ func GetRolesByUser(userId string) []*Role {
 	if err != nil {
 		panic(err)
 	}
-	for idx := range roles {
-		roles[idx].Users = nil
+
+	for i := range roles {
+		roles[i].Users = nil
 	}
 
 	return roles

--- a/object/role.go
+++ b/object/role.go
@@ -158,6 +158,9 @@ func GetRolesByUser(userId string) []*Role {
 	if err != nil {
 		panic(err)
 	}
+	for idx := range roles {
+		roles[idx].Users = nil
+	}
 
 	return roles
 }


### PR DESCRIPTION
Once a user login, he can get all the user names in the currently associated permissions or roles from the JWT token.  This might be a security issue IMO.