### PR TITLE
feat: add s3ForcePathStyle for storage provider

### DIFF
--- a/deployment/deploy.go
+++ b/deployment/deploy.go
@@ -26,7 +26,7 @@ import (
 )
 
 func deployStaticFiles(provider *object.Provider) {
-	storageProvider := storage.GetStorageProvider(provider.Type, provider.ClientId, provider.ClientSecret, provider.RegionId, provider.Bucket, provider.Endpoint)
+	storageProvider := storage.GetStorageProvider(provider.Type, provider.ClientId, provider.ClientSecret, provider.RegionId, provider.Bucket, provider.Endpoint, provider.S3ForcePathStyle)
 	if storageProvider == nil {
 		panic(fmt.Sprintf("the provider type: %s is not supported", provider.Type))
 	}

--- a/object/provider.go
+++ b/object/provider.go
@@ -61,6 +61,7 @@ type Provider struct {
 	Domain           string `xorm:"varchar(100)" json:"domain"`
 	Bucket           string `xorm:"varchar(100)" json:"bucket"`
 	PathPrefix       string `xorm:"varchar(100)" json:"pathPrefix"`
+	S3ForcePathStyle bool   `json:"s3ForcePathStyle"`
 
 	Metadata               string `xorm:"mediumtext" json:"metadata"`
 	IdP                    string `xorm:"mediumtext" json:"idP"`

--- a/object/storage.go
+++ b/object/storage.go
@@ -104,7 +104,7 @@ func GetUploadFileUrl(provider *Provider, fullFilePath string, hasTimestamp bool
 
 func uploadFile(provider *Provider, fullFilePath string, fileBuffer *bytes.Buffer, lang string) (string, string, error) {
 	endpoint := getProviderEndpoint(provider)
-	storageProvider := storage.GetStorageProvider(provider.Type, provider.ClientId, provider.ClientSecret, provider.RegionId, provider.Bucket, endpoint)
+	storageProvider := storage.GetStorageProvider(provider.Type, provider.ClientId, provider.ClientSecret, provider.RegionId, provider.Bucket, endpoint, provider.S3ForcePathStyle)
 	if storageProvider == nil {
 		return "", "", fmt.Errorf(i18n.Translate(lang, "storage:The provider type: %s is not supported"), provider.Type)
 	}
@@ -155,7 +155,7 @@ func DeleteFile(provider *Provider, objectKey string, lang string) error {
 	}
 
 	endpoint := getProviderEndpoint(provider)
-	storageProvider := storage.GetStorageProvider(provider.Type, provider.ClientId, provider.ClientSecret, provider.RegionId, provider.Bucket, endpoint)
+	storageProvider := storage.GetStorageProvider(provider.Type, provider.ClientId, provider.ClientSecret, provider.RegionId, provider.Bucket, endpoint, provider.S3ForcePathStyle)
 	if storageProvider == nil {
 		return fmt.Errorf(i18n.Translate(lang, "storage:The provider type: %s is not supported"), provider.Type)
 	}

--- a/storage/minio_s3.go
+++ b/storage/minio_s3.go
@@ -20,7 +20,7 @@ import (
 	"github.com/casdoor/oss/s3"
 )
 
-func NewMinIOS3StorageProvider(clientId string, clientSecret string, region string, bucket string, endpoint string) oss.StorageInterface {
+func NewMinIOS3StorageProvider(clientId string, clientSecret string, region string, bucket string, endpoint string, s3ForcePathStyle bool) oss.StorageInterface {
 	sp := s3.New(&s3.Config{
 		AccessID:         clientId,
 		AccessKey:        clientSecret,
@@ -29,7 +29,7 @@ func NewMinIOS3StorageProvider(clientId string, clientSecret string, region stri
 		Endpoint:         endpoint,
 		S3Endpoint:       endpoint,
 		ACL:              awss3.BucketCannedACLPublicRead,
-		S3ForcePathStyle: false,
+		S3ForcePathStyle: s3ForcePathStyle,
 	})
 
 	return sp

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -16,14 +16,14 @@ package storage
 
 import "github.com/casdoor/oss"
 
-func GetStorageProvider(providerType string, clientId string, clientSecret string, region string, bucket string, endpoint string) oss.StorageInterface {
+func GetStorageProvider(providerType string, clientId string, clientSecret string, region string, bucket string, endpoint string, s3ForcePathStyle bool) oss.StorageInterface {
 	switch providerType {
 	case "Local File System":
 		return NewLocalFileSystemStorageProvider(clientId, clientSecret, region, bucket, endpoint)
 	case "AWS S3":
 		return NewAwsS3StorageProvider(clientId, clientSecret, region, bucket, endpoint)
 	case "MinIO":
-		return NewMinIOS3StorageProvider(clientId, clientSecret, region, bucket, endpoint)
+		return NewMinIOS3StorageProvider(clientId, clientSecret, region, bucket, endpoint, s3ForcePathStyle)
 	case "Aliyun OSS":
 		return NewAliyunOssStorageProvider(clientId, clientSecret, region, bucket, endpoint)
 	case "Tencent Cloud COS":

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -631,7 +631,7 @@ class ProviderEditPage extends React.Component {
             {["MinIO"].includes(this.state.provider.type) ? (
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={2}>
-                  {Setting.getLabel(i18next.t("provider:Force Path Style"), i18next.t("provider:Force Path Style - Tooltip"))} :
+                  {Setting.getLabel(i18next.t("provider:Force path style"), i18next.t("provider:Force path style - Tooltip"))} :
                 </Col>
                 <Col span={22} >
                   <Switch checked={this.state.provider.s3ForcePathStyle} onChange={checked => {

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -628,6 +628,18 @@ class ProviderEditPage extends React.Component {
                 </Col>
               </Row>
             ) : null}
+            {["MinIO"].includes(this.state.provider.type) ? (
+              <Row style={{marginTop: "20px"}} >
+                <Col style={{marginTop: "5px"}} span={2}>
+                  {Setting.getLabel(i18next.t("provider:Force Path Style"), i18next.t("provider:Force Path Style - Tooltip"))} :
+                </Col>
+                <Col span={22} >
+                  <Switch checked={this.state.provider.s3ForcePathStyle} onChange={checked => {
+                    this.updateProviderField("s3ForcePathStyle", checked);
+                  }} />
+                </Col>
+              </Row>
+            ) : null}
           </div>
         ) : null}
         {


### PR DESCRIPTION
fix #1974

This pr is related to the previous [one](https://github.com/casdoor/casdoor/pull/1818). The URL path for the MinIO storage provider has two styles, controlled by `s3ForcePathStyle`. When `s3ForcePathStyle` is true, the URL format is endpoint/bucket/xx. When `s3ForcePathStyle` is false, the URL format is bucket.endpoint/xx. To support both styles, users are allowed to modify `s3ForcePathStyle` themselves.