### PR TITLE
fix: modify sticky column on chat and message pages

### DIFF
--- a/web/src/ChatListPage.js
+++ b/web/src/ChatListPage.js
@@ -82,6 +82,7 @@ class ChatListPage extends BaseListPage {
         dataIndex: "organization",
         key: "organization",
         width: "150px",
+        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("organization"),
         render: (text, record, index) => {
@@ -165,7 +166,6 @@ class ChatListPage extends BaseListPage {
         dataIndex: "user1",
         key: "user1",
         width: "120px",
-        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("user1"),
         render: (text, record, index) => {
@@ -181,7 +181,6 @@ class ChatListPage extends BaseListPage {
         dataIndex: "user2",
         key: "user2",
         width: "120px",
-        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("user2"),
         render: (text, record, index) => {

--- a/web/src/MessageListPage.js
+++ b/web/src/MessageListPage.js
@@ -78,6 +78,7 @@ class MessageListPage extends BaseListPage {
         dataIndex: "organization",
         key: "organization",
         width: "150px",
+        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("organization"),
         render: (text, record, index) => {
@@ -119,7 +120,6 @@ class MessageListPage extends BaseListPage {
         dataIndex: "chat",
         key: "chat",
         width: "120px",
-        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("chat"),
         render: (text, record, index) => {
@@ -135,7 +135,6 @@ class MessageListPage extends BaseListPage {
         dataIndex: "author",
         key: "author",
         width: "120px",
-        fixed: "left",
         sorter: true,
         ...this.getColumnSearchProps("author"),
         render: (text, record, index) => {


### PR DESCRIPTION
fix: #1914
modify sticky column on chat and message pages
Before
![1685601606215](https://github.com/casdoor/casdoor/assets/82175017/5a5dd830-1a83-4111-9da5-cc34811b25ce)
![1685601611992](https://github.com/casdoor/casdoor/assets/82175017/cecfc1e0-8734-4cca-997c-b273e18846f3)
After
![1685600937020](https://github.com/casdoor/casdoor/assets/82175017/ef918735-784d-47ff-a4e4-2b976756b8f7)
![1685601021235](https://github.com/casdoor/casdoor/assets/82175017/0961dbb1-1ff5-4a8a-a32d-9ff32e8436ce)
