### PR TITLE
feat: fix error handling in AdfsIdProvider

### DIFF
--- a/idp/adfs.go
+++ b/idp/adfs.go
@@ -121,6 +121,9 @@ func (idp *AdfsIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error) {
 		return nil, err
 	}
 	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
 	var respKeys struct {
 		Keys []interface{} `json:"keys"`
 	}


### PR DESCRIPTION
This picks up a dropped `err` variable in the `idp` package.