### PR TITLE
feat: fix function CheckAccountItemModifyRule

### DIFF
--- a/controllers/base.go
+++ b/controllers/base.go
@@ -48,6 +48,9 @@ func (c *ApiController) IsGlobalAdmin() bool {
 
 func (c *ApiController) IsAdmin() bool {
 	isGlobalAdmin, user := c.isGlobalAdmin()
+	if user == nil {
+		return false
+	}
 
 	return isGlobalAdmin || user.IsAdmin
 }

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -178,7 +178,7 @@ func (c *ApiController) UpdateUser() {
 	if affected {
 		object.UpdateUserToOriginalDatabase(&user)
 
-		if isAdmin && oldUser.GetId() == c.GetSessionUsername() {
+		if oldUser.GetId() == c.GetSessionUsername() {
 			c.SetSessionUsername(user.GetId())
 		}
 	}

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -177,10 +177,6 @@ func (c *ApiController) UpdateUser() {
 	affected := object.UpdateUser(id, &user, columns, isAdmin)
 	if affected {
 		object.UpdateUserToOriginalDatabase(&user)
-
-		if oldUser.GetId() == c.GetSessionUsername() {
-			c.SetSessionUsername(user.GetId())
-		}
 	}
 
 	c.Data["json"] = wrapActionResponse(affected)

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -177,6 +177,10 @@ func (c *ApiController) UpdateUser() {
 	affected := object.UpdateUser(id, &user, columns, isAdmin)
 	if affected {
 		object.UpdateUserToOriginalDatabase(&user)
+
+		if isAdmin && oldUser.GetId() == c.GetSessionUsername() {
+			c.SetSessionUsername(user.GetId())
+		}
 	}
 
 	c.Data["json"] = wrapActionResponse(affected)

--- a/object/organization.go
+++ b/object/organization.go
@@ -216,7 +216,7 @@ func CheckAccountItemModifyRule(accountItem *AccountItem, isAdmin bool, lang str
 
 	switch accountItem.ModifyRule {
 	case "Admin":
-		if isAdmin {
+		if !isAdmin {
 			return false, fmt.Sprintf(i18n.Translate(lang, "organization:Only admin can modify the %s."), accountItem.Name)
 		}
 	case "Immutable":


### PR DESCRIPTION
If user changes its owner username, the sessionUsername in server will be invalid.  After update user succesfully, if the user modifies its owner username,  setting the sessionUsername with the new username.

Fix: https://github.com/casdoor/casdoor/issues/1790