### PR TITLE
fix: modify sticky column on chat and message pages

### DIFF
--- a/web/src/ChatListPage.js
+++ b/web/src/ChatListPage.js
@@ -82,6 +82,7 @@ class ChatListPage extends BaseListPage {
         dataIndex: "organization",
         key: "organization",
         width: "150px",
+        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("organization"),
         render: (text, record, index) => {
@@ -165,7 +166,6 @@ class ChatListPage extends BaseListPage {
         dataIndex: "user1",
         key: "user1",
         width: "120px",
-        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("user1"),
         render: (text, record, index) => {
@@ -181,7 +181,6 @@ class ChatListPage extends BaseListPage {
         dataIndex: "user2",
         key: "user2",
         width: "120px",
-        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("user2"),
         render: (text, record, index) => {

--- a/web/src/MessageListPage.js
+++ b/web/src/MessageListPage.js
@@ -78,6 +78,7 @@ class MessageListPage extends BaseListPage {
         dataIndex: "organization",
         key: "organization",
         width: "150px",
+        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("organization"),
         render: (text, record, index) => {
@@ -119,7 +120,6 @@ class MessageListPage extends BaseListPage {
         dataIndex: "chat",
         key: "chat",
         width: "120px",
-        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("chat"),
         render: (text, record, index) => {
@@ -135,7 +135,6 @@ class MessageListPage extends BaseListPage {
         dataIndex: "author",
         key: "author",
         width: "120px",
-        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("author"),
         render: (text, record, index) => {


### PR DESCRIPTION
fix: #1914
modify sticky column on chat and message pages
Before
![1685600981221](https://github.com/casdoor/casdoor/assets/82175017/40f99d60-3aee-4318-be99-8c44d0a2a249)
![1685601606215](https://github.com/casdoor/casdoor/assets/82175017/3bf79503-76a8-47a3-a24f-ad01471d2d7f)
After
![1685600937020](https://github.com/casdoor/casdoor/assets/82175017/a040879b-f11f-4244-8d43-43d7af66b1de)
![1685601021235](https://github.com/casdoor/casdoor/assets/82175017/22a20603-2f05-465d-868a-458f6dd89967)
