### PR TITLE
feat: fix bug that failed to set password after changing username

### DIFF
--- a/controllers/user.go
+++ b/controllers/user.go
@@ -448,6 +448,11 @@ func (c *ApiController) SetPassword() {
 	}
 
 	targetUser, err := object.GetUser(userId)
+
+	if targetUser == nil {
+		c.ResponseError("the user doesn't exist: " + userId)
+		return
+	}
 	if err != nil {
 		c.ResponseError(err.Error())
 		return

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -448,9 +448,8 @@ func (c *ApiController) SetPassword() {
 	}
 
 	targetUser, err := object.GetUser(userId)
-
 	if targetUser == nil {
-		c.ResponseError("the user doesn't exist: " + userId)
+		c.ResponseError(fmt.Sprintf(c.T("general:The user: %s doesn't exist"), userId))
 		return
 	}
 	if err != nil {

--- a/web/src/UserEditPage.js
+++ b/web/src/UserEditPage.js
@@ -402,7 +402,7 @@ class UserEditPage extends React.Component {
             {Setting.getLabel(i18next.t("general:Password"), i18next.t("general:Password - Tooltip"))} :
           </Col>
           <Col span={22} >
-            <PasswordModal user={this.state.user} organization={this.getUserOrganization()} account={this.props.account} disabled={disabled} />
+            <PasswordModal user={this.state.user} userName={this.state.userName} organization={this.getUserOrganization()} account={this.props.account} disabled={disabled} />
           </Col>
         </Row>
       );

--- a/web/src/common/modal/PasswordModal.js
+++ b/web/src/common/modal/PasswordModal.js
@@ -26,6 +26,7 @@ export const PasswordModal = (props) => {
   const [newPassword, setNewPassword] = React.useState("");
   const [rePassword, setRePassword] = React.useState("");
   const {user} = props;
+  const {userName} = props;
   const {organization} = props;
   const {account} = props;
 
@@ -90,7 +91,7 @@ export const PasswordModal = (props) => {
       return;
     }
 
-    UserBackend.setPassword(user.owner, user.name, oldPassword, newPassword)
+    UserBackend.setPassword(user.owner, userName, oldPassword, newPassword)
       .then((res) => {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("user:Password set successfully"));


### PR DESCRIPTION
When we add a new member to an organization using Casdoor, Casdoor will automatically generate a member with a random username, such as "user_qvducc". When we change the username, for example, to "yunshu", an issue arises where we are unable to successfully edit the password. This is because Casdoor searches for a user based on `owner/username`, and before any changes are saved, the username in the database remains "user_qvducc". However, the frontend uses `orgName/yunshu` instead of `orgName/user_qvducc` to send the request to change the password. As a result, the backend cannot find the user and the password change fails.