### PR TITLE
fix: fix "Accept-Language" parsing in request

### DIFF
--- a/controllers/util.go
+++ b/controllers/util.go
@@ -55,6 +55,9 @@ func (c *ApiController) T(error string) string {
 // GetAcceptLanguage ...
 func (c *ApiController) GetAcceptLanguage() string {
 	language := c.Ctx.Request.Header.Get("Accept-Language")
+	if len(language) > 2 {
+		language = language[0:2]
+	}
 	return conf.GetLanguage(language)
 }
 


### PR DESCRIPTION
## desc

fix to get the correct language from the content of "Accept-Language"

## when:
<html><head></head><body>

Accept-Language | zh;q=0.9,en;q=0.8
-- | --


</body></html>

## before:

`GetAcceptLanguage` always return `en`

## fixed:

`GetAcceptLanguage` will return the current language

