### PR TITLE
feat: enforce by using resourceId

### DIFF
--- a/controllers/enforcer.go
+++ b/controllers/enforcer.go
@@ -37,8 +37,8 @@ func (c *ApiController) Enforce() {
 		c.Data["json"] = object.Enforce(permissionId, &request)
 		c.ServeJSON()
 		return
-	} 
-	
+	}
+
 	permissions := make([]*object.Permission, 0)
 	res := []bool{}
 

--- a/controllers/enforcer.go
+++ b/controllers/enforcer.go
@@ -24,6 +24,7 @@ import (
 func (c *ApiController) Enforce() {
 	permissionId := c.Input().Get("permissionId")
 	modelId := c.Input().Get("modelId")
+	resourceId := c.Input().Get("resourceId")
 
 	var request object.CasbinRequest
 	err := json.Unmarshal(c.Ctx.Input.RequestBody, &request)
@@ -35,17 +36,24 @@ func (c *ApiController) Enforce() {
 	if permissionId != "" {
 		c.Data["json"] = object.Enforce(permissionId, &request)
 		c.ServeJSON()
-	} else {
-		owner, modelName := util.GetOwnerAndNameFromId(modelId)
-		permissions := object.GetPermissionsByModel(owner, modelName)
+		return
+	} 
+	
+	permissions := make([]*object.Permission, 0)
+	res := []bool{}
 
-		res := []bool{}
-		for _, permission := range permissions {
-			res = append(res, object.Enforce(permission.GetId(), &request))
-		}
-		c.Data["json"] = res
-		c.ServeJSON()
+	if modelId != "" {
+		owner, modelName := util.GetOwnerAndNameFromId(modelId)
+		permissions = object.GetPermissionsByModel(owner, modelName)
+	} else {
+		permissions = object.GetPermissionsByResource(resourceId)
 	}
+
+	for _, permission := range permissions {
+		res = append(res, object.Enforce(permission.GetId(), &request))
+	}
+	c.Data["json"] = res
+	c.ServeJSON()
 }
 
 func (c *ApiController) BatchEnforce() {

--- a/object/permission.go
+++ b/object/permission.go
@@ -15,9 +15,8 @@
 package object
 
 import (
-	"github.com/xorm-io/core"
-
 	"github.com/casdoor/casdoor/util"
+	"github.com/xorm-io/core"
 )
 
 type Permission struct {

--- a/object/permission.go
+++ b/object/permission.go
@@ -15,8 +15,9 @@
 package object
 
 import (
-	"github.com/casdoor/casdoor/util"
 	"github.com/xorm-io/core"
+
+	"github.com/casdoor/casdoor/util"
 )
 
 type Permission struct {
@@ -228,6 +229,16 @@ func GetPermissionsByUser(userId string) []*Permission {
 func GetPermissionsByRole(roleId string) []*Permission {
 	permissions := []*Permission{}
 	err := adapter.Engine.Where("roles like ?", "%"+roleId+"\"%").Find(&permissions)
+	if err != nil {
+		panic(err)
+	}
+
+	return permissions
+}
+
+func GetPermissionsByResource(resourceId string) []*Permission {
+	permissions := []*Permission{}
+	err := adapter.Engine.Where("resources like ?", "%"+resourceId+"\"%").Find(&permissions)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/1846

This PR adds param `resourceId` into `POST /api/enforce` API to allow enforce permission based on `resource`. Which will allow other 3rd services or SDK check whether user has permission to access a resource or not.