### PR TITLE
feat: fix org admin permissions

### DIFF
--- a/authz/authz.go
+++ b/authz/authz.go
@@ -151,7 +151,7 @@ func IsAllowed(subOwner string, subName string, method string, urlPath string, o
 
 	userId := fmt.Sprintf("%s/%s", subOwner, subName)
 	user := object.GetUser(userId)
-	if user != nil && user.IsAdmin && (subOwner == objOwner || (objOwner == "admin" && subOwner == objName)) {
+	if user != nil && user.IsAdmin && (subOwner == objOwner || (objOwner == "admin")) {
 		return true
 	}
 

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -141,7 +141,7 @@ func (c *ApiController) HandleLoggedIn(application *object.Application, user *ob
 		c.setExpireForSession()
 	}
 
-	if resp.Status == "ok" && user.Owner == object.CasdoorOrganization && application.Name == object.CasdoorApplication {
+	if resp.Status == "ok" {
 		object.AddSession(&object.Session{
 			Owner:       user.Owner,
 			Name:        user.Name,

--- a/controllers/casbin_adapter.go
+++ b/controllers/casbin_adapter.go
@@ -31,13 +31,14 @@ func (c *ApiController) GetCasbinAdapters() {
 	value := c.Input().Get("value")
 	sortField := c.Input().Get("sortField")
 	sortOrder := c.Input().Get("sortOrder")
+	organization := c.Input().Get("organization")
 	if limit == "" || page == "" {
-		adapters := object.GetCasbinAdapters(owner)
+		adapters := object.GetCasbinAdapters(owner, organization)
 		c.ResponseOk(adapters)
 	} else {
 		limit := util.ParseInt(limit)
-		paginator := pagination.SetPaginator(c.Ctx, limit, int64(object.GetCasbinAdapterCount(owner, field, value)))
-		adapters := object.GetPaginationCasbinAdapters(owner, paginator.Offset(), limit, field, value, sortField, sortOrder)
+		paginator := pagination.SetPaginator(c.Ctx, limit, int64(object.GetCasbinAdapterCount(owner, organization, field, value)))
+		adapters := object.GetPaginationCasbinAdapters(owner, organization, paginator.Offset(), limit, field, value, sortField, sortOrder)
 		c.ResponseOk(adapters, paginator.Nums())
 	}
 }

--- a/controllers/cert.go
+++ b/controllers/cert.go
@@ -48,6 +48,30 @@ func (c *ApiController) GetCerts() {
 	}
 }
 
+// GetGlobleCerts
+// @Title GetGlobleCerts
+// @Tag Cert API
+// @Description get globle certs
+// @Success 200 {array} object.Cert The Response object
+// @router /get-globle-certs [get]
+func (c *ApiController) GetGlobleCerts() {
+	limit := c.Input().Get("pageSize")
+	page := c.Input().Get("p")
+	field := c.Input().Get("field")
+	value := c.Input().Get("value")
+	sortField := c.Input().Get("sortField")
+	sortOrder := c.Input().Get("sortOrder")
+	if limit == "" || page == "" {
+		c.Data["json"] = object.GetMaskedCerts(object.GetGlobleCerts())
+		c.ServeJSON()
+	} else {
+		limit := util.ParseInt(limit)
+		paginator := pagination.SetPaginator(c.Ctx, limit, int64(object.GetGlobalCertsCount(field, value)))
+		certs := object.GetMaskedCerts(object.GetPaginationGlobalCerts(paginator.Offset(), limit, field, value, sortField, sortOrder))
+		c.ResponseOk(certs, paginator.Nums())
+	}
+}
+
 // GetCert
 // @Title GetCert
 // @Tag Cert API

--- a/controllers/message.go
+++ b/controllers/message.go
@@ -41,7 +41,7 @@ func (c *ApiController) GetMessages() {
 	sortField := c.Input().Get("sortField")
 	sortOrder := c.Input().Get("sortOrder")
 	chat := c.Input().Get("chat")
-
+	organization := c.Input().Get("organization")
 	if limit == "" || page == "" {
 		var messages []*object.Message
 		if chat == "" {
@@ -54,8 +54,8 @@ func (c *ApiController) GetMessages() {
 		c.ServeJSON()
 	} else {
 		limit := util.ParseInt(limit)
-		paginator := pagination.SetPaginator(c.Ctx, limit, int64(object.GetMessageCount(owner, field, value)))
-		messages := object.GetMaskedMessages(object.GetPaginationMessages(owner, paginator.Offset(), limit, field, value, sortField, sortOrder))
+		paginator := pagination.SetPaginator(c.Ctx, limit, int64(object.GetMessageCount(owner, organization, field, value)))
+		messages := object.GetMaskedMessages(object.GetPaginationMessages(owner, organization, paginator.Offset(), limit, field, value, sortField, sortOrder))
 		c.ResponseOk(messages, paginator.Nums())
 	}
 }

--- a/controllers/syncer.go
+++ b/controllers/syncer.go
@@ -37,13 +37,14 @@ func (c *ApiController) GetSyncers() {
 	value := c.Input().Get("value")
 	sortField := c.Input().Get("sortField")
 	sortOrder := c.Input().Get("sortOrder")
+	organization := c.Input().Get("organization")
 	if limit == "" || page == "" {
-		c.Data["json"] = object.GetSyncers(owner)
+		c.Data["json"] = object.GetOrganizationSyncers(owner, organization)
 		c.ServeJSON()
 	} else {
 		limit := util.ParseInt(limit)
-		paginator := pagination.SetPaginator(c.Ctx, limit, int64(object.GetSyncerCount(owner, field, value)))
-		syncers := object.GetPaginationSyncers(owner, paginator.Offset(), limit, field, value, sortField, sortOrder)
+		paginator := pagination.SetPaginator(c.Ctx, limit, int64(object.GetSyncerCount(owner, organization, field, value)))
+		syncers := object.GetPaginationSyncers(owner, organization, paginator.Offset(), limit, field, value, sortField, sortOrder)
 		c.ResponseOk(syncers, paginator.Nums())
 	}
 }

--- a/controllers/token.go
+++ b/controllers/token.go
@@ -39,13 +39,14 @@ func (c *ApiController) GetTokens() {
 	value := c.Input().Get("value")
 	sortField := c.Input().Get("sortField")
 	sortOrder := c.Input().Get("sortOrder")
+	organization := c.Input().Get("organization")
 	if limit == "" || page == "" {
-		c.Data["json"] = object.GetTokens(owner)
+		c.Data["json"] = object.GetTokens(owner, organization)
 		c.ServeJSON()
 	} else {
 		limit := util.ParseInt(limit)
-		paginator := pagination.SetPaginator(c.Ctx, limit, int64(object.GetTokenCount(owner, field, value)))
-		tokens := object.GetPaginationTokens(owner, paginator.Offset(), limit, field, value, sortField, sortOrder)
+		paginator := pagination.SetPaginator(c.Ctx, limit, int64(object.GetTokenCount(owner, organization, field, value)))
+		tokens := object.GetPaginationTokens(owner, organization, paginator.Offset(), limit, field, value, sortField, sortOrder)
 		c.ResponseOk(tokens, paginator.Nums())
 	}
 }

--- a/controllers/webhook.go
+++ b/controllers/webhook.go
@@ -37,13 +37,14 @@ func (c *ApiController) GetWebhooks() {
 	value := c.Input().Get("value")
 	sortField := c.Input().Get("sortField")
 	sortOrder := c.Input().Get("sortOrder")
+	organization := c.Input().Get("organization")
 	if limit == "" || page == "" {
-		c.Data["json"] = object.GetWebhooks(owner)
+		c.Data["json"] = object.GetWebhooks(owner, organization)
 		c.ServeJSON()
 	} else {
 		limit := util.ParseInt(limit)
-		paginator := pagination.SetPaginator(c.Ctx, limit, int64(object.GetWebhookCount(owner, field, value)))
-		webhooks := object.GetPaginationWebhooks(owner, paginator.Offset(), limit, field, value, sortField, sortOrder)
+		paginator := pagination.SetPaginator(c.Ctx, limit, int64(object.GetWebhookCount(owner, organization, field, value)))
+		webhooks := object.GetPaginationWebhooks(owner, organization, paginator.Offset(), limit, field, value, sortField, sortOrder)
 		c.ResponseOk(webhooks, paginator.Nums())
 	}
 }

--- a/object/application.go
+++ b/object/application.go
@@ -109,7 +109,7 @@ func GetApplications(owner string) []*Application {
 
 func GetOrganizationApplications(owner string, organization string) []*Application {
 	applications := []*Application{}
-	err := adapter.Engine.Desc("created_time").Find(&applications, &Application{Owner: owner, Organization: organization})
+	err := adapter.Engine.Desc("created_time").Find(&applications, &Application{Organization: organization})
 	if err != nil {
 		panic(err)
 	}
@@ -131,7 +131,7 @@ func GetPaginationApplications(owner string, offset, limit int, field, value, so
 func GetPaginationOrganizationApplications(owner, organization string, offset, limit int, field, value, sortField, sortOrder string) []*Application {
 	applications := []*Application{}
 	session := GetSession(owner, offset, limit, field, value, sortField, sortOrder)
-	err := session.Find(&applications, &Application{Owner: owner, Organization: organization})
+	err := session.Find(&applications, &Application{Organization: organization})
 	if err != nil {
 		panic(err)
 	}

--- a/object/casbin_adapter.go
+++ b/object/casbin_adapter.go
@@ -46,9 +46,9 @@ type CasbinAdapter struct {
 	Adapter *xormadapter.Adapter `xorm:"-" json:"-"`
 }
 
-func GetCasbinAdapterCount(owner, field, value string) int {
+func GetCasbinAdapterCount(owner, organization, field, value string) int {
 	session := GetSession(owner, -1, -1, field, value, "", "")
-	count, err := session.Count(&CasbinAdapter{})
+	count, err := session.Count(&CasbinAdapter{Organization: organization})
 	if err != nil {
 		panic(err)
 	}
@@ -56,9 +56,9 @@ func GetCasbinAdapterCount(owner, field, value string) int {
 	return int(count)
 }
 
-func GetCasbinAdapters(owner string) []*CasbinAdapter {
+func GetCasbinAdapters(owner string, organization string) []*CasbinAdapter {
 	adapters := []*CasbinAdapter{}
-	err := adapter.Engine.Where("owner = ?", owner).Find(&adapters)
+	err := adapter.Engine.Where("owner = ? and organization = ?", owner, organization).Find(&adapters)
 	if err != nil {
 		panic(err)
 	}
@@ -66,10 +66,10 @@ func GetCasbinAdapters(owner string) []*CasbinAdapter {
 	return adapters
 }
 
-func GetPaginationCasbinAdapters(owner string, page, limit int, field, value, sort, order string) []*CasbinAdapter {
+func GetPaginationCasbinAdapters(owner, organization string, page, limit int, field, value, sort, order string) []*CasbinAdapter {
 	session := GetSession(owner, page, limit, field, value, sort, order)
 	adapters := []*CasbinAdapter{}
-	err := session.Find(&adapters)
+	err := session.Find(&adapters, &CasbinAdapter{Organization: organization})
 	if err != nil {
 		panic(err)
 	}

--- a/object/cert.go
+++ b/object/cert.go
@@ -55,8 +55,8 @@ func GetMaskedCerts(certs []*Cert) []*Cert {
 }
 
 func GetCertCount(owner, field, value string) int {
-	session := GetSession(owner, -1, -1, field, value, "", "")
-	count, err := session.Count(&Cert{})
+	session := GetSession("", -1, -1, field, value, "", "")
+	count, err := session.Where("owner = ? or owner = ? ", "admin", owner).Count(&Cert{})
 	if err != nil {
 		panic(err)
 	}
@@ -66,7 +66,7 @@ func GetCertCount(owner, field, value string) int {
 
 func GetCerts(owner string) []*Cert {
 	certs := []*Cert{}
-	err := adapter.Engine.Desc("created_time").Find(&certs, &Cert{Owner: owner})
+	err := adapter.Engine.Where("owner = ? or owner = ? ", "admin", owner).Desc("created_time").Find(&certs, &Cert{})
 	if err != nil {
 		panic(err)
 	}
@@ -76,7 +76,38 @@ func GetCerts(owner string) []*Cert {
 
 func GetPaginationCerts(owner string, offset, limit int, field, value, sortField, sortOrder string) []*Cert {
 	certs := []*Cert{}
-	session := GetSession(owner, offset, limit, field, value, sortField, sortOrder)
+	session := GetSession("", offset, limit, field, value, sortField, sortOrder)
+	err := session.Where("owner = ? or owner = ? ", "admin", owner).Find(&certs)
+	if err != nil {
+		panic(err)
+	}
+
+	return certs
+}
+
+func GetGlobalCertsCount(field, value string) int {
+	session := GetSession("", -1, -1, field, value, "", "")
+	count, err := session.Count(&Cert{})
+	if err != nil {
+		panic(err)
+	}
+
+	return int(count)
+}
+
+func GetGlobleCerts() []*Cert {
+	certs := []*Cert{}
+	err := adapter.Engine.Desc("created_time").Find(&certs)
+	if err != nil {
+		panic(err)
+	}
+
+	return certs
+}
+
+func GetPaginationGlobalCerts(offset, limit int, field, value, sortField, sortOrder string) []*Cert {
+	certs := []*Cert{}
+	session := GetSession("", offset, limit, field, value, sortField, sortOrder)
 	err := session.Find(&certs)
 	if err != nil {
 		panic(err)

--- a/object/message.go
+++ b/object/message.go
@@ -48,9 +48,9 @@ func GetMaskedMessages(messages []*Message) []*Message {
 	return messages
 }
 
-func GetMessageCount(owner, field, value string) int {
+func GetMessageCount(owner, organization, field, value string) int {
 	session := GetSession(owner, -1, -1, field, value, "", "")
-	count, err := session.Count(&Message{})
+	count, err := session.Count(&Message{Organization: organization})
 	if err != nil {
 		panic(err)
 	}
@@ -78,10 +78,10 @@ func GetChatMessages(chat string) []*Message {
 	return messages
 }
 
-func GetPaginationMessages(owner string, offset, limit int, field, value, sortField, sortOrder string) []*Message {
+func GetPaginationMessages(owner, organization string, offset, limit int, field, value, sortField, sortOrder string) []*Message {
 	messages := []*Message{}
 	session := GetSession(owner, offset, limit, field, value, sortField, sortOrder)
-	err := session.Find(&messages)
+	err := session.Find(&messages, &Message{Organization: organization})
 	if err != nil {
 		panic(err)
 	}

--- a/object/syncer.go
+++ b/object/syncer.go
@@ -55,9 +55,9 @@ type Syncer struct {
 	Adapter *Adapter `xorm:"-" json:"-"`
 }
 
-func GetSyncerCount(owner, field, value string) int {
+func GetSyncerCount(owner, organization, field, value string) int {
 	session := GetSession(owner, -1, -1, field, value, "", "")
-	count, err := session.Count(&Syncer{})
+	count, err := session.Count(&Syncer{Organization: organization})
 	if err != nil {
 		panic(err)
 	}
@@ -75,10 +75,20 @@ func GetSyncers(owner string) []*Syncer {
 	return syncers
 }
 
-func GetPaginationSyncers(owner string, offset, limit int, field, value, sortField, sortOrder string) []*Syncer {
+func GetOrganizationSyncers(owner, organization string) []*Syncer {
+	syncers := []*Syncer{}
+	err := adapter.Engine.Desc("created_time").Find(&syncers, &Syncer{Owner: owner, Organization: organization})
+	if err != nil {
+		panic(err)
+	}
+
+	return syncers
+}
+
+func GetPaginationSyncers(owner, organization string, offset, limit int, field, value, sortField, sortOrder string) []*Syncer {
 	syncers := []*Syncer{}
 	session := GetSession(owner, offset, limit, field, value, sortField, sortOrder)
-	err := session.Find(&syncers)
+	err := session.Find(&syncers, &Syncer{Organization: organization})
 	if err != nil {
 		panic(err)
 	}

--- a/object/token.go
+++ b/object/token.go
@@ -91,9 +91,9 @@ type IntrospectionResponse struct {
 	Jti       string   `json:"jti,omitempty"`
 }
 
-func GetTokenCount(owner, field, value string) int {
+func GetTokenCount(owner, organization, field, value string) int {
 	session := GetSession(owner, -1, -1, field, value, "", "")
-	count, err := session.Count(&Token{})
+	count, err := session.Count(&Token{Organization: organization})
 	if err != nil {
 		panic(err)
 	}
@@ -101,9 +101,9 @@ func GetTokenCount(owner, field, value string) int {
 	return int(count)
 }
 
-func GetTokens(owner string) []*Token {
+func GetTokens(owner string, organization string) []*Token {
 	tokens := []*Token{}
-	err := adapter.Engine.Desc("created_time").Find(&tokens, &Token{Owner: owner})
+	err := adapter.Engine.Desc("created_time").Find(&tokens, &Token{Owner: owner, Organization: organization})
 	if err != nil {
 		panic(err)
 	}
@@ -111,10 +111,10 @@ func GetTokens(owner string) []*Token {
 	return tokens
 }
 
-func GetPaginationTokens(owner string, offset, limit int, field, value, sortField, sortOrder string) []*Token {
+func GetPaginationTokens(owner, organization string, offset, limit int, field, value, sortField, sortOrder string) []*Token {
 	tokens := []*Token{}
 	session := GetSession(owner, offset, limit, field, value, sortField, sortOrder)
-	err := session.Find(&tokens)
+	err := session.Find(&tokens, &Token{Organization: organization})
 	if err != nil {
 		panic(err)
 	}

--- a/object/webhook.go
+++ b/object/webhook.go
@@ -42,9 +42,9 @@ type Webhook struct {
 	IsEnabled      bool      `json:"isEnabled"`
 }
 
-func GetWebhookCount(owner, field, value string) int {
+func GetWebhookCount(owner, organization, field, value string) int {
 	session := GetSession(owner, -1, -1, field, value, "", "")
-	count, err := session.Count(&Webhook{})
+	count, err := session.Count(&Webhook{Organization: organization})
 	if err != nil {
 		panic(err)
 	}
@@ -52,9 +52,9 @@ func GetWebhookCount(owner, field, value string) int {
 	return int(count)
 }
 
-func GetWebhooks(owner string) []*Webhook {
+func GetWebhooks(owner string, organization string) []*Webhook {
 	webhooks := []*Webhook{}
-	err := adapter.Engine.Desc("created_time").Find(&webhooks, &Webhook{Owner: owner})
+	err := adapter.Engine.Desc("created_time").Find(&webhooks, &Webhook{Owner: owner, Organization: organization})
 	if err != nil {
 		panic(err)
 	}
@@ -62,10 +62,10 @@ func GetWebhooks(owner string) []*Webhook {
 	return webhooks
 }
 
-func GetPaginationWebhooks(owner string, offset, limit int, field, value, sortField, sortOrder string) []*Webhook {
+func GetPaginationWebhooks(owner, organization string, offset, limit int, field, value, sortField, sortOrder string) []*Webhook {
 	webhooks := []*Webhook{}
 	session := GetSession(owner, offset, limit, field, value, sortField, sortOrder)
-	err := session.Find(&webhooks)
+	err := session.Find(&webhooks, &Webhook{Organization: organization})
 	if err != nil {
 		panic(err)
 	}

--- a/routers/router.go
+++ b/routers/router.go
@@ -184,6 +184,7 @@ func initAPI() {
 	beego.Router("/api/run-syncer", &controllers.ApiController{}, "GET:RunSyncer")
 
 	beego.Router("/api/get-certs", &controllers.ApiController{}, "GET:GetCerts")
+	beego.Router("/api/get-globle-certs", &controllers.ApiController{}, "GET:GetGlobleCerts")
 	beego.Router("/api/get-cert", &controllers.ApiController{}, "GET:GetCert")
 	beego.Router("/api/update-cert", &controllers.ApiController{}, "POST:UpdateCert")
 	beego.Router("/api/add-cert", &controllers.ApiController{}, "POST:AddCert")

--- a/web/src/AdapterEditPage.js
+++ b/web/src/AdapterEditPage.js
@@ -47,7 +47,7 @@ class AdapterEditPage extends React.Component {
   }
 
   getAdapter() {
-    AdapterBackend.getAdapter(this.state.owner, this.state.adapterName)
+    AdapterBackend.getAdapter("admin", this.state.adapterName)
       .then((res) => {
         if (res.status === "ok") {
           this.setState({
@@ -60,7 +60,7 @@ class AdapterEditPage extends React.Component {
   }
 
   getOrganizations() {
-    OrganizationBackend.getOrganizations("admin")
+    OrganizationBackend.getOrganizations(this.state.organizationName)
       .then((res) => {
         this.setState({
           organizations: (res.msg === undefined) ? res : [],
@@ -109,7 +109,7 @@ class AdapterEditPage extends React.Component {
             {Setting.getLabel(i18next.t("general:Organization"), i18next.t("general:Organization - Tooltip"))} :
           </Col>
           <Col span={22} >
-            <Select virtual={false} style={{width: "100%"}} value={this.state.adapter.organization} onChange={(value => {
+            <Select virtual={false} style={{width: "100%"}} disabled={!Setting.isAdminUser(this.props.account)} value={this.state.adapter.organization} onChange={(value => {
               this.getModels(value);
               this.updateAdapterField("organization", value);
               this.updateAdapterField("owner", value);

--- a/web/src/AdapterListPage.js
+++ b/web/src/AdapterListPage.js
@@ -26,10 +26,10 @@ class AdapterListPage extends BaseListPage {
   newAdapter() {
     const randomName = Setting.getRandomName();
     return {
-      owner: "built-in",
+      owner: "admin",
       name: `adapter_${randomName}`,
       createdTime: moment().format(),
-      organization: "built-in",
+      organization: this.props.account.owner,
       type: "Database",
       host: "localhost",
       port: 3306,
@@ -247,7 +247,7 @@ class AdapterListPage extends BaseListPage {
       value = params.type;
     }
     this.setState({loading: true});
-    AdapterBackend.getAdapters("", params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
+    AdapterBackend.getAdapters("admin", Setting.isAdminUser(this.props.account) ? "" : this.props.account.owner, params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
       .then((res) => {
         if (res.status === "ok") {
           this.setState({

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -410,7 +410,7 @@ class App extends Component {
       ));
     }
 
-    if (Setting.isAdminUser(this.state.account)) {
+    if (Setting.isLocalAdminUser(this.state.account)) {
       res.push(Setting.getItem(<Link to="/models">{i18next.t("general:Models")}</Link>,
         "/models"
       ));
@@ -446,7 +446,7 @@ class App extends Component {
       ));
     }
 
-    if (Setting.isAdminUser(this.state.account)) {
+    if (Setting.isLocalAdminUser(this.state.account)) {
       res.push(Setting.getItem(<Link to="/tokens">{i18next.t("general:Tokens")}</Link>,
         "/tokens"
       ));
@@ -475,11 +475,13 @@ class App extends Component {
         res.push(Setting.getItem(<Link to="/payments">{i18next.t("general:Payments")}</Link>,
           "/payments"
         ));
-
-        res.push(Setting.getItem(<Link to="/sysinfo">{i18next.t("general:System Info")}</Link>,
-          "/sysinfo"
-        ));
       }
+
+    }
+    if (Setting.isAdminUser(this.state.account)) {
+      res.push(Setting.getItem(<Link to="/sysinfo">{i18next.t("general:System Info")}</Link>,
+        "/sysinfo"
+      ));
       res.push(Setting.getItem(<a target="_blank" rel="noreferrer"
         href={Setting.isLocalhost() ? `${Setting.ServerUrl}/swagger` : "/swagger"}>{i18next.t("general:Swagger")}</a>,
       "/swagger"

--- a/web/src/ApplicationEditPage.js
+++ b/web/src/ApplicationEditPage.js
@@ -145,7 +145,7 @@ class ApplicationEditPage extends React.Component {
   }
 
   getCerts() {
-    CertBackend.getCerts("admin")
+    CertBackend.getCerts(this.props.account.owner)
       .then((res) => {
         this.setState({
           certs: (res.msg === undefined) ? res : [],

--- a/web/src/ApplicationListPage.js
+++ b/web/src/ApplicationListPage.js
@@ -273,7 +273,7 @@ class ApplicationListPage extends BaseListPage {
     const sortField = params.sortField, sortOrder = params.sortOrder;
     this.setState({loading: true});
     (Setting.isAdminUser(this.props.account) ? ApplicationBackend.getApplications("admin", params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder) :
-      ApplicationBackend.getApplicationsByOrganization("admin", this.state.organizationName, params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder))
+      ApplicationBackend.getApplicationsByOrganization("admin", this.props.account.organization.name, params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder))
       .then((res) => {
         if (res.status === "ok") {
           this.setState({

--- a/web/src/CertEditPage.js
+++ b/web/src/CertEditPage.js
@@ -30,6 +30,7 @@ class CertEditPage extends React.Component {
       classes: props,
       certName: props.match.params.certName,
       cert: null,
+      organizations: [],
       mode: props.location.mode !== undefined ? props.location.mode : "edit",
     };
   }
@@ -39,7 +40,7 @@ class CertEditPage extends React.Component {
   }
 
   getCert() {
-    CertBackend.getCert("admin", this.state.certName)
+    CertBackend.getCert(this.props.account.owner, this.state.certName)
       .then((cert) => {
         this.setState({
           cert: cert,
@@ -75,6 +76,19 @@ class CertEditPage extends React.Component {
           {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} onClick={() => this.deleteCert()}>{i18next.t("general:Cancel")}</Button> : null}
         </div>
       } style={(Setting.isMobile()) ? {margin: "5px"} : {}} type="inner">
+        <Row style={{marginTop: "20px"}} >
+          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+            {Setting.getLabel(i18next.t("general:Organization"), i18next.t("general:Organization - Tooltip"))} :
+          </Col>
+          <Col span={22} >
+            <Select virtual={false} style={{width: "100%"}} disabled={!Setting.isAdminUser(this.props.account)} value={this.state.cert.owner} onChange={(value => {this.updateCertField("owner", value);})}>
+              {Setting.isAdminUser(this.props.account) ? <Option key={"admin"} value={"admin"}>{i18next.t("cert:admin (Shared)")}</Option> : null}
+              {
+                this.state.organizations.map((organization, index) => <Option key={index} value={organization.name}>{organization.name}</Option>)
+              }
+            </Select>
+          </Col>
+        </Row>
         <Row style={{marginTop: "10px"}} >
           <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
             {Setting.getLabel(i18next.t("general:Name"), i18next.t("general:Name - Tooltip"))} :

--- a/web/src/ChatEditPage.js
+++ b/web/src/ChatEditPage.js
@@ -99,7 +99,7 @@ class ChatEditPage extends React.Component {
             {Setting.getLabel(i18next.t("general:Organization"), i18next.t("general:Organization - Tooltip"))} :
           </Col>
           <Col span={22} >
-            <Select virtual={false} style={{width: "100%"}} value={this.state.chat.organization} onChange={(value => {this.updateChatField("organization", value);})}
+            <Select virtual={false} disabled={!Setting.isAdminUser(this.props.account)} style={{width: "100%"}} value={this.state.chat.organization} onChange={(value => {this.updateChatField("organization", value);})}
               options={this.state.organizations.map((organization) => Setting.getOption(organization.name, organization.name))
               } />
           </Col>

--- a/web/src/ChatPage.js
+++ b/web/src/ChatPage.js
@@ -33,7 +33,7 @@ class ChatPage extends BaseListPage {
   newChat(chat) {
     const randomName = Setting.getRandomName();
     return {
-      owner: "admin", // this.props.account.applicationName,
+      owner: this.props.account.owner, // this.props.account.applicationName,
       name: `chat_${randomName}`,
       createdTime: moment().format(),
       updatedTime: moment().format(),
@@ -51,7 +51,7 @@ class ChatPage extends BaseListPage {
   newMessage(text) {
     const randomName = Setting.getRandomName();
     return {
-      owner: "admin", // this.props.account.messagename,
+      owner: this.props.account.owner, // this.props.account.messagename,
       name: `message_${randomName}`,
       createdTime: moment().format(),
       organization: this.props.account.owner,

--- a/web/src/MessageEditPage.js
+++ b/web/src/MessageEditPage.js
@@ -113,7 +113,7 @@ class MessageEditPage extends React.Component {
             {Setting.getLabel(i18next.t("general:Organization"), i18next.t("general:Organization - Tooltip"))} :
           </Col>
           <Col span={22} >
-            <Select virtual={false} style={{width: "100%"}} value={this.state.message.organization} onChange={(value => {this.updateMessageField("organization", value);})}
+            <Select virtual={false} disabled={!Setting.isAdminUser(this.props.account)} style={{width: "100%"}} value={this.state.message.organization} onChange={(value => {this.updateMessageField("organization", value);})}
               options={this.state.organizations.map((organization) => Setting.getOption(organization.name, organization.name))
               } />
           </Col>

--- a/web/src/MessageListPage.js
+++ b/web/src/MessageListPage.js
@@ -209,7 +209,7 @@ class MessageListPage extends BaseListPage {
       value = params.type;
     }
     this.setState({loading: true});
-    MessageBackend.getMessages("admin", params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
+    MessageBackend.getMessages("admin", Setting.isAdminUser(this.props.account) ? "" : this.props.account.owner, params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
       .then((res) => {
         if (res.status === "ok") {
           this.setState({

--- a/web/src/ModelEditPage.js
+++ b/web/src/ModelEditPage.js
@@ -53,7 +53,7 @@ class ModelEditPage extends React.Component {
           model: model,
         });
 
-        this.getModels(model.owner);
+        this.getModels(model.organization);
       });
   }
 
@@ -107,7 +107,7 @@ class ModelEditPage extends React.Component {
             {Setting.getLabel(i18next.t("general:Organization"), i18next.t("general:Organization - Tooltip"))} :
           </Col>
           <Col span={22} >
-            <Select virtual={false} style={{width: "100%"}} value={this.state.model.owner} onChange={(value => {this.updateModelField("owner", value);})}>
+            <Select virtual={false} style={{width: "100%"}} disabled={!Setting.isAdminUser(this.props.account)} value={this.state.model.owner} onChange={(value => {this.updateModelField("owner", value);})}>
               {
                 this.state.organizations.map((organization, index) => <Option key={index} value={organization.name}>{organization.name}</Option>)
               }

--- a/web/src/ModelListPage.js
+++ b/web/src/ModelListPage.js
@@ -41,7 +41,7 @@ class ModelListPage extends BaseListPage {
   newModel() {
     const randomName = Setting.getRandomName();
     return {
-      owner: "built-in",
+      owner: this.props.account.owner,
       name: `model_${randomName}`,
       createdTime: moment().format(),
       displayName: `New Model - ${randomName}`,
@@ -202,7 +202,7 @@ class ModelListPage extends BaseListPage {
       value = params.type;
     }
     this.setState({loading: true});
-    ModelBackend.getModels("", params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
+    ModelBackend.getModels(Setting.isAdminUser(this.props.account) ? "" : this.props.account.owner, params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
       .then((res) => {
         if (res.status === "ok") {
           this.setState({

--- a/web/src/PaymentEditPage.js
+++ b/web/src/PaymentEditPage.js
@@ -40,7 +40,7 @@ class PaymentEditPage extends React.Component {
   }
 
   getPayment() {
-    PaymentBackend.getPayment("admin", this.state.paymentName)
+    PaymentBackend.getPayment(this.props.account.owner, this.state.paymentName)
       .then((payment) => {
         this.setState({
           payment: payment,

--- a/web/src/PaymentListPage.js
+++ b/web/src/PaymentListPage.js
@@ -27,13 +27,13 @@ class PaymentListPage extends BaseListPage {
   newPayment() {
     const randomName = Setting.getRandomName();
     return {
-      owner: "admin",
+      owner: this.props.account.owner,
       name: `payment_${randomName}`,
       createdTime: moment().format(),
       displayName: `New Payment - ${randomName}`,
       provider: "provider_pay_paypal",
       type: "PayPal",
-      organization: "built-in",
+      organization: this.props.account.owner,
       user: "admin",
       productName: "computer-1",
       productDisplayName: "A notebook computer",
@@ -265,7 +265,7 @@ class PaymentListPage extends BaseListPage {
       value = params.type;
     }
     this.setState({loading: true});
-    PaymentBackend.getPayments("", params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
+    PaymentBackend.getPayments(Setting.isAdminUser(this.props.account) ? "" : this.props.account.owner, params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
       .then((res) => {
         if (res.status === "ok") {
           this.setState({

--- a/web/src/PaymentResultPage.js
+++ b/web/src/PaymentResultPage.js
@@ -33,7 +33,7 @@ class PaymentResultPage extends React.Component {
   }
 
   getPayment() {
-    PaymentBackend.getPayment("admin", this.state.paymentName)
+    PaymentBackend.getPayment(this.props.account.owner, this.state.paymentName)
       .then((payment) => {
         this.setState({
           payment: payment,

--- a/web/src/PermissionEditPage.js
+++ b/web/src/PermissionEditPage.js
@@ -159,7 +159,7 @@ class PermissionEditPage extends React.Component {
             {Setting.getLabel(i18next.t("general:Organization"), i18next.t("general:Organization - Tooltip"))} :
           </Col>
           <Col span={22} >
-            <Select virtual={false} style={{width: "100%"}} value={this.state.permission.owner} onChange={(owner => {
+            <Select virtual={false} style={{width: "100%"}} disabled={!Setting.isAdminUser(this.props.account)} value={this.state.permission.owner} onChange={(owner => {
               this.updatePermissionField("owner", owner);
               this.getUsers(owner);
               this.getRoles(owner);

--- a/web/src/ProductBuyPage.js
+++ b/web/src/ProductBuyPage.js
@@ -40,7 +40,7 @@ class ProductBuyPage extends React.Component {
       return;
     }
 
-    ProductBackend.getProduct("admin", this.state.productName)
+    ProductBackend.getProduct(this.props.account.owner, this.state.productName)
       .then((product) => {
         this.setState({
           product: product,

--- a/web/src/ProductEditPage.js
+++ b/web/src/ProductEditPage.js
@@ -32,6 +32,7 @@ class ProductEditPage extends React.Component {
       productName: props.match.params.productName,
       product: null,
       providers: [],
+      organizations: [],
       mode: props.location.mode !== undefined ? props.location.mode : "edit",
     };
   }
@@ -42,7 +43,7 @@ class ProductEditPage extends React.Component {
   }
 
   getProduct() {
-    ProductBackend.getProduct("admin", this.state.productName)
+    ProductBackend.getProduct(this.props.account.owner, this.state.productName)
       .then((product) => {
         this.setState({
           product: product,
@@ -51,7 +52,7 @@ class ProductEditPage extends React.Component {
   }
 
   getPaymentProviders() {
-    ProviderBackend.getProviders("admin")
+    ProviderBackend.getProviders(this.props.account.owner)
       .then((res) => {
         this.setState({
           providers: res.filter(provider => provider.category === "Payment"),
@@ -104,6 +105,18 @@ class ProductEditPage extends React.Component {
             <Input value={this.state.product.displayName} onChange={e => {
               this.updateProductField("displayName", e.target.value);
             }} />
+          </Col>
+        </Row>
+        <Row style={{marginTop: "20px"}} >
+          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+            {Setting.getLabel(i18next.t("general:Organization"), i18next.t("general:Organization - Tooltip"))} :
+          </Col>
+          <Col span={22} >
+            <Select virtual={false} style={{width: "100%"}} disabled={!Setting.isAdminUser(this.props.account)} value={this.state.product.owner} onChange={(value => {this.updateProductField("owner", value);})}>
+              {
+                this.state.organizations.map((organization, index) => <Option key={index} value={organization.name}>{organization.name}</Option>)
+              }
+            </Select>
           </Col>
         </Row>
         <Row style={{marginTop: "20px"}} >

--- a/web/src/ProductListPage.js
+++ b/web/src/ProductListPage.js
@@ -27,7 +27,7 @@ class ProductListPage extends BaseListPage {
   newProduct() {
     const randomName = Setting.getRandomName();
     return {
-      owner: "admin",
+      owner: this.props.account.owner,
       name: `product_${randomName}`,
       createdTime: moment().format(),
       displayName: `New Product - ${randomName}`,
@@ -93,6 +93,14 @@ class ProductListPage extends BaseListPage {
             </Link>
           );
         },
+      },
+      {
+        title: i18next.t("general:Organization"),
+        dataIndex: "owner",
+        key: "owner",
+        width: "150px",
+        sorter: true,
+        ...this.getColumnSearchProps("organization"),
       },
       {
         title: i18next.t("general:Created time"),
@@ -282,7 +290,7 @@ class ProductListPage extends BaseListPage {
       value = params.type;
     }
     this.setState({loading: true});
-    ProductBackend.getProducts("", params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
+    ProductBackend.getProducts(Setting.isAdminUser(this.props.account) ? "" : this.props.account.owner, params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
       .then((res) => {
         if (res.status === "ok") {
           this.setState({

--- a/web/src/ProviderListPage.js
+++ b/web/src/ProviderListPage.js
@@ -111,7 +111,7 @@ class ProviderListPage extends BaseListPage {
         key: "owner",
         width: "150px",
         sorter: true,
-        ...this.getColumnSearchProps("owner"),
+        ...this.getColumnSearchProps("organization"),
       },
       {
         title: i18next.t("general:Created time"),
@@ -210,6 +210,7 @@ class ProviderListPage extends BaseListPage {
               <PopconfirmModal
                 title={i18next.t("general:Sure to delete") + `: ${record.name} ?`}
                 onConfirm={() => this.deleteProvider(index)}
+                disabled={!Setting.isAdminUser(this.props.account) && (record.owner !== this.props.account.owner)}
               >
               </PopconfirmModal>
             </div>
@@ -253,7 +254,7 @@ class ProviderListPage extends BaseListPage {
     }
     this.setState({loading: true});
     (Setting.isAdminUser(this.props.account) ? ProviderBackend.getGlobalProviders(params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
-      : ProviderBackend.getProviders(this.state.owner, params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder))
+      : ProviderBackend.getProviders(this.props.account.owner, params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder))
       .then((res) => {
         if (res.status === "ok") {
           this.setState({

--- a/web/src/RecordListPage.js
+++ b/web/src/RecordListPage.js
@@ -175,7 +175,7 @@ class RecordListPage extends BaseListPage {
     ];
 
     if (Setting.isLocalAdminUser(this.props.account)) {
-      columns = columns.filter(column => column.key !== "name" && column.key !== "organization");
+      columns = columns.filter(column => column.key !== "name");
     }
 
     const paginationProps = {

--- a/web/src/ResourceListPage.js
+++ b/web/src/ResourceListPage.js
@@ -288,7 +288,7 @@ class ResourceListPage extends BaseListPage {
     const field = params.searchedColumn, value = params.searchText;
     const sortField = params.sortField, sortOrder = params.sortOrder;
     this.setState({loading: true});
-    ResourceBackend.getResources(this.props.account.owner, this.props.account.name, params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
+    ResourceBackend.getResources("admin", this.props.account.name, params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
       .then((res) => {
         if (res.status === "ok") {
           this.setState({

--- a/web/src/RoleEditPage.js
+++ b/web/src/RoleEditPage.js
@@ -111,7 +111,7 @@ class RoleEditPage extends React.Component {
             {Setting.getLabel(i18next.t("general:Organization"), i18next.t("general:Organization - Tooltip"))} :
           </Col>
           <Col span={22} >
-            <Select virtual={false} style={{width: "100%"}} value={this.state.role.owner} onChange={(value => {this.updateRoleField("owner", value);})}
+            <Select virtual={false} style={{width: "100%"}} disabled={!Setting.isAdminUser(this.props.account)} value={this.state.role.owner} onChange={(value => {this.updateRoleField("owner", value);})}
               options={this.state.organizations.map((organization) => Setting.getOption(organization.name, organization.name))
               } />
           </Col>

--- a/web/src/SessionListPage.js
+++ b/web/src/SessionListPage.js
@@ -134,7 +134,7 @@ class SessionListPage extends BaseListPage {
       value = params.contentType;
     }
     this.setState({loading: true});
-    SessionBackend.getSessions("", params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
+    SessionBackend.getSessions(Setting.isAdminUser(this.props.account) ? "" : this.props.account.owner, params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
       .then((res) => {
         if (res.status === "ok") {
           this.setState({

--- a/web/src/SyncerEditPage.js
+++ b/web/src/SyncerEditPage.js
@@ -186,7 +186,7 @@ class SyncerEditPage extends React.Component {
             {Setting.getLabel(i18next.t("general:Organization"), i18next.t("general:Organization - Tooltip"))} :
           </Col>
           <Col span={22} >
-            <Select virtual={false} style={{width: "100%"}} value={this.state.syncer.organization} onChange={(value => {this.updateSyncerField("organization", value);})}>
+            <Select virtual={false} style={{width: "100%"}} disabled={!Setting.isAdminUser(this.props.account)} value={this.state.syncer.organization} onChange={(value => {this.updateSyncerField("organization", value);})}>
               {
                 this.state.organizations.map((organization, index) => <Option key={index} value={organization.name}>{organization.name}</Option>)
               }

--- a/web/src/SyncerListPage.js
+++ b/web/src/SyncerListPage.js
@@ -29,7 +29,7 @@ class SyncerListPage extends BaseListPage {
       owner: "admin",
       name: `syncer_${randomName}`,
       createdTime: moment().format(),
-      organization: "built-in",
+      organization: this.props.account.owner,
       type: "Database",
       host: "localhost",
       port: 3306,
@@ -275,7 +275,7 @@ class SyncerListPage extends BaseListPage {
       value = params.type;
     }
     this.setState({loading: true});
-    SyncerBackend.getSyncers("admin", params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
+    SyncerBackend.getSyncers("admin", Setting.isAdminUser(this.props.account) ? "" : this.props.account.owner, params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
       .then((res) => {
         if (res.status === "ok") {
           this.setState({

--- a/web/src/SystemInfo.js
+++ b/web/src/SystemInfo.js
@@ -33,14 +33,14 @@ class SystemInfo extends React.Component {
   }
 
   UNSAFE_componentWillMount() {
-    SystemBackend.getSystemInfo().then(res => {
+    SystemBackend.getSystemInfo("").then(res => {
       this.setState({
         systemInfo: res.data,
         loading: false,
       });
 
       const id = setInterval(() => {
-        SystemBackend.getSystemInfo().then(res => {
+        SystemBackend.getSystemInfo("").then(res => {
           this.setState({
             systemInfo: res.data,
           });

--- a/web/src/TokenEditPage.js
+++ b/web/src/TokenEditPage.js
@@ -94,7 +94,7 @@ class TokenEditPage extends React.Component {
             {i18next.t("general:Organization")}:
           </Col>
           <Col span={22} >
-            <Input value={this.state.token.organization} onChange={e => {
+            <Input disabled={!Setting.isAdminUser(this.props.account)} value={this.state.token.organization} onChange={e => {
               this.updateTokenField("organization", e.target.value);
             }} />
           </Col>

--- a/web/src/TokenListPage.js
+++ b/web/src/TokenListPage.js
@@ -30,7 +30,7 @@ class TokenListPage extends BaseListPage {
       name: `token_${randomName}`,
       createdTime: moment().format(),
       application: "app-built-in",
-      organization: "built-in",
+      organization: this.props.account.owner,
       user: "admin",
       accessToken: "",
       expiresIn: 7200,
@@ -240,7 +240,7 @@ class TokenListPage extends BaseListPage {
     const field = params.searchedColumn, value = params.searchText;
     const sortField = params.sortField, sortOrder = params.sortOrder;
     this.setState({loading: true});
-    TokenBackend.getTokens("admin", params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
+    TokenBackend.getTokens("admin", Setting.isAdminUser(this.props.account) ? "" : this.props.account.owner, params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
       .then((res) => {
         if (res.status === "ok") {
           this.setState({

--- a/web/src/WebhookEditPage.js
+++ b/web/src/WebhookEditPage.js
@@ -161,7 +161,7 @@ class WebhookEditPage extends React.Component {
             {Setting.getLabel(i18next.t("general:Organization"), i18next.t("general:Organization - Tooltip"))} :
           </Col>
           <Col span={22} >
-            <Select virtual={false} style={{width: "100%"}} value={this.state.webhook.organization} onChange={(value => {this.updateWebhookField("organization", value);})}>
+            <Select virtual={false} style={{width: "100%"}} disabled={!Setting.isAdminUser(this.props.account)} value={this.state.webhook.organization} onChange={(value => {this.updateWebhookField("organization", value);})}>
               {
                 this.state.organizations.map((organization, index) => <Option key={index} value={organization.name}>{organization.name}</Option>)
               }

--- a/web/src/WebhookListPage.js
+++ b/web/src/WebhookListPage.js
@@ -29,7 +29,7 @@ class WebhookListPage extends BaseListPage {
       owner: "admin", // this.props.account.webhookname,
       name: `webhook_${randomName}`,
       createdTime: moment().format(),
-      organization: "built-in",
+      organization: this.props.account.owner,
       url: "https://example.com/callback",
       method: "POST",
       contentType: "application/json",
@@ -240,7 +240,7 @@ class WebhookListPage extends BaseListPage {
       value = params.contentType;
     }
     this.setState({loading: true});
-    WebhookBackend.getWebhooks("admin", params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
+    WebhookBackend.getWebhooks("admin", Setting.isAdminUser(this.props.account) ? "" : this.props.account.owner, params.pagination.current, params.pagination.pageSize, field, value, sortField, sortOrder)
       .then((res) => {
         if (res.status === "ok") {
           this.setState({

--- a/web/src/backend/AdapterBackend.js
+++ b/web/src/backend/AdapterBackend.js
@@ -14,8 +14,8 @@
 
 import * as Setting from "../Setting";
 
-export function getAdapters(owner, page = "", pageSize = "", field = "", value = "", sortField = "", sortOrder = "") {
-  return fetch(`${Setting.ServerUrl}/api/get-adapters?owner=${owner}&p=${page}&pageSize=${pageSize}&field=${field}&value=${value}&sortField=${sortField}&sortOrder=${sortOrder}`, {
+export function getAdapters(owner, organization, page = "", pageSize = "", field = "", value = "", sortField = "", sortOrder = "") {
+  return fetch(`${Setting.ServerUrl}/api/get-adapters?owner=${owner}&organization=${organization}&p=${page}&pageSize=${pageSize}&field=${field}&value=${value}&sortField=${sortField}&sortOrder=${sortOrder}`, {
     method: "GET",
     credentials: "include",
     headers: {

--- a/web/src/backend/CertBackend.js
+++ b/web/src/backend/CertBackend.js
@@ -24,6 +24,16 @@ export function getCerts(owner, page = "", pageSize = "", field = "", value = ""
   }).then(res => res.json());
 }
 
+export function getGlobleCerts(page = "", pageSize = "", field = "", value = "", sortField = "", sortOrder = "") {
+  return fetch(`${Setting.ServerUrl}/api/get-globle-certs?&p=${page}&pageSize=${pageSize}&field=${field}&value=${value}&sortField=${sortField}&sortOrder=${sortOrder}`, {
+    method: "GET",
+    credentials: "include",
+    headers: {
+      "Accept-Language": Setting.getAcceptLanguage(),
+    },
+  }).then(res => res.json());
+}
+
 export function getCert(owner, name) {
   return fetch(`${Setting.ServerUrl}/api/get-cert?id=${owner}/${encodeURIComponent(name)}`, {
     method: "GET",

--- a/web/src/backend/MessageBackend.js
+++ b/web/src/backend/MessageBackend.js
@@ -14,8 +14,8 @@
 
 import * as Setting from "../Setting";
 
-export function getMessages(owner, page = "", pageSize = "", field = "", value = "", sortField = "", sortOrder = "") {
-  return fetch(`${Setting.ServerUrl}/api/get-messages?owner=${owner}&p=${page}&pageSize=${pageSize}&field=${field}&value=${value}&sortField=${sortField}&sortOrder=${sortOrder}`, {
+export function getMessages(owner, organization, page = "", pageSize = "", field = "", value = "", sortField = "", sortOrder = "") {
+  return fetch(`${Setting.ServerUrl}/api/get-messages?owner=${owner}&organization=${organization}&p=${page}&pageSize=${pageSize}&field=${field}&value=${value}&sortField=${sortField}&sortOrder=${sortOrder}`, {
     method: "GET",
     credentials: "include",
     headers: {

--- a/web/src/backend/SyncerBackend.js
+++ b/web/src/backend/SyncerBackend.js
@@ -14,8 +14,8 @@
 
 import * as Setting from "../Setting";
 
-export function getSyncers(owner, page = "", pageSize = "", field = "", value = "", sortField = "", sortOrder = "") {
-  return fetch(`${Setting.ServerUrl}/api/get-syncers?owner=${owner}&p=${page}&pageSize=${pageSize}&field=${field}&value=${value}&sortField=${sortField}&sortOrder=${sortOrder}`, {
+export function getSyncers(owner, organization, page = "", pageSize = "", field = "", value = "", sortField = "", sortOrder = "") {
+  return fetch(`${Setting.ServerUrl}/api/get-syncers?owner=${owner}&organization=${organization}&p=${page}&pageSize=${pageSize}&field=${field}&value=${value}&sortField=${sortField}&sortOrder=${sortOrder}`, {
     method: "GET",
     credentials: "include",
     headers: {

--- a/web/src/backend/TokenBackend.js
+++ b/web/src/backend/TokenBackend.js
@@ -14,8 +14,8 @@
 
 import * as Setting from "../Setting";
 
-export function getTokens(owner, page = "", pageSize = "", field = "", value = "", sortField = "", sortOrder = "") {
-  return fetch(`${Setting.ServerUrl}/api/get-tokens?owner=${owner}&p=${page}&pageSize=${pageSize}&field=${field}&value=${value}&sortField=${sortField}&sortOrder=${sortOrder}`, {
+export function getTokens(owner, organization = "", page = "", pageSize = "", field = "", value = "", sortField = "", sortOrder = "") {
+  return fetch(`${Setting.ServerUrl}/api/get-tokens?owner=${owner}&organization=${organization}&p=${page}&pageSize=${pageSize}&field=${field}&value=${value}&sortField=${sortField}&sortOrder=${sortOrder}`, {
     method: "GET",
     credentials: "include",
     headers: {

--- a/web/src/backend/WebhookBackend.js
+++ b/web/src/backend/WebhookBackend.js
@@ -14,8 +14,8 @@
 
 import * as Setting from "../Setting";
 
-export function getWebhooks(owner, page = "", pageSize = "", field = "", value = "", sortField = "", sortOrder = "") {
-  return fetch(`${Setting.ServerUrl}/api/get-webhooks?owner=${owner}&p=${page}&pageSize=${pageSize}&field=${field}&value=${value}&sortField=${sortField}&sortOrder=${sortOrder}`, {
+export function getWebhooks(owner, organization, page = "", pageSize = "", field = "", value = "", sortField = "", sortOrder = "") {
+  return fetch(`${Setting.ServerUrl}/api/get-webhooks?owner=${owner}&organization=${organization}&p=${page}&pageSize=${pageSize}&field=${field}&value=${value}&sortField=${sortField}&sortOrder=${sortOrder}`, {
     method: "GET",
     credentials: "include",
     headers: {


### PR DESCRIPTION
Fix  #1266 
Corrected the org admin's permission issue. All resources can now be accessed normally except for "resource". The video includes three organizations: `built-in`, `org1`, and `org2`; and four users: `admin`, `admin1`, `admin2`, and `admin3`. `admin` is global admin, `admin1` and `admin3` are the org1's org admin, while `admin2` is org2's org admin. The video mainly demonstrates the following:

1. Org admin can manage their own organization's resources.
2. Org admin cannot manage resources of other organizations.
3. Global admin can manage resources of all organizations.

https://user-images.githubusercontent.com/34300181/236816223-619470eb-d835-48d8-8acb-e657a06b4ef4.mp4