### PR TITLE
feat: fix error without setting syner

### DIFF
--- a/object/syncer_public_api.go
+++ b/object/syncer_public_api.go
@@ -50,6 +50,9 @@ func getEnabledSyncerForOrganization(organization string) (*Syncer, error) {
 func AddUserToOriginalDatabase(user *User) error {
 	syncer, err := getEnabledSyncerForOrganization(user.Owner)
 	if syncer == nil {
+		return nil
+	}
+	if err != nil {
 		return err
 	}
 
@@ -66,6 +69,9 @@ func AddUserToOriginalDatabase(user *User) error {
 func UpdateUserToOriginalDatabase(user *User) error {
 	syncer, err := getEnabledSyncerForOrganization(user.Owner)
 	if syncer == nil {
+		return nil
+	}
+	if err != nil {
 		return err
 	}
 

--- a/object/syncer_public_api.go
+++ b/object/syncer_public_api.go
@@ -15,7 +15,6 @@
 package object
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -45,12 +44,12 @@ func getEnabledSyncerForOrganization(organization string) (*Syncer, error) {
 			return syncer, nil
 		}
 	}
-	return nil, errors.New("no enabled syncer found")
+	return nil, nil
 }
 
 func AddUserToOriginalDatabase(user *User) error {
 	syncer, err := getEnabledSyncerForOrganization(user.Owner)
-	if err != nil {
+	if syncer == nil {
 		return err
 	}
 
@@ -66,7 +65,7 @@ func AddUserToOriginalDatabase(user *User) error {
 
 func UpdateUserToOriginalDatabase(user *User) error {
 	syncer, err := getEnabledSyncerForOrganization(user.Owner)
-	if err != nil {
+	if syncer == nil {
 		return err
 	}
 

--- a/object/user_cred.go
+++ b/object/user_cred.go
@@ -19,6 +19,9 @@ import "github.com/casdoor/casdoor/cred"
 func calculateHash(user *User) (string, error) {
 	syncer, err := getDbSyncerForUser(user)
 	if syncer == nil {
+		return "", nil
+	}
+	if err != nil {
 		return "", err
 	}
 

--- a/object/user_cred.go
+++ b/object/user_cred.go
@@ -18,12 +18,8 @@ import "github.com/casdoor/casdoor/cred"
 
 func calculateHash(user *User) (string, error) {
 	syncer, err := getDbSyncerForUser(user)
-	if err != nil {
-		return "", err
-	}
-
 	if syncer == nil {
-		return "", nil
+		return "", err
 	}
 
 	return syncer.calculateHash(user), nil


### PR DESCRIPTION
fix: #1924

If the organization don't have syner,  when update user it reports error. Now, if syner is nil, it doesn't return err