### PR TITLE
ci: add partial admin feature for managing specific organizations

### DIFF
--- a/controllers/user.go
+++ b/controllers/user.go
@@ -37,6 +37,7 @@ func (c *ApiController) GetGlobalUsers() {
 	value := c.Input().Get("value")
 	sortField := c.Input().Get("sortField")
 	sortOrder := c.Input().Get("sortOrder")
+	userId := c.GetSessionUsername()
 
 	if limit == "" || page == "" {
 		maskedUsers, err := object.GetMaskedUsers(object.GetGlobalUsers())
@@ -67,6 +68,7 @@ func (c *ApiController) GetGlobalUsers() {
 			return
 		}
 
+		users = object.GetFilteredUsers(users, userId)
 		c.ResponseOk(users, paginator.Nums())
 	}
 }

--- a/object/organization.go
+++ b/object/organization.go
@@ -468,3 +468,17 @@ func (org *Organization) GetInitScore() (int, error) {
 		return strconv.Atoi(conf.GetConfigString("initScore"))
 	}
 }
+
+func GetOrgnizationNameMap(userId string) map[string]bool {
+	orgNameMap := map[string]bool{}
+	if userId != "" {
+		permissions := GetOrgPermissionsByUser(userId)
+		for _, permission := range permissions {
+			for _, resource := range permission.Resources {
+				orgNameMap[resource] = true
+			}
+		}
+	}
+
+	return orgNameMap
+}

--- a/object/permission.go
+++ b/object/permission.go
@@ -297,6 +297,16 @@ func GetPermissionsByResource(resourceId string) ([]*Permission, error) {
 	return permissions, nil
 }
 
+func GetOrgPermissionsByUser(userId string) []*Permission {
+	permissions := []*Permission{}
+	err := adapter.Engine.Where("users like ? and resource_type = ?", "%"+userId+"%", "organization").Find(&permissions)
+	if err != nil {
+		panic(err)
+	}
+
+	return permissions
+}
+
 func GetPermissionsBySubmitter(owner string, submitter string) ([]*Permission, error) {
 	permissions := []*Permission{}
 	err := adapter.Engine.Desc("created_time").Find(&permissions, &Permission{Owner: owner, Submitter: submitter})

--- a/object/user.go
+++ b/object/user.go
@@ -426,6 +426,20 @@ func GetMaskedUsers(users []*User, errs ...error) ([]*User, error) {
 	return users, nil
 }
 
+func GetFilteredUsers(users []*User, userId string) []*User {
+	if userId == "built-in/admin" {
+		return users
+	}
+	filteredUsers := make([]*User, 0, len(users))
+	orgNameMap := GetOrgnizationNameMap(userId)
+	for _, user := range users {
+		if orgNameMap[user.Owner] {
+			filteredUsers = append(filteredUsers, user)
+		}
+	}
+	return filteredUsers
+}
+
 func GetLastUser(owner string) (*User, error) {
 	user := User{Owner: owner}
 	existed, err := adapter.Engine.Desc("created_time", "id").Get(&user)

--- a/web/src/PermissionEditPage.js
+++ b/web/src/PermissionEditPage.js
@@ -257,6 +257,7 @@ class PermissionEditPage extends React.Component {
             })}
             options={[
               {value: "Application", name: i18next.t("general:Application")},
+              {value: "Organization", name: i18next.t("general:Organization")},
               {value: "TreeNode", name: i18next.t("permission:TreeNode")},
             ].map((item) => Setting.getOption(item.name, item.value))}
             />
@@ -269,7 +270,12 @@ class PermissionEditPage extends React.Component {
           <Col span={22} >
             <Select virtual={false} mode="tags" style={{width: "100%"}} value={this.state.permission.resources}
               onChange={(value => {this.updatePermissionField("resources", value);})}
-              options={this.state.resources.map((resource) => Setting.getOption(`${resource.name}`, `${resource.name}`))
+              options={
+                this.state.permission.resourceType === "Application" ?
+                  this.state.resources.map((resource) => Setting.getOption(`${resource.name}`, `${resource.name}`)) :
+                  this.state.permission.resourceType === "Organization" ?
+                    this.state.organizations.map((resource) => Setting.getOption(`${resource.name}`, `${resource.name}`)) :
+                    []
               } />
           </Col>
         </Row>


### PR DESCRIPTION
feat #1824

The video demonstrates the following:
There are three organizations: `built-in`, `org1`, and `org2`. There are four users: `admin`, `adminSub`, `admin1`, and `admin2`. `admin` is a globalAdmin, `adminSub` is an admin who can manage `org1` and `built-in` organizations, and `admin1` and `admin2` are local admins of `org1` and `org2` respectively.

The access to user page has been modified using the filter approach, and the video demonstrated the CRUD operations of user page. The video showed that the `admin` can manage the user page of all orgs, while the `adminSub` can only manage the user page of `org1` and `built-in`. 



https://github.com/casdoor/casdoor/assets/34300181/14df0860-4808-4847-8355-fc2492310d22











