### PR TITLE
fix: fix incorrect field in oidc

### DIFF
--- a/idp/casdoor.go
+++ b/idp/casdoor.go
@@ -108,8 +108,8 @@ func (idp *CasdoorIdProvider) GetToken(code string) (*oauth2.Token, error) {
 
 type CasdoorUserInfo struct {
 	Id          string `json:"sub"`
-	Name        string `json:"name"`
-	DisplayName string `json:"preferred_username"`
+	Name        string `json:"preferred_username,omitempty"`
+	DisplayName string `json:"name"`
 	Email       string `json:"email"`
 	AvatarUrl   string `json:"picture"`
 	Status      string `json:"status"`

--- a/idp/custom.go
+++ b/idp/custom.go
@@ -61,8 +61,8 @@ func (idp *CustomIdProvider) GetToken(code string) (*oauth2.Token, error) {
 
 type CustomUserInfo struct {
 	Id          string `json:"sub"`
-	Name        string `json:"name"`
-	DisplayName string `json:"preferred_username"`
+	Name        string `json:"preferred_username,omitempty"`
+	DisplayName string `json:"name"`
 	Email       string `json:"email"`
 	AvatarUrl   string `json:"picture"`
 	Status      string `json:"status"`


### PR DESCRIPTION
Related #1598
Refer to [OIDC standard](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse) "preferred_username" defined in the specification is the username, and name is the full name. 