### PR TITLE
feat: make redirectUri token param follow OAuth2 standard

### DIFF
--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -334,8 +334,9 @@ class LoginPage extends React.Component {
             } else if (responseType === "code") {
               this.postCodeLoginAction(res);
             } else if (responseType === "token" || responseType === "id_token") {
+              const amendatoryResponseType = responseType === "token" ? "access_toke" : responseType;
               const accessToken = res.data;
-              Setting.goToLink(`${oAuthParams.redirectUri}#${responseType}=${accessToken}?state=${oAuthParams.state}&token_type=bearer`);
+              Setting.goToLink(`${oAuthParams.redirectUri}#${amendatoryResponseType}=${accessToken}&state=${oAuthParams.state}&token_type=bearer`);
             } else if (responseType === "saml") {
               if (res.data2.method === "POST") {
                 this.setState({

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -334,7 +334,7 @@ class LoginPage extends React.Component {
             } else if (responseType === "code") {
               this.postCodeLoginAction(res);
             } else if (responseType === "token" || responseType === "id_token") {
-              const amendatoryResponseType = responseType === "token" ? "access_toke" : responseType;
+              const amendatoryResponseType = responseType === "token" ? "access_token" : responseType;
               const accessToken = res.data;
               Setting.goToLink(`${oAuthParams.redirectUri}#${amendatoryResponseType}=${accessToken}&state=${oAuthParams.state}&token_type=bearer`);
             } else if (responseType === "saml") {


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/1793

1. rename "token" to "access_token" #1793 
2. change "?" to "&" #1012 
 
I will update the relevant document in [casdoor-website](https://github.com/casdoor/casdoor-website) when the PR is merged.