### PR TITLE
fix: skip checking old password when the code is provided

### DIFF
--- a/controllers/user.go
+++ b/controllers/user.go
@@ -478,7 +478,7 @@ func (c *ApiController) SetPassword() {
 				return
 			}
 		}
-	} else {
+	} else if code == "" {
 		msg := object.CheckPassword(targetUser, oldPassword, c.GetAcceptLanguage())
 		if msg != "" {
 			c.ResponseError(msg)


### PR DESCRIPTION
fix: #2423

fix: #2419