### PR TITLE
Allow multiple similar providers, display by display name

### DIFF
--- a/web/src/auth/ProviderButton.js
+++ b/web/src/auth/ProviderButton.js
@@ -46,7 +46,7 @@ import {getEvent} from "./Util";
 import {Modal} from "antd";
 
 function getSigninButton(provider) {
-  const text = i18next.t("login:Sign in with {type}").replace("{type}", provider.type);
+  const text = i18next.t("login:Sign in with {type}").replace("{type}", provider.displayName);
   if (provider.type === "GitHub") {
     return <GithubLoginButton text={text} align={"center"} />;
   } else if (provider.type === "Google") {


### PR DESCRIPTION
Then log in to the page, when there are multiple similar providers, they cannot be distinguished. Using displayName is easier to distinguish.

![5befe7ae5cfe6a4af1a684a3f44bd680](https://github.com/casdoor/casdoor/assets/30221300/83c157e4-a5be-4046-be95-e1f44d8ab155)
