### PR TITLE
fix a bug: login with account/password cannot redirect successfully (When Casdoor working as a OAuth server)

### DIFF
--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -353,7 +353,7 @@ class LoginPage extends React.Component {
             }
           };
           if (res.status === "ok") {
-            callback();
+            callback(res);
           } else if (res.status === NextMfa) {
             this.setState({
               getVerifyTotp: () => {


### PR DESCRIPTION
Cannot login successfully when I test the official demo: casnode+casdoor.
After some debugging, fixed this problem by modify this line of code.