### PR TITLE
fix：sticky column cover other column 

### DIFF
--- a/web/src/ChatListPage.js
+++ b/web/src/ChatListPage.js
@@ -82,6 +82,7 @@ class ChatListPage extends BaseListPage {
         dataIndex: "organization",
         key: "organization",
         width: "150px",
+        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("organization"),
         render: (text, record, index) => {
@@ -165,7 +166,6 @@ class ChatListPage extends BaseListPage {
         dataIndex: "user1",
         key: "user1",
         width: "120px",
-        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("user1"),
         render: (text, record, index) => {
@@ -181,7 +181,6 @@ class ChatListPage extends BaseListPage {
         dataIndex: "user2",
         key: "user2",
         width: "120px",
-        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("user2"),
         render: (text, record, index) => {

--- a/web/src/MessageListPage.js
+++ b/web/src/MessageListPage.js
@@ -78,6 +78,7 @@ class MessageListPage extends BaseListPage {
         dataIndex: "organization",
         key: "organization",
         width: "150px",
+        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("organization"),
         render: (text, record, index) => {
@@ -119,7 +120,6 @@ class MessageListPage extends BaseListPage {
         dataIndex: "chat",
         key: "chat",
         width: "120px",
-        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("chat"),
         render: (text, record, index) => {
@@ -135,7 +135,6 @@ class MessageListPage extends BaseListPage {
         dataIndex: "author",
         key: "author",
         width: "120px",
-        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("author"),
         render: (text, record, index) => {


### PR DESCRIPTION
Fix: #1914
1.First column add fixed attribute
2.right fixed column properties
Before
![1685600981221](https://github.com/casdoor/casdoor/assets/82175017/96229e6b-534a-4424-a483-56595ae51388)
![1685601606215](https://github.com/casdoor/casdoor/assets/82175017/912d77fb-b702-4326-906b-e2c5310bbcbf)
After
![1685601915710](https://github.com/casdoor/casdoor/assets/82175017/2ee20ac2-8c69-4aad-bc96-94d47350b558)
![1685601021235](https://github.com/casdoor/casdoor/assets/82175017/260e9e2f-8530-4383-8a5b-1cd00e60781f)
