### PR TITLE
fix: init groups modify rule with admin

### DIFF
--- a/object/init.go
+++ b/object/init.go
@@ -61,7 +61,7 @@ func getBuiltInAccountItems() []*AccountItem {
 		{Name: "Signup application", Visible: true, ViewRule: "Public", ModifyRule: "Admin"},
 		{Name: "Roles", Visible: true, ViewRule: "Public", ModifyRule: "Immutable"},
 		{Name: "Permissions", Visible: true, ViewRule: "Public", ModifyRule: "Immutable"},
-		{Name: "Groups", Visible: true, ViewRule: "Public", ModifyRule: "Immutable"},
+		{Name: "Groups", Visible: true, ViewRule: "Public", ModifyRule: "Admin"},
 		{Name: "3rd-party logins", Visible: true, ViewRule: "Self", ModifyRule: "Self"},
 		{Name: "Properties", Visible: false, ViewRule: "Admin", ModifyRule: "Admin"},
 		{Name: "Is admin", Visible: true, ViewRule: "Admin", ModifyRule: "Admin"},

--- a/web/src/OrganizationListPage.js
+++ b/web/src/OrganizationListPage.js
@@ -74,7 +74,7 @@ class OrganizationListPage extends BaseListPage {
         {name: "Ranking", visible: true, viewRule: "Public", modifyRule: "Admin"},
         {name: "Signup application", visible: true, viewRule: "Public", modifyRule: "Admin"},
         {name: "API key", label: i18next.t("general:API key"), modifyRule: "Self"},
-        {name: "Groups", visible: true, viewRule: "Public", modifyRule: "Immutable"},
+        {name: "Groups", visible: true, viewRule: "Public", modifyRule: "Admin"},
         {name: "Roles", visible: true, viewRule: "Public", modifyRule: "Immutable"},
         {name: "Permissions", visible: true, viewRule: "Public", modifyRule: "Immutable"},
         {name: "3rd-party logins", visible: true, viewRule: "Self", modifyRule: "Self"},


### PR DESCRIPTION
Groups should be abled to update by admin that using the sdk to call the API. Now it is imutable, after init Casdoor, the Casnode can not update user because the modify rule.