### PR TITLE
fix: provide detailed description of ldap in swagger

### DIFF
--- a/controllers/ldap.go
+++ b/controllers/ldap.go
@@ -38,8 +38,11 @@ type LdapSyncResp struct {
 }
 
 // GetLdapUsers
-// @Tag Account API
 // @Title GetLdapser
+// @Tag Account API
+// @Description get ldap users
+// Param	id	string	true	"id"
+// @Success 200 {object} LdapResp The Response object
 // @router /get-ldap-users [get]
 func (c *ApiController) GetLdapUsers() {
 	id := c.Input().Get("id")
@@ -94,8 +97,11 @@ func (c *ApiController) GetLdapUsers() {
 }
 
 // GetLdaps
-// @Tag Account API
 // @Title GetLdaps
+// @Tag Account API
+// @Description get ldaps
+// @Param	owner	query	string	false	"owner"
+// @Success 200 {array} object.Ldap The Response object
 // @router /get-ldaps [get]
 func (c *ApiController) GetLdaps() {
 	owner := c.Input().Get("owner")
@@ -104,8 +110,11 @@ func (c *ApiController) GetLdaps() {
 }
 
 // GetLdap
-// @Tag Account API
 // @Title GetLdap
+// @Tag Account API
+// @Description get ldap
+// @Param	id	query	string	true	"id"
+// @Success 200 {object} object.Ldap The Response object
 // @router /get-ldap [get]
 func (c *ApiController) GetLdap() {
 	id := c.Input().Get("id")
@@ -120,8 +129,11 @@ func (c *ApiController) GetLdap() {
 }
 
 // AddLdap
-// @Tag Account API
 // @Title AddLdap
+// @Tag Account API
+// @Description add ldap
+// @Param	body	body	object.Ldap		true	"The details of the ldap"
+// @Success 200 {object} controllers.Response The Response object
 // @router /add-ldap [post]
 func (c *ApiController) AddLdap() {
 	var ldap object.Ldap
@@ -160,8 +172,11 @@ func (c *ApiController) AddLdap() {
 }
 
 // UpdateLdap
-// @Tag Account API
 // @Title UpdateLdap
+// @Tag Account API
+// @Description update ldap
+// @Param	body	body	object.Ldap		true	"The details of the ldap"
+// @Success 200 {object} controllers.Response The Response object
 // @router /update-ldap [post]
 func (c *ApiController) UpdateLdap() {
 	var ldap object.Ldap
@@ -198,8 +213,11 @@ func (c *ApiController) UpdateLdap() {
 }
 
 // DeleteLdap
-// @Tag Account API
 // @Title DeleteLdap
+// @Tag Account API
+// @Description delete ldap
+// @Param	body	body	object.Ldap		true	"The details of the ldap"
+// @Success 200 {object} controllers.Response The Response object
 // @router /delete-ldap [post]
 func (c *ApiController) DeleteLdap() {
 	var ldap object.Ldap
@@ -222,8 +240,11 @@ func (c *ApiController) DeleteLdap() {
 }
 
 // SyncLdapUsers
-// @Tag Account API
 // @Title SyncLdapUsers
+// @Tag Account API
+// @Description sync ldap users
+// @Param	id	query	string		true	"id"
+// @Success 200 {object} LdapSyncResp The Response object
 // @router /sync-ldap-users [post]
 func (c *ApiController) SyncLdapUsers() {
 	id := c.Input().Get("id")

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -188,7 +188,27 @@
                 "tags": [
                     "Account API"
                 ],
-                "operationId": "ApiController.AddLdap"
+                "description": "add ldap",
+                "operationId": "ApiController.AddLdap",
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "The details of the ldap",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/object.Ldap"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The Response object",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.Response"
+                        }
+                    }
+                }
             }
         },
         "/api/add-message": {
@@ -1086,7 +1106,27 @@
                 "tags": [
                     "Account API"
                 ],
-                "operationId": "ApiController.DeleteLdap"
+                "description": "delete ldap",
+                "operationId": "ApiController.DeleteLdap",
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "The details of the ldap",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/object.Ldap"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The Response object",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.Response"
+                        }
+                    }
+                }
             }
         },
         "/api/delete-message": {
@@ -2098,7 +2138,25 @@
                 "tags": [
                     "Account API"
                 ],
-                "operationId": "ApiController.GetLdap"
+                "description": "get ldap",
+                "operationId": "ApiController.GetLdap",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "id",
+                        "description": "id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The Response object",
+                        "schema": {
+                            "$ref": "#/definitions/object.Ldap"
+                        }
+                    }
+                }
             }
         },
         "/api/get-ldap-users": {
@@ -2106,7 +2164,16 @@
                 "tags": [
                     "Account API"
                 ],
-                "operationId": "ApiController.GetLdapser"
+                "description": "get ldap users",
+                "operationId": "ApiController.GetLdapser",
+                "responses": {
+                    "200": {
+                        "description": "The Response object",
+                        "schema": {
+                            "$ref": "#/definitions/LdapResp"
+                        }
+                    }
+                }
             }
         },
         "/api/get-ldaps": {
@@ -2114,7 +2181,27 @@
                 "tags": [
                     "Account API"
                 ],
-                "operationId": "ApiController.GetLdaps"
+                "description": "get ldaps",
+                "operationId": "ApiController.GetLdaps",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "owner",
+                        "description": "owner",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The Response object",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/object.Ldap"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/get-message": {
@@ -4139,7 +4226,25 @@
                 "tags": [
                     "Account API"
                 ],
-                "operationId": "ApiController.SyncLdapUsers"
+                "description": "sync ldap users",
+                "operationId": "ApiController.SyncLdapUsers",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "id",
+                        "description": "id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The Response object",
+                        "schema": {
+                            "$ref": "#/definitions/LdapSyncResp"
+                        }
+                    }
+                }
             }
         },
         "/api/unlink": {
@@ -4329,7 +4434,27 @@
                 "tags": [
                     "Account API"
                 ],
-                "operationId": "ApiController.UpdateLdap"
+                "description": "update ldap",
+                "operationId": "ApiController.UpdateLdap",
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "The details of the ldap",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/object.Ldap"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The Response object",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.Response"
+                        }
+                    }
+                }
             }
         },
         "/api/update-message": {
@@ -5152,6 +5277,14 @@
             "title": "LaravelResponse",
             "type": "object"
         },
+        "LdapResp": {
+            "title": "LdapResp",
+            "type": "object"
+        },
+        "LdapSyncResp": {
+            "title": "LdapSyncResp",
+            "type": "object"
+        },
         "Response": {
             "title": "Response",
             "type": "object"
@@ -5674,6 +5807,59 @@
                     "type": "string"
                 },
                 "token_type": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "object.Ldap": {
+            "title": "Ldap",
+            "type": "object",
+            "properties": {
+                "autoSync": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "baseDn": {
+                    "type": "string"
+                },
+                "createdTime": {
+                    "type": "string"
+                },
+                "enableSsl": {
+                    "type": "boolean"
+                },
+                "filter": {
+                    "type": "string"
+                },
+                "filterFields": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "host": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "lastSync": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "port": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "serverName": {
                     "type": "string"
                 },
                 "username": {

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -122,7 +122,20 @@ paths:
     post:
       tags:
       - Account API
+      description: add ldap
       operationId: ApiController.AddLdap
+      parameters:
+      - in: body
+        name: body
+        description: The details of the ldap
+        required: true
+        schema:
+          $ref: '#/definitions/object.Ldap'
+      responses:
+        "200":
+          description: The Response object
+          schema:
+            $ref: '#/definitions/controllers.Response'
   /api/add-message:
     post:
       tags:
@@ -702,7 +715,20 @@ paths:
     post:
       tags:
       - Account API
+      description: delete ldap
       operationId: ApiController.DeleteLdap
+      parameters:
+      - in: body
+        name: body
+        description: The details of the ldap
+        required: true
+        schema:
+          $ref: '#/definitions/object.Ldap'
+      responses:
+        "200":
+          description: The Response object
+          schema:
+            $ref: '#/definitions/controllers.Response'
   /api/delete-message:
     post:
       tags:
@@ -1360,17 +1386,48 @@ paths:
     get:
       tags:
       - Account API
+      description: get ldap
       operationId: ApiController.GetLdap
+      parameters:
+      - in: query
+        name: id
+        description: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: The Response object
+          schema:
+            $ref: '#/definitions/object.Ldap'
   /api/get-ldap-users:
     get:
       tags:
       - Account API
+      description: get ldap users
       operationId: ApiController.GetLdapser
+      responses:
+        "200":
+          description: The Response object
+          schema:
+            $ref: '#/definitions/LdapResp'
   /api/get-ldaps:
     get:
       tags:
       - Account API
+      description: get ldaps
       operationId: ApiController.GetLdaps
+      parameters:
+      - in: query
+        name: owner
+        description: owner
+        type: string
+      responses:
+        "200":
+          description: The Response object
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/object.Ldap'
   /api/get-message:
     get:
       tags:
@@ -2703,7 +2760,19 @@ paths:
     post:
       tags:
       - Account API
+      description: sync ldap users
       operationId: ApiController.SyncLdapUsers
+      parameters:
+      - in: query
+        name: id
+        description: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: The Response object
+          schema:
+            $ref: '#/definitions/LdapSyncResp'
   /api/unlink:
     post:
       tags:
@@ -2827,7 +2896,20 @@ paths:
     post:
       tags:
       - Account API
+      description: update ldap
       operationId: ApiController.UpdateLdap
+      parameters:
+      - in: body
+        name: body
+        description: The details of the ldap
+        required: true
+        schema:
+          $ref: '#/definitions/object.Ldap'
+      responses:
+        "200":
+          description: The Response object
+          schema:
+            $ref: '#/definitions/controllers.Response'
   /api/update-message:
     post:
       tags:
@@ -3367,6 +3449,12 @@ definitions:
   LaravelResponse:
     title: LaravelResponse
     type: object
+  LdapResp:
+    title: LdapResp
+    type: object
+  LdapSyncResp:
+    title: LdapSyncResp
+    type: object
   Response:
     title: Response
     type: object
@@ -3722,6 +3810,42 @@ definitions:
       sub:
         type: string
       token_type:
+        type: string
+      username:
+        type: string
+  object.Ldap:
+    title: Ldap
+    type: object
+    properties:
+      autoSync:
+        type: integer
+        format: int64
+      baseDn:
+        type: string
+      createdTime:
+        type: string
+      enableSsl:
+        type: boolean
+      filter:
+        type: string
+      filterFields:
+        type: array
+        items:
+          type: string
+      host:
+        type: string
+      id:
+        type: string
+      lastSync:
+        type: string
+      owner:
+        type: string
+      password:
+        type: string
+      port:
+        type: integer
+        format: int64
+      serverName:
         type: string
       username:
         type: string


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/2055

As the swagger documentation does not contain a description of the parameters and results for ldap methods,
I add the details.For example:
```go
// GetLdapUsers
// @Title GetLdapser
// @Tag Account API
// @Description get ldap users
// Param	id	string	true	"id"
// @Success 200 {object} LdapResp The Response object
// @router /get-ldap-users [get]
func (c *ApiController) GetLdapUsers() {
         ......
}
```