### PR TITLE
feat: support data initialization for groups, adapters, enforcers, plans and pricings

### DIFF
--- a/init_data.json.template
+++ b/init_data.json.template
@@ -146,7 +146,8 @@
       "isForbidden": false,
       "isDeleted": false,
       "signupApplication": "",
-      "createdIp": ""
+      "createdIp": "",
+      "groups": []
     }
   ],
   "providers": [
@@ -348,6 +349,75 @@
       "organization": "",
       "owner": "",
       "url": ""
+    }
+  ],
+  "groups": [
+    {
+        "owner": "",
+        "name":"",
+        "displayName": "",
+        "manager": "",
+        "contactEmail": "",
+        "type": "",
+        "parent_id": "",
+        "isTopGroup": true,
+        "title": "",
+        "key": "",
+        "children": "",
+        "isEnabled": true
+    }
+  ],
+  "adapters": [
+    {
+        "owner": "",
+        "name": "",
+        "table": "",
+        "useSameDb": true,
+        "type": "",
+        "databaseType": "",
+        "database": "",
+        "host": "",
+        "port": 0,
+        "user": "",
+        "password": "",
+    }
+  ],
+  "enforcers": [
+    {
+        "owner": "",
+        "name": "",
+        "displayName": "",
+        "description": "",
+        "model": "",
+        "adapter": "",
+        "enforcer": ""
+    }
+  ],
+  "plans": [
+    {
+        "owner": "",
+        "name": "",
+        "displayName": "",
+        "description": "",
+        "price": 0,
+        "currency": "",
+        "period": "",
+        "product": "",
+        "paymentProviders": [],
+        "isEnabled": true,
+        "role", ""
+    }
+  ],
+  "pricings": [
+    {
+        "owner": "",
+        "name": "",
+        "displayName": "",
+        "description": "",
+        "plans": [],
+        "isEnabled": true,
+        "trialDuration": 0,
+        "application": "",
     }
   ]
 }

--- a/main.go
+++ b/main.go
@@ -36,12 +36,12 @@ func main() {
 	object.CreateTables()
 
 	object.InitDb()
-	object.InitFromFile()
 	object.InitDefaultStorageProvider()
 	object.InitLdapAutoSynchronizer()
 	proxy.InitHttpClient()
 	authz.InitApi()
 	object.InitUserManager()
+	object.InitFromFile()
 	object.InitCasvisorConfig()
 
 	util.SafeGoroutine(func() { object.RunSyncUsersJob() })

--- a/object/init_data.go
+++ b/object/init_data.go
@@ -35,6 +35,11 @@ type InitData struct {
 	Syncers       []*Syncer       `json:"syncers"`
 	Tokens        []*Token        `json:"tokens"`
 	Webhooks      []*Webhook      `json:"webhooks"`
+	Groups        []*Group        `json:"groups"`
+	Adapters      []*Adapter      `json:"adapters"`
+	Enforcers     []*Enforcer     `json:"enforcers"`
+	Plans         []*Plan         `json:"plans"`
+	Pricings      []*Pricing      `json:"pricings"`
 }
 
 func InitFromFile() {
@@ -94,6 +99,21 @@ func InitFromFile() {
 		for _, webhook := range initData.Webhooks {
 			initDefinedWebhook(webhook)
 		}
+		for _, group := range initData.Groups {
+			initDefinedGroup(group)
+		}
+		for _, adapter := range initData.Adapters {
+			initDefinedAdapter(adapter)
+		}
+		for _, enforcer := range initData.Enforcers {
+			initDefinedEnforcer(enforcer)
+		}
+		for _, plan := range initData.Plans {
+			initDefinedPlan(plan)
+		}
+		for _, pricing := range initData.Pricings {
+			initDefinedPricing(pricing)
+		}
 	}
 }
 
@@ -120,6 +140,11 @@ func readInitDataFromFile(filePath string) (*InitData, error) {
 		Syncers:       []*Syncer{},
 		Tokens:        []*Token{},
 		Webhooks:      []*Webhook{},
+		Groups:        []*Group{},
+		Adapters:      []*Adapter{},
+		Enforcers:     []*Enforcer{},
+		Plans:         []*Plan{},
+		Pricings:      []*Pricing{},
 	}
 	err := util.JsonToStruct(s, data)
 	if err != nil {
@@ -190,7 +215,16 @@ func readInitDataFromFile(filePath string) (*InitData, error) {
 			webhook.Headers = []*Header{}
 		}
 	}
-
+	for _, plan := range data.Plans {
+		if plan.PaymentProviders == nil {
+			plan.PaymentProviders = []string{}
+		}
+	}
+	for _, pricing := range data.Pricings {
+		if pricing.Plans == nil {
+			pricing.Plans = []string{}
+		}
+	}
 	return data, nil
 }
 
@@ -430,6 +464,81 @@ func initDefinedWebhook(webhook *Webhook) {
 	}
 	webhook.CreatedTime = util.GetCurrentTime()
 	_, err = AddWebhook(webhook)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func initDefinedGroup(group *Group) {
+	existed, err := getGroup(group.Owner, group.Name)
+	if err != nil {
+		panic(err)
+	}
+	if existed != nil {
+		return
+	}
+	group.CreatedTime = util.GetCurrentTime()
+	_, err = AddGroup(group)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func initDefinedAdapter(adapter *Adapter) {
+	existed, err := getAdapter(adapter.Owner, adapter.Name)
+	if err != nil {
+		panic(err)
+	}
+	if existed != nil {
+		return
+	}
+	adapter.CreatedTime = util.GetCurrentTime()
+	_, err = AddAdapter(adapter)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func initDefinedEnforcer(enforcer *Enforcer) {
+	existed, err := getEnforcer(enforcer.Owner, enforcer.Name)
+	if err != nil {
+		panic(err)
+	}
+	if existed != nil {
+		return
+	}
+	enforcer.CreatedTime = util.GetCurrentTime()
+	_, err = AddEnforcer(enforcer)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func initDefinedPlan(plan *Plan) {
+	existed, err := getPlan(plan.Owner, plan.Name)
+	if err != nil {
+		panic(err)
+	}
+	if existed != nil {
+		return
+	}
+	plan.CreatedTime = util.GetCurrentTime()
+	_, err = AddPlan(plan)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func initDefinedPricing(pricing *Pricing) {
+	existed, err := getPlan(pricing.Owner, pricing.Name)
+	if err != nil {
+		panic(err)
+	}
+	if existed != nil {
+		return
+	}
+	pricing.CreatedTime = util.GetCurrentTime()
+	_, err = AddPricing(pricing)
 	if err != nil {
 		panic(err)
 	}

--- a/object/init_data_dump.go
+++ b/object/init_data_dump.go
@@ -96,6 +96,31 @@ func writeInitDataToFile(filePath string) error {
 		return err
 	}
 
+	groups, err := GetGroups("")
+	if err != nil {
+		return err
+	}
+
+	adapters, err := GetAdapters("")
+	if err != nil {
+		return err
+	}
+
+	enforcers, err := GetEnforcers("")
+	if err != nil {
+		return err
+	}
+
+	plans, err := GetPlans("")
+	if err != nil {
+		return err
+	}
+
+	pricings, err := GetPricings("")
+	if err != nil {
+		return err
+	}
+
 	data := &InitData{
 		Organizations: organizations,
 		Applications:  applications,
@@ -112,6 +137,11 @@ func writeInitDataToFile(filePath string) error {
 		Syncers:       syncers,
 		Tokens:        tokens,
 		Webhooks:      webhooks,
+		Groups:        groups,
+		Adapters:      adapters,
+		Enforcers:     enforcers,
+		Plans:         plans,
+		Pricings:      pricings,
 	}
 
 	text := util.StructToJsonFormatted(data)

--- a/object/user.go
+++ b/object/user.go
@@ -793,6 +793,13 @@ func AddUser(user *User) (bool, error) {
 	}
 	user.Ranking = int(count + 1)
 
+	if user.Groups != nil && len(user.Groups) > 0 {
+		_, err = userEnforcer.UpdateGroupsForUser(user.GetId(), user.Groups)
+		if err != nil {
+			return false, err
+		}
+	}
+
 	affected, err := ormer.Engine.Insert(user)
 	if err != nil {
 		return false, err
@@ -821,6 +828,13 @@ func AddUsers(users []*User) (bool, error) {
 		user.PermanentAvatar, err = getPermanentAvatarUrl(user.Owner, user.Name, user.Avatar, true)
 		if err != nil {
 			return false, err
+		}
+
+		if user.Groups != nil && len(user.Groups) > 0 {
+			_, err = userEnforcer.UpdateGroupsForUser(user.GetId(), user.Groups)
+			if err != nil {
+				return false, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/2606

This pr aims to add data initialization support for 
1. groups
2. adapters
3. enforcers
4. plans
5. pricings

And  support initialize users with group in `init_data.json`

The reason I swapped the initialization order in `main.go` is to ensure that the table `casbin_user_rule` which is initialed by function `object.InitUserManager()` has been successfully created