### PR TITLE
fix: add isReadOnly for syncer

### DIFF
--- a/object/syncer.go
+++ b/object/syncer.go
@@ -51,7 +51,7 @@ type Syncer struct {
 	ErrorText        string         `xorm:"mediumtext" json:"errorText"`
 	SyncInterval     int            `json:"syncInterval"`
 	IsEnabled        bool           `json:"isEnabled"`
-	ReadOnlyEnabled  bool           `json:"readOnlyEnabled"`
+	IsReadOnly       bool           `json:"isReadOnly"`
 
 	Adapter *Adapter `xorm:"-" json:"-"`
 }

--- a/object/syncer.go
+++ b/object/syncer.go
@@ -51,6 +51,7 @@ type Syncer struct {
 	ErrorText        string         `xorm:"mediumtext" json:"errorText"`
 	SyncInterval     int            `json:"syncInterval"`
 	IsEnabled        bool           `json:"isEnabled"`
+	ReadOnlyEnabled  bool           `json:"readOnlyEnabled"`
 
 	Adapter *Adapter `xorm:"-" json:"-"`
 }

--- a/object/syncer_sync.go
+++ b/object/syncer_sync.go
@@ -63,9 +63,11 @@ func (syncer *Syncer) syncUsers() {
 				}
 			} else {
 				if user.PreHash == oHash {
-					updatedOUser := syncer.createOriginalUserFromUser(user)
-					syncer.updateUser(updatedOUser)
-					fmt.Printf("Update from user to oUser: %v\n", updatedOUser)
+					if !syncer.ReadOnlyEnabled {
+						updatedOUser := syncer.createOriginalUserFromUser(user)
+						syncer.updateUser(updatedOUser)
+						fmt.Printf("Update from user to oUser: %v\n", updatedOUser)
+					}
 
 					// update preHash
 					user.PreHash = user.Hash
@@ -91,15 +93,17 @@ func (syncer *Syncer) syncUsers() {
 		panic(err)
 	}
 
-	for _, user := range users {
-		id := user.Id
-		if _, ok := oUserMap[id]; !ok {
-			newOUser := syncer.createOriginalUserFromUser(user)
-			_, err = syncer.addUser(newOUser)
-			if err != nil {
-				panic(err)
+	if !syncer.ReadOnlyEnabled {
+		for _, user := range users {
+			id := user.Id
+			if _, ok := oUserMap[id]; !ok {
+				newOUser := syncer.createOriginalUserFromUser(user)
+				_, err = syncer.addUser(newOUser)
+				if err != nil {
+					panic(err)
+				}
+				fmt.Printf("New oUser: %v\n", newOUser)
 			}
-			fmt.Printf("New oUser: %v\n", newOUser)
 		}
 	}
 }

--- a/object/syncer_sync.go
+++ b/object/syncer_sync.go
@@ -63,7 +63,7 @@ func (syncer *Syncer) syncUsers() {
 				}
 			} else {
 				if user.PreHash == oHash {
-					if !syncer.ReadOnlyEnabled {
+					if !syncer.IsReadOnly {
 						updatedOUser := syncer.createOriginalUserFromUser(user)
 						syncer.updateUser(updatedOUser)
 						fmt.Printf("Update from user to oUser: %v\n", updatedOUser)
@@ -93,7 +93,7 @@ func (syncer *Syncer) syncUsers() {
 		panic(err)
 	}
 
-	if !syncer.ReadOnlyEnabled {
+	if !syncer.IsReadOnly {
 		for _, user := range users {
 			id := user.Id
 			if _, ok := oUserMap[id]; !ok {

--- a/web/src/SyncerEditPage.js
+++ b/web/src/SyncerEditPage.js
@@ -386,6 +386,16 @@ class SyncerEditPage extends React.Component {
             }} />
           </Col>
         </Row>
+        <Row style={{marginTop: "20px"}} >
+          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 19 : 2}>
+            {Setting.getLabel(i18next.t("general:Read-only mod"), i18next.t("general:Read-only mod - Tooltip"))} :
+          </Col>
+          <Col span={1} >
+            <Switch checked={this.state.syncer.readOnlyEnabled} onChange={checked => {
+              this.updateSyncerField("readOnlyEnabled", checked);
+            }} />
+          </Col>
+        </Row>
       </Card>
     );
   }

--- a/web/src/SyncerEditPage.js
+++ b/web/src/SyncerEditPage.js
@@ -388,11 +388,11 @@ class SyncerEditPage extends React.Component {
         </Row>
         <Row style={{marginTop: "20px"}} >
           <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 19 : 2}>
-            {Setting.getLabel(i18next.t("general:Read-only mod"), i18next.t("general:Read-only mod - Tooltip"))} :
+            {Setting.getLabel(i18next.t("general:Is read-only"), i18next.t("general:Is read-only - Tooltip"))} :
           </Col>
           <Col span={1} >
-            <Switch checked={this.state.syncer.readOnlyEnabled} onChange={checked => {
-              this.updateSyncerField("readOnlyEnabled", checked);
+            <Switch checked={this.state.syncer.isReadOnly} onChange={checked => {
+              this.updateSyncerField("isReadOnly", checked);
             }} />
           </Col>
         </Row>


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/1934

When read-only mode is enabled, user info in casdoor will not be synchronized with the source database.


https://github.com/casdoor/casdoor/assets/34300181/ff4327ba-0282-46d2-8c49-e82e88dfbbdd

