### PR TITLE
fix: If redirectUri already has parameters, concatenate the code and state parameters with &, when fastAutoSignin.

### DIFF
--- a/object/payment.go
+++ b/object/payment.go
@@ -54,7 +54,7 @@ type Payment struct {
 	// Order Info
 	OutOrderId string          `xorm:"varchar(100)" json:"outOrderId"`
 	PayUrl     string          `xorm:"varchar(2000)" json:"payUrl"`
-	SuccessUrl string          `xorm:"varchar(2000)" json:"successUrl""` // `successUrl` is redirected from `payUrl` after pay success
+	SuccessUrl string          `xorm:"varchar(2000)" json:"successUrl"` // `successUrl` is redirected from `payUrl` after pay success
 	State      pp.PaymentState `xorm:"varchar(100)" json:"state"`
 	Message    string          `xorm:"varchar(2000)" json:"message"`
 }

--- a/routers/static_filter.go
+++ b/routers/static_filter.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -83,8 +84,14 @@ func fastAutoSignin(ctx *context.Context) (string, error) {
 		return "", fmt.Errorf(code.Message)
 	}
 
-	res := fmt.Sprintf("%s?code=%s&state=%s", redirectUri, code.Code, state)
-	return res, nil
+	// If redirectUri already has parameters, and if so, concatenate the code and state parameters with &
+	redirectUrl, _ := url.Parse(redirectUri)
+	urlParams, _ := url.ParseQuery(redirectUrl.RawQuery)
+	if urlParams != nil && len(urlParams) > 0 {
+		return fmt.Sprintf("%s&code=%s&state=%s", redirectUri, code.Code, state), nil
+	} else {
+		return fmt.Sprintf("%s?code=%s&state=%s", redirectUri, code.Code, state), nil
+	}
 }
 
 func StaticFilter(ctx *context.Context) {


### PR DESCRIPTION
 1. Delete unnecessary " from Payment struct.
 2. If redirectUri already has parameters, concatenate the code and state parameters with &, when fastAutoSignin.