### PR TITLE
ci: stop building docker image of linux/arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,7 +195,7 @@ jobs:
         with:
           context: .
           target: STANDARD
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: casbin/casdoor:${{steps.get-current-tag.outputs.tag }},casbin/casdoor:latest
 
@@ -205,6 +205,6 @@ jobs:
         with:
           context: .
           target: ALLINONE
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: casbin/casdoor-all-in-one:${{steps.get-current-tag.outputs.tag }},casbin/casdoor-all-in-one:latest

--- a/build.sh
+++ b/build.sh
@@ -9,4 +9,4 @@ else
     export GOPROXY="https://goproxy.cn,direct"
 fi
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o server_linux_amd64 .
-CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-w -s" -o server_linux_arm64 .
+# CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-w -s" -o server_linux_arm64 .


### PR DESCRIPTION
![image](https://github.com/casdoor/casdoor/assets/53544726/502bc0d1-c1d6-4d67-9b23-b1dce5e608e4)
https://github.com/casdoor/casdoor/actions/runs/6324483447/job/17174471503

Building docker image for linux/arm64 takes too long