### PR TITLE
Customization of the initialization file

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -22,3 +22,4 @@ batchSize = 100
 ldapServerPort = 389
 quota = {"organization": -1, "user": -1, "application": -1, "provider": -1}
 logConfig = {"filename": "logs/casdoor.log", "maxdays":99999, "perm":"0770"}
+initDataFile = "./init_data.json"

--- a/object/init_data.go
+++ b/object/init_data.go
@@ -14,7 +14,10 @@
 
 package object
 
-import "github.com/casdoor/casdoor/util"
+import (
+	"github.com/casdoor/casdoor/conf"
+	"github.com/casdoor/casdoor/util"
+)
 
 type InitData struct {
 	Organizations []*Organization `json:"organizations"`
@@ -35,7 +38,12 @@ type InitData struct {
 }
 
 func InitFromFile() {
-	initData, err := readInitDataFromFile("./init_data.json")
+	initDataFile := conf.GetConfigString("initDataFile")
+	if initDataFile == "" {
+		return
+	}
+
+	initData, err := readInitDataFromFile(initDataFile)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This simple fix allows you to install the initialization file in the configuration file.
Default behavior does not change.
Customization of the definition of "init_data.json" is convenient for me because it is explicitly defined.