### PR TITLE
fix: use ID in OAuth2 user info if set when creating users

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -615,11 +615,15 @@ func (c *ApiController) Login() {
 						return
 					}
 
+					userId := userInfo.Id
+					if len(strings.TrimSpace(userId)) == 0 {
+						userId = util.GenerateId()
+					}
 					user = &object.User{
 						Owner:             application.Organization,
 						Name:              userInfo.Username,
 						CreatedTime:       util.GetCurrentTime(),
-						Id:                util.GenerateId(),
+						Id:                userId,
 						Type:              "normal-user",
 						DisplayName:       userInfo.DisplayName,
 						Avatar:            userInfo.AvatarUrl,


### PR DESCRIPTION
Fix #2350 