### PR TITLE
fix: sendCasAuthenticationResponseErr when pgtUrlObj if not valid url

### DIFF
--- a/controllers/cas.go
+++ b/controllers/cas.go
@@ -121,15 +121,15 @@ func (c *RootController) CasP3ProxyValidate() {
 		pgtiou := serviceResponse.Success.ProxyGrantingTicket
 		// todo: check whether it is https
 		pgtUrlObj, err := url.Parse(pgtUrl)
+		if err != nil {
+			c.sendCasAuthenticationResponseErr(InvalidProxyCallback, "callback is not valid url", format)
+			return
+		}
 		if pgtUrlObj.Scheme != "https" {
 			c.sendCasAuthenticationResponseErr(InvalidProxyCallback, "callback is not https", format)
 			return
 		}
 		// make a request to pgturl passing pgt and pgtiou
-		if err != nil {
-			c.sendCasAuthenticationResponseErr(InternalError, err.Error(), format)
-			return
-		}
 		param := pgtUrlObj.Query()
 		param.Add("pgtId", pgt)
 		param.Add("pgtIou", pgtiou)

--- a/controllers/cas.go
+++ b/controllers/cas.go
@@ -122,13 +122,15 @@ func (c *RootController) CasP3ProxyValidate() {
 		// todo: check whether it is https
 		pgtUrlObj, err := url.Parse(pgtUrl)
 		if err != nil {
-			c.sendCasAuthenticationResponseErr(InvalidProxyCallback, "callback is not valid url", format)
+			c.sendCasAuthenticationResponseErr(InvalidProxyCallback, err.Error(), format)
 			return
 		}
+
 		if pgtUrlObj.Scheme != "https" {
 			c.sendCasAuthenticationResponseErr(InvalidProxyCallback, "callback is not https", format)
 			return
 		}
+
 		// make a request to pgturl passing pgt and pgtiou
 		param := pgtUrlObj.Query()
 		param.Add("pgtId", pgt)


### PR DESCRIPTION
check pgtUrlObj.Scheme first will cause panic if url.Parse returns error.