### PR TITLE
feat: allow dot in the username (like john.smith)

### DIFF
--- a/util/validation.go
+++ b/util/validation.go
@@ -34,7 +34,7 @@ func init() {
 	rePhone, _ = regexp.Compile(`(\d{3})\d*(\d{4})`)
 	ReWhiteSpace, _ = regexp.Compile(`\s`)
 	ReFieldWhiteList, _ = regexp.Compile(`^[A-Za-z0-9]+$`)
-	ReUserName, _ = regexp.Compile("^[a-zA-Z0-9]+((?:-[a-zA-Z0-9]+)|(?:_[a-zA-Z0-9]+))*$")
+	ReUserName, _ = regexp.Compile("^[a-zA-Z0-9]+([-._][a-zA-Z0-9]+)*$")
 }
 
 func IsEmailValid(email string) bool {


### PR DESCRIPTION
Allow dot in the username (like john.smith), which is a corporate standard in many organizations.