### PR TITLE
feat: restrict the model of application type resource permission

### DIFF
--- a/object/enforcer.go
+++ b/object/enforcer.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/casbin/casbin/v2"
-	"github.com/casbin/casbin/v2/config"
 	"github.com/casdoor/casdoor/util"
 	xormadapter "github.com/casdoor/xorm-adapter/v3"
 	"github.com/xorm-io/core"
@@ -254,15 +253,9 @@ func (enforcer *Enforcer) LoadModelCfg() error {
 		return fmt.Errorf("the model: %s for enforcer: %s is not found", enforcer.Model, enforcer.GetId())
 	}
 
-	cfg, err := config.NewConfigFromText(model.ModelText)
+	enforcer.ModelCfg, err = getModelCfg(model)
 	if err != nil {
 		return err
-	}
-
-	enforcer.ModelCfg = make(map[string]string)
-	enforcer.ModelCfg["p"] = cfg.String("policy_definition::p")
-	if cfg.String("role_definition::g") != "" {
-		enforcer.ModelCfg["g"] = cfg.String("role_definition::g")
 	}
 
 	return nil

--- a/object/model.go
+++ b/object/model.go
@@ -17,6 +17,7 @@ package object
 import (
 	"fmt"
 
+	"github.com/casbin/casbin/v2/config"
 	"github.com/casbin/casbin/v2/model"
 	"github.com/casdoor/casdoor/util"
 	"github.com/xorm-io/core"
@@ -187,4 +188,18 @@ func (m *Model) initModel() error {
 	}
 
 	return nil
+}
+
+func getModelCfg(m *Model) (map[string]string, error) {
+	cfg, err := config.NewConfigFromText(m.ModelText)
+	if err != nil {
+		return nil, err
+	}
+
+	modelCfg := make(map[string]string)
+	modelCfg["p"] = cfg.String("policy_definition::p")
+	if cfg.String("role_definition::g") != "" {
+		modelCfg["g"] = cfg.String("role_definition::g")
+	}
+	return modelCfg, nil
 }

--- a/object/permission.go
+++ b/object/permission.go
@@ -150,6 +150,21 @@ func UpdatePermission(id string, permission *Permission) (bool, error) {
 		return false, nil
 	}
 
+	if permission.ResourceType == "Application" {
+		model, err := GetModel(util.GetId(owner, permission.Model))
+		if err != nil {
+			return false, err
+		}
+		modelCfg, err := getModelCfg(model)
+		if err != nil {
+			return false, err
+		}
+
+		if len(strings.Split(modelCfg["p"], ",")) != 3 {
+			return false, fmt.Errorf("the model: %s for permission: %s is not valid, application type resources need 3 size [policy_defination] model", permission.Model, permission.GetId())
+		}
+	}
+
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(permission)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
fix: #2373

In order to make as little change as possible, check whether the model meets the requirements of the login policy when the permission editing page is updated, so as to avoid the error of mismatch between the model and the policy during login.

But it cause a new problem, for some user they use the application resource permission not only for UI login check but somewhere else. I'm not really sure what percentage of people use it that way.  Maybe we can add a type specific for UI login check.