### PR TITLE
fix: fix URL path in MinIO storage provider

### DIFF
--- a/storage/minio_s3.go
+++ b/storage/minio_s3.go
@@ -29,7 +29,7 @@ func NewMinIOS3StorageProvider(clientId string, clientSecret string, region stri
 		Endpoint:         endpoint,
 		S3Endpoint:       endpoint,
 		ACL:              awss3.BucketCannedACLPublicRead,
-		S3ForcePathStyle: true,
+		S3ForcePathStyle: false,
 	})
 
 	return sp


### PR DESCRIPTION
Fix: #1813

When set `s3ForcePathStyle = true` the endpoint will be `endpoint/${bucketName}/key` lead the excess `${bucketName}`


https://user-images.githubusercontent.com/41513919/236747989-18299950-45eb-4b71-b419-627ef5c6b891.mp4

