### PR TITLE
fix: set the default value of user.Groups for syncer

### DIFF
--- a/object/syncer_util.go
+++ b/object/syncer_util.go
@@ -170,6 +170,7 @@ func (syncer *Syncer) getOriginalUsersFromMap(results []map[string]string) []*Or
 		originalUser := &OriginalUser{
 			Address:    []string{},
 			Properties: map[string]string{},
+			Groups:     []string{},
 		}
 
 		for _, tableColumn := range syncer.TableColumns {


### PR DESCRIPTION
Modifying a user synchronized by syncer will be blocked. The default value of user.Groups for syncer is nil, while the default value of user.Groups created by the Casdoor front-end is an empty slice with a length of 0. These two JSON parsing results are different, and since the Groups rule is immutable, modification is blocked.


https://github.com/casdoor/casdoor/assets/34300181/ad1ebd6c-4a78-4b3c-a74e-2ab94a070d4d


This PR changes the default value of `user.groups` for syncer to an empty slice with a length of 0.