### PR TITLE
feat: set default passwordType to argon2id when add organization

### DIFF
--- a/web/src/OrganizationListPage.js
+++ b/web/src/OrganizationListPage.js
@@ -32,7 +32,7 @@ class OrganizationListPage extends BaseListPage {
       displayName: `New Organization - ${randomName}`,
       websiteUrl: "https://door.casdoor.com",
       favicon: `${Setting.StaticBaseUrl}/img/favicon.png`,
-      passwordType: "plain",
+      passwordType: "argon2id",
       PasswordSalt: "",
       passwordOptions: [],
       countryCodes: ["US"],


### PR DESCRIPTION
argon2id is currently the recommended Key Derivation Function to store password by OWASP.

https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html