### PR TITLE
feat: use the casbin model to store relationships between users and groups

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func main() {
 	object.InitLdapAutoSynchronizer()
 	proxy.InitHttpClient()
 	authz.InitApi()
+	object.InitUserManager()
 
 	util.SafeGoroutine(func() { object.RunSyncUsersJob() })
 

--- a/object/group.go
+++ b/object/group.go
@@ -214,30 +214,18 @@ func ConvertToTreeData(groups []*Group, parentId string) []*Group {
 	return treeData
 }
 
-func RemoveUserFromGroup(owner, name, groupId string) (bool, error) {
-	user, err := getUser(owner, name)
-	if err != nil {
-		return false, err
-	}
-	if user == nil {
-		return false, errors.New("user not exist")
-	}
-
-	user.Groups = util.DeleteVal(user.Groups, groupId)
-	affected, err := updateUser(user.GetId(), user, []string{"groups"})
-	if err != nil {
-		return false, err
-	}
-	return affected != 0, err
-}
-
 func GetGroupUserCount(groupId string, field, value string) (int64, error) {
+	owner, _ := util.GetOwnerAndNameFromId(groupId)
+	names, err := userEnforcer.GetUserNamesByGroupName(groupId)
+	if err != nil {
+		return 0, err
+	}
+
 	if field == "" && value == "" {
-		return ormer.Engine.Where(builder.Like{"`groups`", groupId}).
-			Count(&User{})
+		return int64(len(names)), nil
 	} else {
 		return ormer.Engine.Table("user").
-			Where(builder.Like{"`groups`", groupId}).
+			Where("owner = ?", owner).In("name", names).
 			And(fmt.Sprintf("user.%s LIKE ?", util.CamelToSnakeCase(field)), "%"+value+"%").
 			Count()
 	}
@@ -245,8 +233,14 @@ func GetGroupUserCount(groupId string, field, value string) (int64, error) {
 
 func GetPaginationGroupUsers(groupId string, offset, limit int, field, value, sortField, sortOrder string) ([]*User, error) {
 	users := []*User{}
+	owner, _ := util.GetOwnerAndNameFromId(groupId)
+	names, err := userEnforcer.GetUserNamesByGroupName(groupId)
+	if err != nil {
+		return nil, err
+	}
+
 	session := ormer.Engine.Table("user").
-		Where(builder.Like{"`groups`", groupId + "\""})
+		Where("owner = ?", owner).In("name", names)
 
 	if offset != -1 && limit != -1 {
 		session.Limit(limit, offset)
@@ -265,7 +259,7 @@ func GetPaginationGroupUsers(groupId string, offset, limit int, field, value, so
 		session = session.Desc(fmt.Sprintf("user.%s", util.SnakeString(sortField)))
 	}
 
-	err := session.Find(&users)
+	err = session.Find(&users)
 	if err != nil {
 		return nil, err
 	}
@@ -275,13 +269,13 @@ func GetPaginationGroupUsers(groupId string, offset, limit int, field, value, so
 
 func GetGroupUsers(groupId string) ([]*User, error) {
 	users := []*User{}
-	err := ormer.Engine.Table("user").
-		Where(builder.Like{"`groups`", groupId + "\""}).
-		Find(&users)
+	owner, _ := util.GetOwnerAndNameFromId(groupId)
+	names, err := userEnforcer.GetUserNamesByGroupName(groupId)
+
+	err = ormer.Engine.Where("owner = ?", owner).In("name", names).Find(&users)
 	if err != nil {
 		return nil, err
 	}
-
 	return users, nil
 }
 

--- a/object/user_enforcer.go
+++ b/object/user_enforcer.go
@@ -6,15 +6,6 @@ import (
 	"github.com/casdoor/casdoor/util"
 )
 
-type IUserGroupEnforcer interface {
-	AddGroupForUser(user string, group string) (bool, error)
-	AddGroupsForUser(user string, groups []string) (bool, error)
-	DeleteGroupForUser(user string, group string) (bool, error)
-	DeleteGroupsForUser(user string) (bool, error)
-	GetGroupsForUser(user string) ([]string, error)
-	GetAllUsersByGroup(group string) ([]string, error)
-}
-
 type UserGroupEnforcer struct {
 	// use rbac model implement use group, the enforcer can also implement user role
 	enforcer *casbin.Enforcer

--- a/object/user_enforcer.go
+++ b/object/user_enforcer.go
@@ -1,0 +1,104 @@
+package object
+
+import (
+	"github.com/casbin/casbin/v2"
+	"github.com/casbin/casbin/v2/errors"
+	"github.com/casdoor/casdoor/util"
+)
+
+type IUserGroupEnforcer interface {
+	AddGroupForUser(user string, group string) (bool, error)
+	AddGroupsForUser(user string, groups []string) (bool, error)
+	DeleteGroupForUser(user string, group string) (bool, error)
+	DeleteGroupsForUser(user string) (bool, error)
+	GetGroupsForUser(user string) ([]string, error)
+	GetAllUsersByGroup(group string) ([]string, error)
+}
+
+type UserGroupEnforcer struct {
+	// use rbac model implement use group, the enforcer can also implement user role
+	enforcer *casbin.Enforcer
+}
+
+func NewUserGroupEnforcer(enforcer *casbin.Enforcer) *UserGroupEnforcer {
+	return &UserGroupEnforcer{
+		enforcer: enforcer,
+	}
+}
+
+func (e *UserGroupEnforcer) AddGroupForUser(user string, group string) (bool, error) {
+	return e.enforcer.AddRoleForUser(user, GetGroupWithPrefix(group))
+}
+
+func (e *UserGroupEnforcer) AddGroupsForUser(user string, groups []string) (bool, error) {
+	g := make([]string, len(groups))
+	for i, group := range groups {
+		g[i] = GetGroupWithPrefix(group)
+	}
+	return e.enforcer.AddRolesForUser(user, g)
+}
+
+func (e *UserGroupEnforcer) DeleteGroupForUser(user string, group string) (bool, error) {
+	return e.enforcer.DeleteRoleForUser(user, GetGroupWithPrefix(group))
+}
+
+func (e *UserGroupEnforcer) DeleteGroupsForUser(user string) (bool, error) {
+	return e.enforcer.DeleteRolesForUser(user)
+}
+
+func (e *UserGroupEnforcer) GetGroupsForUser(user string) ([]string, error) {
+	groups, err := e.enforcer.GetRolesForUser(user)
+	for i, group := range groups {
+		groups[i] = GetGroupWithoutPrefix(group)
+	}
+	return groups, err
+}
+
+func (e *UserGroupEnforcer) GetAllUsersByGroup(group string) ([]string, error) {
+	users, err := e.enforcer.GetUsersForRole(GetGroupWithPrefix(group))
+	if err != nil {
+		if err == errors.ERR_NAME_NOT_FOUND {
+			return []string{}, nil
+		}
+		return nil, err
+	}
+	return users, nil
+}
+
+func GetGroupWithPrefix(group string) string {
+	return "group:" + group
+}
+
+func GetGroupWithoutPrefix(group string) string {
+	return group[len("group:"):]
+}
+
+func (e *UserGroupEnforcer) GetUserNamesByGroupName(groupName string) ([]string, error) {
+	var names []string
+
+	userIds, err := e.GetAllUsersByGroup(groupName)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, userId := range userIds {
+		_, name := util.GetOwnerAndNameFromIdNoCheck(userId)
+		names = append(names, name)
+	}
+
+	return names, nil
+}
+
+func (e *UserGroupEnforcer) UpdateGroupsForUser(user string, groups []string) (bool, error) {
+	_, err := e.DeleteGroupsForUser(user)
+	if err != nil {
+		return false, err
+	}
+
+	affected, err := e.AddGroupsForUser(user, groups)
+	if err != nil {
+		return false, err
+	}
+
+	return affected, nil
+}

--- a/web/src/GroupTreePage.js
+++ b/web/src/GroupTreePage.js
@@ -221,6 +221,7 @@ class GroupTreePage extends React.Component {
           onChange={(value) => {
             this.setState({
               organizationName: value,
+              groupName: "",
             });
             this.props.history.push(`/trees/${value}`);
           }}


### PR DESCRIPTION
The pr use casbin store the relationship tetween users and groups, replace the old query statment that using `like` to query users in group.  Note that this commit now does not consider migrating existing user and group relationships into casbin, which would result in users not being found in the organization's group management. I'm not sure if I need to add a migration file before the pr be merged.

The `GroupManager` is not being used now. However, it may then be used to store group hierarchy to determine the inherited permissions of all groups above the user.

Next step, improve the permisson page, support UI to add permission for a group. Because of the implement of using casbin manager user in Casdoor, then we can support the more convenient API, such as `HasPermissionForUser()` to ckeck if a user(group) has permision. It will be more friendly than using Enforce API directly.

Fix: https://github.com/casdoor/casdoor/issues/2020