### PR TITLE
feat: prevent infinite recursion when role contain subrole

### DIFF
--- a/object/role.go
+++ b/object/role.go
@@ -391,9 +391,12 @@ func GetAncestorRoles(roleIds ...string) ([]*Role, error) {
 
 // containsRole is a helper function to check if a roles is related to any role in the given list roles
 func containsRole(role *Role, roleMap map[string]*Role, visited map[string]bool, roleIds ...string) bool {
-	if isContain, ok := visited[role.GetId()]; ok {
+	roleId := role.GetId()
+	if isContain, ok := visited[roleId]; ok {
 		return isContain
 	}
+
+	visited[role.GetId()] = false
 
 	for _, subRole := range role.Roles {
 		if util.HasString(roleIds, subRole) {


### PR DESCRIPTION
feat: prevent infinite recursion when role contain subrole and vice versa. when both of them are still not visited, it will cause infinite recursion