### PR TITLE
feat: fix panic when url.Parse() fails to parse URL

### DIFF
--- a/util/path.go
+++ b/util/path.go
@@ -72,6 +72,9 @@ func UrlJoin(base string, path string) string {
 
 func GetUrlPath(urlString string) string {
 	u, _ := url.Parse(urlString)
+	if u == nil {
+		return ""
+	}
 	return u.Path
 }
 


### PR DESCRIPTION
Together with: https://github.com/casdoor/casdoor-website/pull/503

when url.Parse() return nil,err , u.Path would trigger panic