### PR TITLE
fix: application fails to call /api/get-resources

### DIFF
--- a/controllers/resource.go
+++ b/controllers/resource.go
@@ -52,14 +52,6 @@ func (c *ApiController) GetResources() {
 	sortField := c.Input().Get("sortField")
 	sortOrder := c.Input().Get("sortOrder")
 
-	userObj, ok := c.RequireSignedInUser()
-	if !ok {
-		return
-	}
-	if userObj.IsAdmin {
-		user = ""
-	}
-
 	if limit == "" || page == "" {
 		resources, err := object.GetResources(owner, user)
 		if err != nil {


### PR DESCRIPTION
just like other apis, resource.go.GetResources() no longer calls ApiController.RequireSignedInUser() to auth or check

mentioned on dc: https://discord.com/channels/1022748306096537660/1065201965883199518/1133592853214416906