### PR TITLE
feat: IntrospectToken return the right Jti (JWT ID instead of User Id)

### DIFF
--- a/controllers/token.go
+++ b/controllers/token.go
@@ -325,7 +325,7 @@ func (c *ApiController) IntrospectToken() {
 		Sub:       jwtToken.Subject,
 		Aud:       jwtToken.Audience,
 		Iss:       jwtToken.Issuer,
-		Jti:       jwtToken.Id,
+		Jti:       jwtToken.ID,
 	}
 	c.ServeJSON()
 }


### PR DESCRIPTION
The current IntrospectToken response return user Id instead of JWT ID 
<img width="1704" alt="image" src="https://github.com/casdoor/casdoor/assets/55494127/9484a8db-b90a-41d2-981e-a0135306a92a">
