### PR TITLE
feat: improve route, separate App.js and use lazy route in EntryPage

### DIFF
--- a/web/craco.config.js
+++ b/web/craco.config.js
@@ -1,6 +1,4 @@
 const CracoLessPlugin = require("craco-less");
-const {BundleAnalyzerPlugin} = require("webpack-bundle-analyzer");
-const path = require("path");
 
 module.exports = {
   devServer: {
@@ -59,15 +57,6 @@ module.exports = {
   webpack: {
     configure: (webpackConfig) => {
       if (webpackConfig.mode === "production") {
-        webpackConfig.plugins = webpackConfig.plugins.concat(
-          new BundleAnalyzerPlugin({
-            analyzerMode: "server",
-            analyzerHost: "127.0.0.1",
-            analyzerPort: 8888,
-            openAnalyzer: true, // 构建完打开浏览器
-            reportFilename: path.resolve(__dirname, "analyzer/index.html"),
-          })
-        );
         webpackConfig.devtool = false;
         webpackConfig.optimization = {
           splitChunks: {

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "@ctrl/tinycolor": "^3.5.0",
     "@emotion/react": "^11.10.5",
     "@metamask/eth-sig-util": "^6.0.0",
+    "@reduxjs/toolkit": "^2.2.1",
     "@web3-onboard/coinbase": "^2.2.5",
     "@web3-onboard/core": "^2.20.5",
     "@web3-onboard/frontier": "^2.0.4",
@@ -32,6 +33,7 @@
     "file-saver": "^2.0.5",
     "i18n-iso-countries": "^7.0.0",
     "i18next": "^19.8.9",
+    "i18next-resources-to-backend": "^1.2.0",
     "jwt-decode": "^4.0.0",
     "libphonenumber-js": "^1.10.19",
     "moment": "^2.29.1",
@@ -48,9 +50,12 @@
     "react-highlight-words": "^0.18.0",
     "react-i18next": "^11.8.7",
     "react-metamask-avatar": "^1.2.1",
+    "react-redux": "^9.1.0",
     "react-router-dom": "^5.3.3",
     "react-scripts": "5.0.1",
-    "react-social-login-buttons": "^3.4.0"
+    "react-social-login-buttons": "^3.4.0",
+    "redux": "^5.0.1",
+    "webpack-bundle-analyzer": "^4.10.1"
   },
   "scripts": {
     "start": "cross-env PORT=7001 craco start",

--- a/web/package.json
+++ b/web/package.json
@@ -54,8 +54,7 @@
     "react-router-dom": "^5.3.3",
     "react-scripts": "5.0.1",
     "react-social-login-buttons": "^3.4.0",
-    "redux": "^5.0.1",
-    "webpack-bundle-analyzer": "^4.10.1"
+    "redux": "^5.0.1"
   },
   "scripts": {
     "start": "cross-env PORT=7001 craco start",

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -19,7 +19,7 @@ import * as Setting from "./Setting";
 import {StyleProvider, legacyLogicalPropertiesTransformer} from "@ant-design/cssinjs";
 import {GithubOutlined, InfoCircleFilled, ShareAltOutlined} from "@ant-design/icons";
 import {Alert, Button, ConfigProvider, Drawer, FloatButton, Layout, Result, Tooltip} from "antd";
-import {Route, Switch, withRouter} from "react-router-dom";
+import {Redirect, Route, Switch, withRouter} from "react-router-dom";
 import CustomGithubCorner from "./common/CustomGithubCorner";
 import * as Conf from "./Conf";
 
@@ -355,6 +355,15 @@ class App extends Component {
           }
         </Layout>
       );
+    }
+
+    if (window.location.pathname === "/" && !this.props.account) {
+      if (this.props.account === null) {
+        sessionStorage.setItem("from", window.location.pathname);
+        return <Redirect to="/login" />;
+      } else if (this.props.account === undefined) {
+        return null;
+      }
     }
 
     return (

--- a/web/src/AppContent.js
+++ b/web/src/AppContent.js
@@ -1,0 +1,353 @@
+import * as Setting from "./Setting";
+import {Avatar, Button, Card, Drawer, Dropdown, Menu, Result, Tooltip} from "antd";
+import EnableMfaNotification from "./common/notifaction/EnableMfaNotification";
+import {Link, Redirect, Route, Switch} from "react-router-dom";
+import React, {Suspense} from "react";
+import i18next from "i18next";
+import {
+  AppstoreTwoTone,
+  BarsOutlined,
+  DeploymentUnitOutlined, DollarTwoTone, DownOutlined,
+  HomeTwoTone,
+  LockTwoTone, LogoutOutlined,
+  SafetyCertificateTwoTone, SettingOutlined, SettingTwoTone, WalletTwoTone
+} from "@ant-design/icons";
+import {Content, Header} from "antd/es/layout/layout";
+import indexRouters from "./routers";
+import LanguageSelect from "./common/select/LanguageSelect";
+import ThemeSelect from "./common/select/ThemeSelect";
+import OpenTour from "./common/OpenTour";
+import OrganizationSelect from "./common/select/OrganizationSelect";
+import * as Conf from "./Conf";
+import AccountAvatar from "./account/AccountAvatar";
+import {useDispatch, useSelector} from "react-redux";
+import {setLogo, setThemeAlgorithm} from "./store/themeSlice";
+import * as AuthBackend from "./auth/AuthBackend";
+import {clearWeb3AuthToken} from "./auth/Web3Auth";
+import {setAccount} from "./store/accountSlice";
+
+function AppContent(props) {
+
+  const account = useSelector((state) => state.account.value);
+  const themeAlgorithm = useSelector((state) => state.theme.themeAlgorithm);
+  const logo = useSelector((state) => state.theme.logo);
+
+  const dispatch = useDispatch();
+
+  function isWithoutCard() {
+    return Setting.isMobile() || window.location.pathname.startsWith("/trees");
+  }
+
+  function renderLoginIfNotLoggedIn(component) {
+    if (account === null) {
+      sessionStorage.setItem("from", window.location.pathname);
+      return <Redirect to="/login" />;
+    } else if (account === undefined) {
+      return null;
+    } else {
+      return component;
+    }
+  }
+
+  function logout() {
+
+    props.setExpiredAndSubmitted();
+
+    AuthBackend.logout()
+      .then((res) => {
+        if (res.status === "ok") {
+          const owner = account.owner;
+
+          dispatch(setThemeAlgorithm(["default"]));
+          dispatch(setAccount(null));
+
+          clearWeb3AuthToken();
+          Setting.showMessage("success", i18next.t("application:Logged out successfully"));
+          const redirectUri = res.data2;
+          if (redirectUri !== null && redirectUri !== undefined && redirectUri !== "") {
+            Setting.goToLink(redirectUri);
+          } else if (owner !== "built-in") {
+            Setting.goToLink(`${window.location.origin}/login/${owner}`);
+          } else {
+            Setting.goToLinkSoft(this, "/");
+          }
+        } else {
+          Setting.showMessage("error", `Failed to log out: ${res.msg}`);
+        }
+      });
+  }
+
+  function renderRouter() {
+    return (
+      <Suspense fallback={<div></div>}>
+        <Switch>
+          {indexRouters.map((el, index) => {
+            const Element = el.component;
+            return (<Route key="" exact={el.exact} path={el.path} render={(props) => {
+              if (el.path === "/mfa/setup") {
+                props.onfinish = () => {this.props.setRequireMfaFalse();};
+                props.account = account;
+                return renderLoginIfNotLoggedIn(<Element {...props} />);
+              }
+              if (el.auth) {
+                props.account = account;
+                return renderLoginIfNotLoggedIn(<Element {...props} />);
+              } else {
+                return <Element />;
+              }
+            }} />);
+          })}
+          <Route exact path="" render={(props) =>
+            <Result status="404" title="404 NOT FOUND" subTitle={i18next.t("general:Sorry, the page you visited does not exist.")} extra={<a href="/web/public"><Button type="primary">{i18next.t("general:Back Home")}</Button></a>} />}
+          />
+        </Switch>
+      </Suspense>
+    );
+  }
+
+  function renderAvatar() {
+    if (account.avatar === "") {
+      return (
+        <Avatar style={{backgroundColor: Setting.getAvatarColor(account.name), verticalAlign: "middle"}} size="large">
+          {Setting.getShortName(account.name)}
+        </Avatar>
+      );
+    } else {
+      return (
+        <Avatar src={account.avatar} style={{verticalAlign: "middle"}} size="large"
+          icon={<AccountAvatar src={account.avatar} style={{verticalAlign: "middle"}} size={40} />}
+        >
+          {Setting.getShortName(account.name)}
+        </Avatar>
+      );
+    }
+  }
+
+  function renderRightDropdown() {
+    const items = [];
+    if (props.requiredEnableMfa === false) {
+      items.push(Setting.getItem(<><SettingOutlined />&nbsp;&nbsp;{i18next.t("account:My Account")}</>,
+        "/account"
+      ));
+    }
+    items.push(Setting.getItem(<><LogoutOutlined />&nbsp;&nbsp;{i18next.t("account:Logout")}</>,
+      "/logout"));
+
+    const onClick = (e) => {
+      if (e.key === "/account") {
+        props.history.push("/account");
+      } else if (e.key === "/subscription") {
+        props.history.push("/subscription");
+      } else if (e.key === "/logout") {
+        logout();
+      }
+    };
+
+    return (
+      <Dropdown key="/rightDropDown" menu={{items, onClick}} >
+        <div className="rightDropDown">
+          {
+            renderAvatar()
+          }
+                  &nbsp;
+                  &nbsp;
+          {Setting.isMobile() ? null : Setting.getShortText(Setting.getNameAtLeast(account.displayName), 30)} &nbsp; <DownOutlined />
+                  &nbsp;
+                  &nbsp;
+                  &nbsp;
+        </div>
+      </Dropdown>
+    );
+  }
+
+  function renderAccountMenu() {
+    if (account === undefined) {
+      return null;
+    } else if (account === null) {
+      return (
+        <React.Fragment>
+          <LanguageSelect />
+        </React.Fragment>
+      );
+    } else {
+      return (
+        <React.Fragment>
+          {renderRightDropdown()}
+          <ThemeSelect
+            themeAlgorithm={themeAlgorithm}
+            onChange={(nextThemeAlgorithm) => {
+              // props.setThemeAlgorithm(nextThemeAlgorithm);
+              dispatch(setThemeAlgorithm(nextThemeAlgorithm));
+              // props.setLogo(nextThemeAlgorithm);
+              dispatch(setLogo(nextThemeAlgorithm));
+            }} />
+          <LanguageSelect languages={account.organization.languages} />
+          <Tooltip title="Click to open AI assitant">
+            <div className="select-box" onClick={() => {
+              props.OpenAiAssistant();
+            }}>
+              <DeploymentUnitOutlined style={{fontSize: "24px", color: "rgb(77,77,77)"}} />
+            </div>
+          </Tooltip>
+          <OpenTour />
+          {Setting.isAdminUser(account) && !Setting.isMobile() && (props.uri.indexOf("/trees") === -1) &&
+                      <OrganizationSelect
+                        initValue={Setting.getOrganization()}
+                        withAll={true}
+                        style={{marginRight: "20px", width: "180px", display: "flex"}}
+                        onChange={(value) => {
+                          Setting.setOrganization(value);
+                        }}
+                        className="select-box"
+                      />
+          }
+        </React.Fragment>
+      );
+    }
+  }
+
+  function getMenuItems() {
+    const res = [];
+
+    if (account === null || account === undefined) {
+      return [];
+    }
+
+    res.push(Setting.getItem(<Link to="/">{i18next.t("general:Home")}</Link>, "/home", <HomeTwoTone />, [
+      Setting.getItem(<Link to="/">{i18next.t("general:Dashboard")}</Link>, "/"),
+      Setting.getItem(<Link to="/shortcuts">{i18next.t("general:Shortcuts")}</Link>, "/shortcuts"),
+      Setting.getItem(<Link to="/apps">{i18next.t("general:Apps")}</Link>, "/apps"),
+    ].filter(item => {
+      return Setting.isLocalAdminUser(account);
+    })));
+
+    if (Setting.isLocalAdminUser(account)) {
+      if (Conf.ShowGithubCorner) {
+        res.push(Setting.getItem(<a href={"https://casdoor.com"}>
+          <span style={{fontWeight: "bold", backgroundColor: "rgba(87,52,211,0.4)", marginTop: "12px", paddingLeft: "5px", paddingRight: "5px", display: "flex", alignItems: "center", height: "40px", borderRadius: "5px"}}>
+            🚀 SaaS Hosting 🔥
+          </span>
+        </a>, "#"));
+      }
+
+      res.push(Setting.getItem(<Link style={{color: "black"}} to="/organizations">{i18next.t("general:User Management")}</Link>, "/orgs", <AppstoreTwoTone />, [
+        Setting.getItem(<Link to="/organizations">{i18next.t("general:Organizations")}</Link>, "/organizations"),
+        Setting.getItem(<Link to="/groups">{i18next.t("general:Groups")}</Link>, "/groups"),
+        Setting.getItem(<Link to="/users">{i18next.t("general:Users")}</Link>, "/users"),
+        Setting.getItem(<Link to="/invitations">{i18next.t("general:Invitations")}</Link>, "/invitations"),
+      ]));
+
+      res.push(Setting.getItem(<Link style={{color: "black"}} to="/applications">{i18next.t("general:Identity")}</Link>, "/identity", <LockTwoTone />, [
+        Setting.getItem(<Link to="/applications">{i18next.t("general:Applications")}</Link>, "/applications"),
+        Setting.getItem(<Link to="/providers">{i18next.t("general:Providers")}</Link>, "/providers"),
+        Setting.getItem(<Link to="/resources">{i18next.t("general:Resources")}</Link>, "/resources"),
+        Setting.getItem(<Link to="/certs">{i18next.t("general:Certs")}</Link>, "/certs"),
+      ]));
+
+      res.push(Setting.getItem(<Link style={{color: "black"}} to="/roles">{i18next.t("general:Authorization")}</Link>, "/auth", <SafetyCertificateTwoTone />, [
+        Setting.getItem(<Link to="/roles">{i18next.t("general:Roles")}</Link>, "/roles"),
+        Setting.getItem(<Link to="/permissions">{i18next.t("general:Permissions")}</Link>, "/permissions"),
+        Setting.getItem(<Link to="/models">{i18next.t("general:Models")}</Link>, "/models"),
+        Setting.getItem(<Link to="/adapters">{i18next.t("general:Adapters")}</Link>, "/adapters"),
+        Setting.getItem(<Link to="/enforcers">{i18next.t("general:Enforcers")}</Link>, "/enforcers"),
+      ].filter(item => {
+        if (!Setting.isLocalAdminUser(account) && ["/models", "/adapters", "/enforcers"].includes(item.key)) {
+          return false;
+        } else {
+          return true;
+        }
+      })));
+
+      res.push(Setting.getItem(<Link style={{color: "black"}} to="/sessions">{i18next.t("general:Logging & Auditing")}</Link>, "/logs", <WalletTwoTone />, [
+        Setting.getItem(<Link to="/sessions">{i18next.t("general:Sessions")}</Link>, "/sessions"),
+        Conf.CasvisorUrl ? Setting.getItem(<a target="_blank" rel="noreferrer" href={Conf.CasvisorUrl}>{i18next.t("general:Records")}</a>, "/records")
+          : Setting.getItem(<Link to="/records">{i18next.t("general:Records")}</Link>, "/records"),
+        Setting.getItem(<Link to="/tokens">{i18next.t("general:Tokens")}</Link>, "/tokens"),
+      ]));
+
+      res.push(Setting.getItem(<Link style={{color: "black"}} to="/products">{i18next.t("general:Business & Payments")}</Link>, "/business", <DollarTwoTone />, [
+        Setting.getItem(<Link to="/products">{i18next.t("general:Products")}</Link>, "/products"),
+        Setting.getItem(<Link to="/payments">{i18next.t("general:Payments")}</Link>, "/payments"),
+        Setting.getItem(<Link to="/plans">{i18next.t("general:Plans")}</Link>, "/plans"),
+        Setting.getItem(<Link to="/pricings">{i18next.t("general:Pricings")}</Link>, "/pricings"),
+        Setting.getItem(<Link to="/subscriptions">{i18next.t("general:Subscriptions")}</Link>, "/subscriptions"),
+      ]));
+
+      if (Setting.isAdminUser(account)) {
+        res.push(Setting.getItem(<Link style={{color: "black"}} to="/sysinfo">{i18next.t("general:Admin")}</Link>, "/admin", <SettingTwoTone />, [
+          Setting.getItem(<Link to="/sysinfo">{i18next.t("general:System Info")}</Link>, "/sysinfo"),
+          Setting.getItem(<Link to="/syncers">{i18next.t("general:Syncers")}</Link>, "/syncers"),
+          Setting.getItem(<Link to="/webhooks">{i18next.t("general:Webhooks")}</Link>, "/webhooks"),
+          Setting.getItem(<a target="_blank" rel="noreferrer" href={Setting.isLocalhost() ? `${Setting.ServerUrl}/swagger` : "/swagger"}>{i18next.t("general:Swagger")}</a>, "/swagger")]));
+      } else {
+        res.push(Setting.getItem(<Link style={{color: "black"}} to="/syncers">{i18next.t("general:Admin")}</Link>, "/admin", <SettingTwoTone />, [
+          Setting.getItem(<Link to="/syncers">{i18next.t("general:Syncers")}</Link>, "/syncers"),
+          Setting.getItem(<Link to="/webhooks">{i18next.t("general:Webhooks")}</Link>, "/webhooks")]));
+      }
+    }
+
+    return res;
+  }
+
+  const onClick = ({key}) => {
+    if (key !== "/swagger" && key !== "/records") {
+      if (props.requiredEnableMfa) {
+        Setting.showMessage("info", "Please enable MFA first!");
+      } else {
+        props.history.push(key);
+      }
+    }
+  };
+  const menuStyleRight = Setting.isAdminUser(account) && !Setting.isMobile() ? "calc(180px + 280px)" : "280px";
+
+  return (
+    <React.Fragment>
+      <EnableMfaNotification account={account} />
+      <Header style={{padding: "0", marginBottom: "3px", backgroundColor: themeAlgorithm.includes("dark") ? "black" : "white"}} >
+        {Setting.isMobile() ? null : (
+          <Link to={"/"}>
+            <div className="logo" style={{background: `url(${logo})`}} />
+          </Link>
+        )}
+        {props.requiredEnableMfa || (Setting.isMobile() ?
+          <React.Fragment>
+            <Drawer title={i18next.t("general:Close")} placement="left" visible={props.menuVisible} onClose={props.onClose}>
+              <Menu
+                items={getMenuItems()}
+                mode={"inline"}
+                selectedKeys={[props.selectedMenuKey]}
+                style={{lineHeight: "64px"}}
+                onClick={props.onClose}
+              >
+              </Menu>
+            </Drawer>
+            <Button icon={<BarsOutlined />} onClick={props.showMenu} type="text">
+              {i18next.t("general:Menu")}
+            </Button>
+          </React.Fragment> :
+          <Menu
+            onClick={onClick}
+            items={getMenuItems()}
+            mode={"horizontal"}
+            selectedKeys={[props.selectedMenuKey]}
+            style={{position: "absolute", left: "145px", right: menuStyleRight}}
+          />
+        )}
+        {
+          renderAccountMenu()
+        }
+      </Header>
+      <Content style={{display: "flex", flexDirection: "column"}} >
+        {isWithoutCard() ?
+          renderRouter() :
+          <Card className="content-warp-card">
+            {renderRouter()}
+          </Card>
+        }
+      </Content>
+
+    </React.Fragment>
+  );
+}
+
+export default AppContent;

--- a/web/src/EntryPage.js
+++ b/web/src/EntryPage.js
@@ -12,26 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from "react";
+import React, {Suspense} from "react";
 import {Redirect, Route, Switch} from "react-router-dom";
 import {Spin} from "antd";
 import i18next from "i18next";
 import * as ApplicationBackend from "./backend/ApplicationBackend";
-import PricingPage from "./pricing/PricingPage";
 import * as Setting from "./Setting";
 import * as Conf from "./Conf";
-import SignupPage from "./auth/SignupPage";
-import SelfLoginPage from "./auth/SelfLoginPage";
-import LoginPage from "./auth/LoginPage";
-import SelfForgetPage from "./auth/SelfForgetPage";
-import ForgetPage from "./auth/ForgetPage";
-import PromptPage from "./auth/PromptPage";
-import ResultPage from "./auth/ResultPage";
-import CasLogout from "./auth/CasLogout";
-import {authConfig} from "./auth/Auth";
-import ProductBuyPage from "./ProductBuyPage";
-import PaymentResultPage from "./PaymentResultPage";
-import QrCodePage from "./QrCodePage";
+import {setTheme} from "./store/themeSlice";
+import {connect} from "react-redux";
+import entryRoutes from "./routers/entry";
 import CustomHead from "./basic/CustomHead";
 
 class EntryPage extends React.Component {
@@ -67,8 +57,9 @@ class EntryPage extends React.Component {
       this.setState({
         application: application,
       });
+
       const themeData = application !== null ? Setting.getThemeData(application.organizationObj, application) : Conf.ThemeDefault;
-      this.props.updataThemeData(themeData);
+      this.props.setTheme(themeData);
     };
 
     const onUpdatePricing = (pricing) => {
@@ -82,9 +73,10 @@ class EntryPage extends React.Component {
             Setting.showMessage("error", res.msg);
             return;
           }
+
           const application = res.data;
           const themeData = application !== null ? Setting.getThemeData(application.organizationObj, application) : Conf.ThemeDefault;
-          this.props.updataThemeData(themeData);
+          this.props.setTheme(themeData);
         });
     };
 
@@ -95,31 +87,33 @@ class EntryPage extends React.Component {
           style={{backgroundImage: Setting.inIframe() || Setting.isMobile() ? null : `url(${this.state.application?.formBackgroundUrl})`}}>
           <Spin size="large" spinning={this.state.application === undefined && this.state.pricing === undefined} tip={i18next.t("login:Loading")}
             style={{margin: "0 auto"}} />
-          <Switch>
-            <Route exact path="/signup" render={(props) => this.renderHomeIfLoggedIn(<SignupPage {...this.props} application={this.state.application} applicationName={authConfig.appName} onUpdateApplication={onUpdateApplication} {...props} />)} />
-            <Route exact path="/signup/:applicationName" render={(props) => this.renderHomeIfLoggedIn(<SignupPage {...this.props} application={this.state.application} onUpdateApplication={onUpdateApplication} {...props} />)} />
-            <Route exact path="/login" render={(props) => this.renderHomeIfLoggedIn(<SelfLoginPage {...this.props} application={this.state.application} onUpdateApplication={onUpdateApplication} {...props} />)} />
-            <Route exact path="/login/:owner" render={(props) => this.renderHomeIfLoggedIn(<SelfLoginPage {...this.props} application={this.state.application} onUpdateApplication={onUpdateApplication} {...props} />)} />
-            <Route exact path="/signup/oauth/authorize" render={(props) => <SignupPage {...this.props} application={this.state.application} onUpdateApplication={onUpdateApplication} {...props} />} />
-            <Route exact path="/login/oauth/authorize" render={(props) => <LoginPage {...this.props} application={this.state.application} type={"code"} mode={"signin"} onUpdateApplication={onUpdateApplication} {...props} />} />
-            <Route exact path="/login/saml/authorize/:owner/:applicationName" render={(props) => <LoginPage {...this.props} application={this.state.application} type={"saml"} mode={"signin"} onUpdateApplication={onUpdateApplication} {...props} />} />
-            <Route exact path="/forget" render={(props) => this.renderHomeIfLoggedIn(<SelfForgetPage {...this.props} application={this.state.application} onUpdateApplication={onUpdateApplication} {...props} />)} />
-            <Route exact path="/forget/:applicationName" render={(props) => this.renderHomeIfLoggedIn(<ForgetPage {...this.props} application={this.state.application} onUpdateApplication={onUpdateApplication} {...props} />)} />
-            <Route exact path="/prompt" render={(props) => this.renderLoginIfNotLoggedIn(<PromptPage {...this.props} application={this.state.application} onUpdateApplication={onUpdateApplication} {...props} />)} />
-            <Route exact path="/prompt/:applicationName" render={(props) => this.renderLoginIfNotLoggedIn(<PromptPage {...this.props} application={this.state.application} onUpdateApplication={onUpdateApplication} {...props} />)} />
-            <Route exact path="/result" render={(props) => this.renderHomeIfLoggedIn(<ResultPage {...this.props} application={this.state.application} onUpdateApplication={onUpdateApplication} {...props} />)} />
-            <Route exact path="/result/:applicationName" render={(props) => this.renderHomeIfLoggedIn(<ResultPage {...this.props} application={this.state.application} onUpdateApplication={onUpdateApplication} {...props} />)} />
-            <Route exact path="/cas/:owner/:casApplicationName/logout" render={(props) => this.renderHomeIfLoggedIn(<CasLogout {...this.props} application={this.state.application} onUpdateApplication={onUpdateApplication} {...props} />)} />
-            <Route exact path="/cas/:owner/:casApplicationName/login" render={(props) => {return (<LoginPage {...this.props} application={this.state.application} type={"cas"} mode={"signin"} onUpdateApplication={onUpdateApplication} {...props} />);}} />
-            <Route exact path="/select-plan/:owner/:pricingName" render={(props) => <PricingPage {...this.props} pricing={this.state.pricing} onUpdatePricing={onUpdatePricing} {...props} />} />
-            <Route exact path="/buy-plan/:owner/:pricingName" render={(props) => <ProductBuyPage {...this.props} pricing={this.state.pricing} onUpdatePricing={onUpdatePricing} {...props} />} />
-            <Route exact path="/buy-plan/:owner/:pricingName/result" render={(props) => <PaymentResultPage {...this.props} pricing={this.state.pricing} onUpdatePricing={onUpdatePricing} {...props} />} />
-            <Route exact path="/qrcode/:owner/:paymentName" render={(props) => <QrCodePage {...this.props} onUpdateApplication={onUpdateApplication} {...props} />} />
-          </Switch>
+          <Suspense fallback={<div></div>}>
+            <Switch>
+              {entryRoutes.map((el, index) => {
+                const Element = el.component;
+                return (<Route key="" exact={el.exact} path={el.path} render={(props) => {
+                  if (el.auth && el.unAuthRedirect === "home") {
+                    props.onUpdateApplication = onUpdateApplication;
+                    props.application = this.state.application;
+                    return this.renderHomeIfLoggedIn(<Element {...this.props} {...props} {...el.props} />);
+                  } else if (el.auth && el.unAuthRedirect === "login") {
+                    props.onUpdateApplication = onUpdateApplication;
+                    props.application = this.state.application;
+                    return this.renderLoginIfNotLoggedIn(<Element {...this.props} {...props} {...el.props} />);
+                  } else {
+                    props.pricing = this.state.pricing;
+                    props.onUpdatePricing = onUpdatePricing;
+                    props.onUpdateApplication = onUpdateApplication;
+                    return <Element {...this.props} {...props} {...el.props} />;
+                  }
+                }} />);
+              })}
+            </Switch>
+          </Suspense>
         </div>
       </React.Fragment>
     );
   }
 }
 
-export default EntryPage;
+export default connect(null, {setTheme})(EntryPage);

--- a/web/src/NoneEntrySetting.js
+++ b/web/src/NoneEntrySetting.js
@@ -1,0 +1,29 @@
+import * as phoneNumber from "libphonenumber-js";
+import {getLanguage} from "./Setting";
+
+export function initCountries() {
+  const countries = require("i18n-iso-countries");
+  countries.registerLocale(require("i18n-iso-countries/langs/" + getLanguage() + ".json"));
+  return countries;
+}
+
+export function getCountryCode(country) {
+  if (phoneNumber.isSupportedCountry(country)) {
+    return phoneNumber.getCountryCallingCode(country);
+  }
+  return "";
+}
+
+export function getCountryCodeData(countryCodes = phoneNumber.getCountries()) {
+  return countryCodes?.map((countryCode) => {
+    if (phoneNumber.isSupportedCountry(countryCode)) {
+      const name = initCountries().getName(countryCode, getLanguage());
+      return {
+        code: countryCode,
+        name: name || "",
+        phone: phoneNumber.getCountryCallingCode(countryCode),
+      };
+    }
+  }).filter(item => item.name !== "")
+    .sort((a, b) => a.phone - b.phone);
+}

--- a/web/src/OrganizationEditPage.js
+++ b/web/src/OrganizationEditPage.js
@@ -18,6 +18,7 @@ import * as OrganizationBackend from "./backend/OrganizationBackend";
 import * as ApplicationBackend from "./backend/ApplicationBackend";
 import * as LdapBackend from "./backend/LdapBackend";
 import * as Setting from "./Setting";
+import * as NoneEntrySetting from "./NoneEntrySetting";
 import * as Conf from "./Conf";
 import i18next from "i18next";
 import {LinkOutlined} from "@ant-design/icons";
@@ -25,6 +26,8 @@ import LdapTable from "./table/LdapTable";
 import AccountTable from "./table/AccountTable";
 import ThemeEditor from "./common/theme/ThemeEditor";
 import MfaTable from "./table/MfaTable";
+import {connect} from "react-redux";
+import {setTheme} from "./store/themeSlice";
 
 const {Option} = Select;
 
@@ -233,7 +236,7 @@ class OrganizationEditPage extends React.Component {
               filterOption={(input, option) => (option?.text ?? "").toLowerCase().includes(input.toLowerCase())}
             >
               {
-                Setting.getCountryCodeData().map((country) => Setting.getCountryCodeOption(country))
+                NoneEntrySetting.getCountryCodeData().map((country) => Setting.getCountryCodeOption(country))
               }
             </Select>
           </Col>
@@ -441,7 +444,9 @@ class OrganizationEditPage extends React.Component {
           Setting.showMessage("success", i18next.t("general:Successfully saved"));
 
           if (this.props.account.organization.name === this.state.organizationName) {
-            this.props.onChangeTheme(Setting.getThemeData(this.state.organization));
+            // this.props.onChangeTheme(Setting.getThemeData(this.state.organization));
+            // const dispatch = useDispatch();
+            setTheme(Setting.getThemeData(this.state.organization));
           }
 
           this.setState({
@@ -495,4 +500,4 @@ class OrganizationEditPage extends React.Component {
   }
 }
 
-export default OrganizationEditPage;
+export default connect(null, {setTheme})(OrganizationEditPage);

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -19,6 +19,7 @@ import * as ProviderBackend from "./backend/ProviderBackend";
 import * as OrganizationBackend from "./backend/OrganizationBackend";
 import * as CertBackend from "./backend/CertBackend";
 import * as Setting from "./Setting";
+import * as NoneEntrySetting from "./NoneEntrySetting";
 import i18next from "i18next";
 import {authConfig} from "./auth/Auth";
 import * as ProviderEditTestEmail from "./common/TestEmailWidget";
@@ -26,7 +27,7 @@ import * as ProviderNotification from "./common/TestNotificationWidget";
 import * as ProviderEditTestSms from "./common/TestSmsWidget";
 import copy from "copy-to-clipboard";
 import {CaptchaPreview} from "./common/CaptchaPreview";
-import {CountryCodeSelect} from "./common/select/CountryCodeSelect";
+import CountryCodeSelect from "./common/select/CountryCodeSelect";
 import * as Web3Auth from "./auth/Web3Auth";
 
 import {Controlled as CodeMirror} from "react-codemirror2";
@@ -1157,7 +1158,7 @@ class ProviderEditPage extends React.Component {
                 <Col span={2} >
                   <Button style={{marginLeft: "10px", marginBottom: "5px"}} type="primary"
                     disabled={!Setting.isValidPhone(this.state.provider.receiver) && (this.state.provider.type !== "Custom HTTP SMS" || this.state.provider.endpoint === "")}
-                    onClick={() => ProviderEditTestSms.sendTestSms(this.state.provider, "+" + Setting.getCountryCode(this.state.provider.content) + this.state.provider.receiver)} >
+                    onClick={() => ProviderEditTestSms.sendTestSms(this.state.provider, "+" + NoneEntrySetting.getCountryCode(this.state.provider.content) + this.state.provider.receiver)} >
                     {i18next.t("provider:Send Testing SMS")}
                   </Button>
                 </Col>

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -370,33 +370,6 @@ export const OtherProviderInfo = {
   },
 };
 
-// export function initCountries() {
-//   const countries = require("i18n-iso-countries");
-//   countries.registerLocale(require("i18n-iso-countries/langs/" + getLanguage() + ".json"));
-//   return countries;
-// }
-
-// export function getCountryCode(country) {
-//   if (phoneNumber.isSupportedCountry(country)) {
-//     return phoneNumber.getCountryCallingCode(country);
-//   }
-//   return "";
-// }
-
-// export function getCountryCodeData(countryCodes = phoneNumber.getCountries()) {
-//   return countryCodes?.map((countryCode) => {
-//     if (phoneNumber.isSupportedCountry(countryCode)) {
-//       const name = initCountries().getName(countryCode, getLanguage());
-//       return {
-//         code: countryCode,
-//         name: name || "",
-//         phone: phoneNumber.getCountryCallingCode(countryCode),
-//       };
-//     }
-//   }).filter(item => item.name !== "")
-//     .sort((a, b) => a.phone - b.phone);
-// }
-
 export function getCountryCodeOption(country) {
   return (
     <Option key={country.code} value={country.code} label={`+${country.phone}`} text={`${country.name}, ${country.code}, ${country.phone}`} >
@@ -860,11 +833,7 @@ export function getLanguage() {
 
 export function setLanguage(language) {
   localStorage.setItem("language", language);
-  i18next.changeLanguage(language).then(
-    () => {
-      window.console.log(i18next.language, i18next.getDataByLanguage("zh"));
-    }
-  );
+  i18next.changeLanguage(language);
 }
 
 export function getAcceptLanguage() {

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -370,32 +370,32 @@ export const OtherProviderInfo = {
   },
 };
 
-export function initCountries() {
-  const countries = require("i18n-iso-countries");
-  countries.registerLocale(require("i18n-iso-countries/langs/" + getLanguage() + ".json"));
-  return countries;
-}
+// export function initCountries() {
+//   const countries = require("i18n-iso-countries");
+//   countries.registerLocale(require("i18n-iso-countries/langs/" + getLanguage() + ".json"));
+//   return countries;
+// }
 
-export function getCountryCode(country) {
-  if (phoneNumber.isSupportedCountry(country)) {
-    return phoneNumber.getCountryCallingCode(country);
-  }
-  return "";
-}
+// export function getCountryCode(country) {
+//   if (phoneNumber.isSupportedCountry(country)) {
+//     return phoneNumber.getCountryCallingCode(country);
+//   }
+//   return "";
+// }
 
-export function getCountryCodeData(countryCodes = phoneNumber.getCountries()) {
-  return countryCodes?.map((countryCode) => {
-    if (phoneNumber.isSupportedCountry(countryCode)) {
-      const name = initCountries().getName(countryCode, getLanguage());
-      return {
-        code: countryCode,
-        name: name || "",
-        phone: phoneNumber.getCountryCallingCode(countryCode),
-      };
-    }
-  }).filter(item => item.name !== "")
-    .sort((a, b) => a.phone - b.phone);
-}
+// export function getCountryCodeData(countryCodes = phoneNumber.getCountries()) {
+//   return countryCodes?.map((countryCode) => {
+//     if (phoneNumber.isSupportedCountry(countryCode)) {
+//       const name = initCountries().getName(countryCode, getLanguage());
+//       return {
+//         code: countryCode,
+//         name: name || "",
+//         phone: phoneNumber.getCountryCallingCode(countryCode),
+//       };
+//     }
+//   }).filter(item => item.name !== "")
+//     .sort((a, b) => a.phone - b.phone);
+// }
 
 export function getCountryCodeOption(country) {
   return (
@@ -860,7 +860,11 @@ export function getLanguage() {
 
 export function setLanguage(language) {
   localStorage.setItem("language", language);
-  i18next.changeLanguage(language);
+  i18next.changeLanguage(language).then(
+    () => {
+      window.console.log(i18next.language, i18next.getDataByLanguage("zh"));
+    }
+  );
 }
 
 export function getAcceptLanguage() {
@@ -1227,11 +1231,11 @@ export function renderSignupLink(application, text) {
     }
   }
 
-  const storeSigninUrl = () => {
-    sessionStorage.setItem("signinUrl", window.location.href);
-  };
+  // const storeSigninUrl = () => {
+  //   sessionStorage.setItem("signinUrl", window.location.href);
+  // };
 
-  return renderLink(url, text, storeSigninUrl);
+  return url;
 }
 
 export function renderForgetLink(application, text) {

--- a/web/src/UserEditPage.js
+++ b/web/src/UserEditPage.js
@@ -34,7 +34,7 @@ import RegionSelect from "./common/select/RegionSelect";
 import WebAuthnCredentialTable from "./table/WebauthnCredentialTable";
 import ManagedAccountTable from "./table/ManagedAccountTable";
 import PropertyTable from "./table/propertyTable";
-import {CountryCodeSelect} from "./common/select/CountryCodeSelect";
+import CountryCodeSelect from "./common/select/CountryCodeSelect";
 import PopconfirmModal from "./common/modal/PopconfirmModal";
 import {DeleteMfa} from "./backend/MfaBackend";
 import {CheckCircleOutlined, HolderOutlined, UsergroupAddOutlined} from "@ant-design/icons";

--- a/web/src/UserListPage.js
+++ b/web/src/UserListPage.js
@@ -18,6 +18,7 @@ import {Button, Space, Switch, Table, Upload} from "antd";
 import {UploadOutlined} from "@ant-design/icons";
 import moment from "moment";
 import * as OrganizationBackend from "./backend/OrganizationBackend";
+import * as NoneEntrySetting from "./NoneEntrySetting";
 import * as Setting from "./Setting";
 import * as UserBackend from "./backend/UserBackend";
 import i18next from "i18next";
@@ -313,7 +314,7 @@ class UserListPage extends BaseListPage {
         sorter: true,
         ...this.getColumnSearchProps("region"),
         render: (text, record, index) => {
-          return Setting.initCountries().getName(record.region, Setting.getLanguage(), {select: "official"});
+          return NoneEntrySetting.initCountries().getName(record.region, Setting.getLanguage(), {select: "official"});
         },
       },
       {

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -842,9 +842,10 @@ class LoginPage extends React.Component {
           !application.enableSignUp ? null : (
             <React.Fragment>
               {i18next.t("login:No account?")}&nbsp;
-              {
-                Setting.renderSignupLink(application, i18next.t("login:sign up now"))
-              }
+              <a type={"link"} style={{float: "right"}} onClick={() => {
+                this.props.history.push(Setting.renderSignupLink(application, i18next.t("login:sign up now")));
+                sessionStorage.setItem("signinUrl", window.location.href);
+              }}>{i18next.t("login:sign up now")}</a>
             </React.Fragment>
           )
         }

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from "react";
+import React, {Suspense, lazy} from "react";
 import {Button, Form, Input, Result} from "antd";
 import * as Setting from "../Setting";
 import * as AuthBackend from "./AuthBackend";
@@ -23,11 +23,13 @@ import {authConfig} from "./Auth";
 import * as ApplicationBackend from "../backend/ApplicationBackend";
 import * as AgreementModal from "../common/modal/AgreementModal";
 import {SendCodeInput} from "../common/SendCodeInput";
-import RegionSelect from "../common/select/RegionSelect";
+// import RegionSelect from "../common/select/RegionSelect";
+const RegionSelect = lazy(() => import("../common/select/RegionSelect"));
 import CustomGithubCorner from "../common/CustomGithubCorner";
 import LanguageSelect from "../common/select/LanguageSelect";
 import {withRouter} from "react-router-dom";
-import {CountryCodeSelect} from "../common/select/CountryCodeSelect";
+// import {CountryCodeSelect} from "../common/select/CountryCodeSelect";
+const CountryCodeSelect = lazy(() => import("../common/select/CountryCodeSelect"));
 import * as PasswordChecker from "../common/PasswordChecker";
 import * as InvitationBackend from "../backend/InvitationBackend";
 
@@ -357,7 +359,9 @@ class SignupPage extends React.Component {
             },
           ]}
         >
-          <RegionSelect onChange={(value) => {this.setState({region: value});}} />
+          <Suspense fallback={<div>loading</div>}>
+            <RegionSelect onChange={(value) => {this.setState({region: value});}} />
+          </Suspense>
         </Form.Item>
       );
     } else if (signupItem.name === "Email") {
@@ -421,10 +425,12 @@ class SignupPage extends React.Component {
                   },
                 ]}
               >
-                <CountryCodeSelect
-                  style={{width: "35%"}}
-                  countryCodes={this.getApplicationObj().organizationObj.countryCodes}
-                />
+                <Suspense fallback={<div>loading</div>}>
+                  <CountryCodeSelect
+                    style={{width: "35%"}}
+                    countryCodes={this.getApplicationObj().organizationObj.countryCodes}
+                  />
+                </Suspense>
               </Form.Item>
               <Form.Item
                 name="phone"
@@ -639,7 +645,8 @@ class SignupPage extends React.Component {
           <a onClick={() => {
             const linkInStorage = sessionStorage.getItem("signinUrl");
             if (linkInStorage !== null && linkInStorage !== "") {
-              Setting.goToLink(linkInStorage);
+              // Setting.goToLink(linkInStorage);
+              this.props.history.push(`/login/${application.name}?orgChoiceMode=None`);
             } else {
               Setting.redirectToLoginPage(application, this.props.history);
             }

--- a/web/src/auth/mfa/MfaVerifySmsForm.js
+++ b/web/src/auth/mfa/MfaVerifySmsForm.js
@@ -1,8 +1,9 @@
 import {UserOutlined} from "@ant-design/icons";
 import {Button, Form, Input} from "antd";
 import i18next from "i18next";
-import React, {useEffect} from "react";
-import {CountryCodeSelect} from "../../common/select/CountryCodeSelect";
+import React, {Suspense, lazy, useEffect} from "react";
+// import {CountryCodeSelect} from "../common/select/CountryCodeSelect";
+const CountryCodeSelect = lazy(() => import("../../common/select/CountryCodeSelect"));
 import {SendCodeInput} from "../../common/SendCodeInput";
 import * as Setting from "../../Setting";
 import {EmailMfaType, SmsMfaType} from "../MfaSetupPage";
@@ -73,11 +74,13 @@ export const MfaVerifySmsForm = ({mfaProps, application, onFinish, method, user}
                   },
                 ]}
               >
-                <CountryCodeSelect
-                  initValue={mfaProps.countryCode}
-                  style={{width: "30%"}}
-                  countryCodes={application.organizationObj.countryCodes}
-                />
+                <Suspense>
+                  <CountryCodeSelect
+                    initValue={mfaProps.countryCode}
+                    style={{width: "30%"}}
+                    countryCodes={application.organizationObj.countryCodes}
+                  />
+                </Suspense>
               </Form.Item>
             }
             <Form.Item

--- a/web/src/common/modal/ResetModal.js
+++ b/web/src/common/modal/ResetModal.js
@@ -19,6 +19,7 @@ import * as Setting from "../../Setting";
 import * as UserBackend from "../../backend/UserBackend";
 import {SendCodeInput} from "../SendCodeInput";
 import {MailOutlined, PhoneOutlined} from "@ant-design/icons";
+import * as NoneEntrySetting from "../../NoneEntrySetting";
 
 export const ResetModal = (props) => {
   const [visible, setVisible] = React.useState(false);
@@ -87,7 +88,7 @@ export const ResetModal = (props) => {
           <Row style={{width: "100%", marginBottom: "20px"}}>
             <Input
               addonBefore={destType === "email" ? i18next.t("user:New Email") : i18next.t("user:New phone")}
-              prefix={destType === "email" ? <React.Fragment><MailOutlined />&nbsp;&nbsp;</React.Fragment> : (<React.Fragment><PhoneOutlined />&nbsp;&nbsp;{countryCode !== "" ? "+" : null}{Setting.getCountryCode(countryCode)}&nbsp;</React.Fragment>)}
+              prefix={destType === "email" ? <React.Fragment><MailOutlined />&nbsp;&nbsp;</React.Fragment> : (<React.Fragment><PhoneOutlined />&nbsp;&nbsp;{countryCode !== "" ? "+" : null}{NoneEntrySetting.getCountryCode(countryCode)}&nbsp;</React.Fragment>)}
               placeholder={placeholder}
               onChange={e => setDest(e.target.value)}
             />

--- a/web/src/common/select/CountryCodeSelect.js
+++ b/web/src/common/select/CountryCodeSelect.js
@@ -15,8 +15,9 @@
 import {Select} from "antd";
 import * as Setting from "../../Setting";
 import React from "react";
+import * as NoneEntrySetting from "../../NoneEntrySetting";
 
-export const CountryCodeSelect = (props) => {
+const CountryCodeSelect = (props) => {
   const {onChange, style, disabled, initValue} = props;
   const countryCodes = props.countryCodes ?? [];
   const [value, setValue] = React.useState("");
@@ -48,8 +49,10 @@ export const CountryCodeSelect = (props) => {
       filterOption={(input, option) => (option?.text ?? "").toLowerCase().includes(input.toLowerCase())}
     >
       {
-        Setting.getCountryCodeData(countryCodes).map((country) => Setting.getCountryCodeOption(country))
+        NoneEntrySetting.getCountryCodeData(countryCodes).map((country) => Setting.getCountryCodeOption(country))
       }
     </Select>
   );
 };
+
+export default CountryCodeSelect;

--- a/web/src/common/select/RegionSelect.js
+++ b/web/src/common/select/RegionSelect.js
@@ -15,6 +15,7 @@
 import React from "react";
 import * as Setting from "../../Setting";
 import {Select} from "antd";
+import * as NoneEntrySetting from "../../NoneEntrySetting";
 
 const {Option} = Select;
 
@@ -47,7 +48,7 @@ class RegionSelect extends React.Component {
         }
       >
         {
-          Setting.getCountryCodeData().map((item) => (
+          NoneEntrySetting.getCountryCodeData().map((item) => (
             <Option key={item.code} value={item.code} label={`${item.name} (${item.code})`} >
               {Setting.getCountryImage(item)}
               {`${item.name} (${item.code})`}

--- a/web/src/i18n.js
+++ b/web/src/i18n.js
@@ -128,6 +128,6 @@ await i18n.use(resourcesToBackend(async(language, namespace) => {
     },
     // debug: true,
     saveMissing: true,
-  }).then(() => window.console.log(i18n.getDataByLanguage("zh")));
+  });
 
 export default i18n;

--- a/web/src/i18n.js
+++ b/web/src/i18n.js
@@ -14,56 +14,9 @@
 
 import i18n from "i18next";
 import en from "./locales/en/data.json";
-import zh from "./locales/zh/data.json";
-import es from "./locales/es/data.json";
-import fr from "./locales/fr/data.json";
-import de from "./locales/de/data.json";
-import id from "./locales/id/data.json";
-import ja from "./locales/ja/data.json";
-import ko from "./locales/ko/data.json";
-import ru from "./locales/ru/data.json";
-import vi from "./locales/vi/data.json";
-import pt from "./locales/pt/data.json";
-import it from "./locales/it/data.json";
-import ms from "./locales/ms/data.json";
-import tr from "./locales/tr/data.json";
-import ar from "./locales/ar/data.json";
-import he from "./locales/he/data.json";
-import nl from "./locales/nl/data.json";
-import pl from "./locales/pl/data.json";
-import fi from "./locales/fi/data.json";
-import sv from "./locales/sv/data.json";
-import uk from "./locales/uk/data.json";
-import kk from "./locales/kk/data.json";
-import fa from "./locales/fa/data.json";
 import * as Conf from "./Conf";
 import {initReactI18next} from "react-i18next";
-
-const resources = {
-  en: en,
-  zh: zh,
-  es: es,
-  fr: fr,
-  de: de,
-  id: id,
-  ja: ja,
-  ko: ko,
-  ru: ru,
-  vi: vi,
-  pt: pt,
-  it: it,
-  ms: ms,
-  tr: tr,
-  ar: ar,
-  he: he,
-  nl: nl,
-  pl: pl,
-  fi: fi,
-  sv: sv,
-  uk: uk,
-  kk: kk,
-  fa: fa,
-};
+import resourcesToBackend from "i18next-resources-to-backend";
 
 function initLanguage() {
   let language = localStorage.getItem("language");
@@ -157,18 +110,24 @@ function initLanguage() {
   return language;
 }
 
-i18n.use(initReactI18next).init({
-  lng: initLanguage(),
+await i18n.use(resourcesToBackend(async(language, namespace) => {
+  const res = await import(`./locales/${language}/data.json`);
+  return res.default[namespace];
+}
+))
+  .use(initReactI18next)
+  .init({
+    lng: initLanguage(),
+    ns: Object.keys(en),
+    fallbackLng: "en",
 
-  resources: resources,
+    keySeparator: false,
 
-  keySeparator: false,
-
-  interpolation: {
-    escapeValue: true,
-  },
-  // debug: true,
-  saveMissing: true,
-});
+    interpolation: {
+      escapeValue: true,
+    },
+    // debug: true,
+    saveMissing: true,
+  }).then(() => window.console.log(i18n.getDataByLanguage("zh")));
 
 export default i18n;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -54,3 +54,7 @@ code {
 .custom-link:hover {
   color: rgb(64 64 64) !important;
 }
+
+#webpack-dev-server-client-overlay {
+  display: none !important;
+}

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -17,20 +17,26 @@ import "react-app-polyfill/ie9";
 import "react-app-polyfill/stable";
 import React from "react";
 import {createRoot} from "react-dom/client";
+import {Provider} from "react-redux";
 import "./index.css";
 import "./App.less";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
 import {BrowserRouter} from "react-router-dom";
 import "./backend/FetchFilter";
+import store from "./store/index";
 
 const container = document.getElementById("root");
 
 const app = createRoot(container);
 
-app.render(<BrowserRouter>
-  <App />
-</BrowserRouter>);
+app.render(
+  <Provider store={store}>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </Provider>
+);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/web/src/routers/entry.js
+++ b/web/src/routers/entry.js
@@ -1,0 +1,119 @@
+import {lazy} from "react";
+
+// Define routes array
+const entryRoutes = [
+  {
+    path: "/signup",
+    component: lazy(() => import("../auth/SignupPage")),
+    auth: true,
+    unAuthRedirect: "home",
+  },
+  {
+    path: "/signup/:applicationName",
+    component: lazy(() => import("../auth/SignupPage")),
+    auth: true,
+    unAuthRedirect: "home",
+  },
+  {
+    path: "/login",
+    component: lazy(() => import("../auth/SelfLoginPage")),
+    auth: true,
+    unAuthRedirect: "home",
+  },
+  {
+    path: "/login/:owner",
+    component: lazy(() => import("../auth/SelfLoginPage")),
+    auth: true,
+    unAuthRedirect: "home",
+  },
+  {
+    path: "/signup/oauth/authorize",
+    component: lazy(() => import("../auth/SignupPage")),
+    auth: true,
+    unAuthRedirect: "home",
+  },
+  {
+    path: "/login/oauth/authorize",
+    component: lazy(() => import("../auth/LoginPage")),
+    auth: true,
+    unAuthRedirect: "home",
+    props: {
+      type: "code",
+      mode: "signin",
+    },
+  },
+  {
+    path: "/login/saml/authorize/:owner/:applicationName",
+    component: lazy(() => import("../auth/LoginPage")),
+    auth: true,
+    unAuthRedirect: "home",
+    props: {
+      type: "saml",
+      mode: "signin",
+    },
+  },
+  {
+    path: "/forget",
+    component: lazy(() => import("../auth/ForgetPage")),
+    auth: true,
+    unAuthRedirect: "home",
+  },
+  {
+    path: "/forget/:applicationName",
+    component: lazy(() => import("../auth/ForgetPage")),
+    auth: true,
+    unAuthRedirect: "home",
+  },
+  {
+    path: "/prompt",
+    component: lazy(() => import("../auth/PromptPage")),
+    auth: true,
+    unAuthRedirect: "login",
+  },
+  {
+    path: "/prompt/:applicationName",
+    component: lazy(() => import("../auth/PromptPage")),
+    auth: true,
+    unAuthRedirect: "login",
+  },
+  {
+    path: "/result",
+    component: lazy(() => import("../auth/ResultPage")),
+    auth: true,
+    unAuthRedirect: "home",
+  },
+  {
+    path: "/result/:applicationName",
+    component: lazy(() => import("../auth/ResultPage")),
+    auth: true,
+    unAuthRedirect: "home",
+  },
+  {
+    path: "/cas/:owner/:casApplicationName/logout",
+    component: lazy(() => import("../auth/CasLogout")),
+    auth: true,
+    unAuthRedirect: "home",
+  },
+  {
+    path: "/cas/:owner/:casApplicationName/login",
+    component: lazy(() => import("../auth/LoginPage")),
+    props: {
+      type: "cas",
+      mode: "signin",
+    },
+  },
+  {
+    path: "/buy-plan/:owner/:pricingName",
+    component: lazy(() => import("../ProductBuyPage")),
+  },
+  {
+    path: "/buy-plan/:owner/:pricingName/result",
+    component: lazy(() => import("../ProductBuyPage")),
+  },
+  {
+    path: "/qrcode/:owner/:paymentName",
+    component: lazy(() => import("../QrCodePage")),
+  },
+];
+
+export default entryRoutes;

--- a/web/src/routers/index.js
+++ b/web/src/routers/index.js
@@ -1,329 +1,382 @@
-import {lazy} from "react";
+import Dashboard from "../basic/Dashboard";
+import AppListPage from "../basic/AppListPage";
+import ShortcutsPage from "../basic/ShortcutsPage";
+import AccountPage from "../account/AccountPage";
+import OrganizationListPage from "../OrganizationListPage";
+import OrganizationEditPage from "../OrganizationEditPage";
+import UserListPage from "../UserListPage";
+import GroupTreePage from "../GroupTreePage";
+import GroupList from "../GroupList";
+import GroupEdit from "../GroupEdit";
+import UserEditPage from "../UserEditPage";
+import InvitationListPage from "../InvitationListPage";
+import InvitationEditPage from "../InvitationEditPage";
+import ApplicationListPage from "../ApplicationListPage";
+import ApplicationEditPage from "../ApplicationEditPage";
+import ProviderListPage from "../ProviderListPage";
+import ProviderEditPage from "../ProviderEditPage";
+import ResourceListPage from "../ResourceListPage";
+import CertListPage from "../CertListPage";
+import CertEditPage from "../CertEditPage";
+import RoleListPage from "../RoleListPage";
+import RoleEditPage from "../RoleEditPage";
+import PermissionListPage from "../PermissionListPage";
+import PermissionEditPage from "../PermissionEditPage";
+import ModelListPage from "../ModelListPage";
+import ModelEditPage from "../ModelEditPage";
+import AdapterListPage from "../AdapterListPage";
+import AdapterEditPage from "../AdapterEditPage";
+import EnforcerListPage from "../EnforcerListPage";
+import EnforcerEditPage from "../EnforcerEditPage";
+import SessionListPage from "../SessionListPage";
+import TokenListPage from "../TokenListPage";
+import TokenEditPage from "../TokenEditPage";
+import ProductListPage from "../ProductListPage";
+import ProductEditPage from "../ProductEditPage";
+import ProductBuyPage from "../ProductBuyPage";
+import RecordListPage from "../RecordListPage";
+import PaymentListPage from "../PaymentListPage";
+import PaymentEditPage from "../PaymentEditPage";
+import PaymentResultPage from "../PaymentResultPage";
+import PlanListPage from "../PlanListPage";
+import PlanEditPage from "../PlanEditPage";
+import PricingListPage from "../PricingListPage";
+import PricingEditPage from "../PricingEditPage";
+import SubscriptionListPage from "../SubscriptionListPage";
+import SubscriptionEditPage from "../SubscriptionEditPage";
+import SystemInfo from "../SystemInfo";
+import SyncerListPage from "../SyncerListPage";
+import SyncerEditPage from "../SyncerEditPage";
+import WebhookListPage from "../WebhookListPage";
+import WebhookEditPage from "../WebhookEditPage";
+import LdapEditPage from "../LdapEditPage";
+import LdapSyncPage from "../LdapSyncPage";
+import MfaSetupPage from "../auth/MfaSetupPage";
+import OidcDiscoveryPage from "../auth/OidcDiscoveryPage";
 
 const indexRouters = [
   {
     path: "/",
     exact: true,
-    component: lazy(() => import("../basic/Dashboard")),
+    component: Dashboard,
     auth: true,
-
   },
   {
     path: "/apps",
     exact: true,
-    component: lazy(() => import("../basic/AppListPage")),
+    component: AppListPage,
     auth: true,
 
   },
   {
     path: "/shortcuts",
     exact: true,
-    component: lazy(() => import("../basic/ShortcutsPage")),
+    component: ShortcutsPage,
     auth: true,
 
   },
   {
     path: "/account",
     exact: true,
-    component: lazy(() => import("../account/AccountPage")),
+    component: AccountPage,
     auth: true,
 
   },
   {
     path: "/organizations",
     exact: true,
-    component: lazy(() => import("../OrganizationListPage")),
+    component: OrganizationListPage,
     auth: true,
 
   },
   {
     path: "/organizations/:organizationName",
     exact: true,
-    component: lazy(() => import("../OrganizationEditPage")),
+    component: OrganizationEditPage,
     auth: true,
 
   },
   {
     path: "/organizations/:organizationName/users",
     exact: true,
-    component: lazy(() => import("../UserListPage")),
+    component: UserListPage,
     auth: true,
   },
   {
     path: "/trees/:organizationName",
     exact: true,
-    component: lazy(() => import("../GroupTreePage")),
+    component: GroupTreePage,
     auth: true,
   },
   {
     path: "/trees/:organizationName/:groupName",
     exact: true,
-    component: lazy(() => import("../GroupTreePage")),
+    component: GroupTreePage,
     auth: true,
   },
   {
     path: "/groups",
     exact: true,
-    component: lazy(() => import("../GroupList")),
+    component: GroupList,
     auth: true,
   },
   {
     path: "/groups/:organizationName/:groupName",
     exact: true,
-    component: lazy(() => import("../GroupEdit")),
+    component: GroupEdit,
     auth: true,
   },
   {
     path: "/users",
     exact: true,
-    component: lazy(() => import("../UserListPage")),
+    component: UserListPage,
     auth: true,
   },
   {
     path: "/users/:organizationName/:userName",
-    component: lazy(() => import("../UserEditPage")),
+    component: UserEditPage,
     auth: true,
   },
   {
     path: "/invitations",
     exact: true,
-    component: lazy(() => import("../InvitationListPage")),
+    component: InvitationListPage,
     auth: true,
   },
   {
     path: "/invitations/:organizationName/:invitationName",
-    component: lazy(() => import("../InvitationEditPage")),
+    component: InvitationEditPage,
     auth: true,
   },
   {
     path: "/applications",
     exact: true,
-    component: lazy(() => import("../ApplicationListPage")),
+    component: ApplicationListPage,
     auth: true,
   },
   {
     path: "/applications/:organizationName/:applicationName",
-    component: lazy(() => import("../ApplicationEditPage")),
+    component: ApplicationEditPage,
     auth: true,
   },
   {
     path: "/providers",
     exact: true,
-    component: lazy(() => import("../ProviderListPage")),
+    component: ProviderListPage,
     auth: true,
   },
   {
     path: "/providers/:organizationName/:providerName",
-    component: lazy(() => import("../ProviderEditPage")),
+    component: ProviderEditPage,
     auth: true,
   },
   {
     path: "/resources",
     exact: true,
-    component: lazy(() => import("../ResourceListPage")),
+    component: ResourceListPage,
     auth: true,
   },
   {
     path: "/certs",
     exact: true,
-    component: lazy(() => import("../CertListPage")),
+    component: CertListPage,
     auth: true,
   },
   {
     path: "/certs/:organizationName/:certName",
-    component: lazy(() => import("../CertEditPage")),
+    component: CertEditPage,
     auth: true,
   },
   {
     path: "/roles",
     exact: true,
-    component: lazy(() => import("../RoleListPage")),
+    component: RoleListPage,
     auth: true,
   },
   {
     path: "/roles/:organizationName/:roleName",
-    component: lazy(() => import("../RoleEditPage")),
+    component: RoleEditPage,
     auth: true,
   },
   {
     path: "/permissions",
     exact: true,
-    component: lazy(() => import("../PermissionListPage")),
+    component: PermissionListPage,
     auth: true,
   },
   {
     path: "/permissions/:organizationName/:permissionName",
-    component: lazy(() => import("../PermissionEditPage")),
+    component: PermissionEditPage,
     auth: true,
   },
   {
     path: "/models",
     exact: true,
-    component: lazy(() => import("../ModelListPage")),
+    component: ModelListPage,
     auth: true,
   },
   {
     path: "/models/:organizationName/:modelName",
-    component: lazy(() => import("../ModelEditPage")),
+    component: ModelEditPage,
     auth: true,
   },
   {
     path: "/adapters",
     exact: true,
-    component: lazy(() => import("../AdapterListPage")),
+    component: AdapterListPage,
     auth: true,
   },
   {
     path: "/adapters/:organizationName/:adapterName",
-    component: lazy(() => import("../AdapterEditPage")),
+    component: AdapterEditPage,
     auth: true,
   },
   {
     path: "/enforcers",
     exact: true,
-    component: lazy(() => import("../EnforcerListPage")),
+    component: EnforcerListPage,
     auth: true,
   },
   {
     path: "/enforcers/:organizationName/:enforcerName",
-    component: lazy(() => import("../EnforcerEditPage")),
+    component: EnforcerEditPage,
     auth: true,
   },
   {
     path: "/sessions",
     exact: true,
-    component: lazy(() => import("../SessionListPage")),
+    component: SessionListPage,
     auth: true,
   },
   {
     path: "/tokens",
     exact: true,
-    component: lazy(() => import("../TokenListPage")),
+    component: TokenListPage,
     auth: true,
   },
   {
     path: "/tokens/:tokenName",
-    component: lazy(() => import("../TokenEditPage")),
+    component: TokenEditPage,
     auth: true,
   },
   {
     path: "/products",
     exact: true,
-    component: lazy(() => import("../ProductListPage")),
+    component: ProductListPage,
     auth: true,
   },
   {
     path: "/products/:organizationName/:productName",
-    component: lazy(() => import("../ProductEditPage")),
+    component: ProductEditPage,
     auth: true,
   },
   {
     path: "/products/:organizationName/:productName/buy",
-    component: lazy(() => import("../ProductBuyPage")),
+    component: ProductBuyPage,
     auth: true,
   },
   {
     path: "/records",
-    component: lazy(() => import("../RecordListPage")),
+    component: RecordListPage,
     auth: true,
   },
   {
     path: "/payments",
     exact: true,
-    component: lazy(() => import("../PaymentListPage")),
+    component: PaymentListPage,
     auth: true,
   },
   {
     path: "/payments/:organizationName/:paymentName",
-    component: lazy(() => import("../PaymentEditPage")),
+    component: PaymentEditPage,
     auth: true,
   },
   {
     path: "/payments/:organizationName/:paymentName/result",
-    component: lazy(() => import("../PaymentResultPage")),
+    component: PaymentResultPage,
     auth: true,
   },
   {
     path: "/plans",
     exact: true,
-    component: lazy(() => import("../PlanListPage")),
+    component: PlanListPage,
     auth: true,
   },
   {
     path: "/plans/:organizationName/:planName",
-    component: lazy(() => import("../PlanEditPage")),
+    component: PlanEditPage,
     auth: true,
   },
   {
     path: "/pricings",
     exact: true,
-    component: lazy(() => import("../PricingListPage")),
+    component: PricingListPage,
     auth: true,
   },
   {
     path: "/pricings/:organizationName/:pricingName",
-    component: lazy(() => import("../PricingEditPage")),
+    component: PricingEditPage,
     auth: true,
   },
   {
     path: "/subscriptions",
     exact: true,
-    component: lazy(() => import("../SubscriptionListPage")),
+    component: SubscriptionListPage,
     auth: true,
   },
   {
     path: "/subscriptions/:organizationName/:subscriptionName",
-    component: lazy(() => import("../SubscriptionEditPage")),
+    component: SubscriptionEditPage,
     auth: true,
   },
   {
     path: "/sysinfo",
     exact: true,
-    component: lazy(() => import("../SystemInfo")),
+    component: SystemInfo,
     auth: true,
   },
   {
     path: "/syncers",
     exact: true,
-    component: lazy(() => import("../SyncerListPage")),
+    component: SyncerListPage,
     auth: true,
   },
   {
     path: "/syncers/:syncerName",
-    component: lazy(() => import("../SyncerEditPage")),
+    component: SyncerEditPage,
     auth: true,
   },
   {
     path: "/webhooks",
     exact: true,
-    component: lazy(() => import("../WebhookListPage")),
+    component: WebhookListPage,
     auth: true,
   },
   {
     path: "/webhooks/:webhookName",
-    component: lazy(() => import("../WebhookEditPage")),
+    component: WebhookEditPage,
     auth: true,
   },
   {
     path: "/ldap/:organizationName/:ldapId",
-    component: lazy(() => import("../LdapEditPage")),
+    component: LdapEditPage,
     auth: true,
   },
   {
     path: "/ldap/sync/:organizationName/:ldapId",
-    component: lazy(() => import("../LdapSyncPage")),
+    component: LdapSyncPage,
     auth: true,
   },
   {
     path: "/mfa/setup",
     exact: true,
-    component: lazy(() => import("../auth/MfaSetupPage")),
+    component: MfaSetupPage,
     auth: true,
   },
   {
     path: "/.well-known/openid-configuration",
     exact: true,
-    component: lazy(() => import("../auth/OidcDiscoveryPage")),
+    component: OidcDiscoveryPage,
   },
 ];
 

--- a/web/src/routers/index.js
+++ b/web/src/routers/index.js
@@ -1,0 +1,330 @@
+import {lazy} from "react";
+
+const indexRouters = [
+  {
+    path: "/",
+    exact: true,
+    component: lazy(() => import("../basic/Dashboard")),
+    auth: true,
+
+  },
+  {
+    path: "/apps",
+    exact: true,
+    component: lazy(() => import("../basic/AppListPage")),
+    auth: true,
+
+  },
+  {
+    path: "/shortcuts",
+    exact: true,
+    component: lazy(() => import("../basic/ShortcutsPage")),
+    auth: true,
+
+  },
+  {
+    path: "/account",
+    exact: true,
+    component: lazy(() => import("../account/AccountPage")),
+    auth: true,
+
+  },
+  {
+    path: "/organizations",
+    exact: true,
+    component: lazy(() => import("../OrganizationListPage")),
+    auth: true,
+
+  },
+  {
+    path: "/organizations/:organizationName",
+    exact: true,
+    component: lazy(() => import("../OrganizationEditPage")),
+    auth: true,
+
+  },
+  {
+    path: "/organizations/:organizationName/users",
+    exact: true,
+    component: lazy(() => import("../UserListPage")),
+    auth: true,
+  },
+  {
+    path: "/trees/:organizationName",
+    exact: true,
+    component: lazy(() => import("../GroupTreePage")),
+    auth: true,
+  },
+  {
+    path: "/trees/:organizationName/:groupName",
+    exact: true,
+    component: lazy(() => import("../GroupTreePage")),
+    auth: true,
+  },
+  {
+    path: "/groups",
+    exact: true,
+    component: lazy(() => import("../GroupList")),
+    auth: true,
+  },
+  {
+    path: "/groups/:organizationName/:groupName",
+    exact: true,
+    component: lazy(() => import("../GroupEdit")),
+    auth: true,
+  },
+  {
+    path: "/users",
+    exact: true,
+    component: lazy(() => import("../UserListPage")),
+    auth: true,
+  },
+  {
+    path: "/users/:organizationName/:userName",
+    component: lazy(() => import("../UserEditPage")),
+    auth: true,
+  },
+  {
+    path: "/invitations",
+    exact: true,
+    component: lazy(() => import("../InvitationListPage")),
+    auth: true,
+  },
+  {
+    path: "/invitations/:organizationName/:invitationName",
+    component: lazy(() => import("../InvitationEditPage")),
+    auth: true,
+  },
+  {
+    path: "/applications",
+    exact: true,
+    component: lazy(() => import("../ApplicationListPage")),
+    auth: true,
+  },
+  {
+    path: "/applications/:organizationName/:applicationName",
+    component: lazy(() => import("../ApplicationEditPage")),
+    auth: true,
+  },
+  {
+    path: "/providers",
+    exact: true,
+    component: lazy(() => import("../ProviderListPage")),
+    auth: true,
+  },
+  {
+    path: "/providers/:organizationName/:providerName",
+    component: lazy(() => import("../ProviderEditPage")),
+    auth: true,
+  },
+  {
+    path: "/resources",
+    exact: true,
+    component: lazy(() => import("../ResourceListPage")),
+    auth: true,
+  },
+  {
+    path: "/certs",
+    exact: true,
+    component: lazy(() => import("../CertListPage")),
+    auth: true,
+  },
+  {
+    path: "/certs/:organizationName/:certName",
+    component: lazy(() => import("../CertEditPage")),
+    auth: true,
+  },
+  {
+    path: "/roles",
+    exact: true,
+    component: lazy(() => import("../RoleListPage")),
+    auth: true,
+  },
+  {
+    path: "/roles/:organizationName/:roleName",
+    component: lazy(() => import("../RoleEditPage")),
+    auth: true,
+  },
+  {
+    path: "/permissions",
+    exact: true,
+    component: lazy(() => import("../PermissionListPage")),
+    auth: true,
+  },
+  {
+    path: "/permissions/:organizationName/:permissionName",
+    component: lazy(() => import("../PermissionEditPage")),
+    auth: true,
+  },
+  {
+    path: "/models",
+    exact: true,
+    component: lazy(() => import("../ModelListPage")),
+    auth: true,
+  },
+  {
+    path: "/models/:organizationName/:modelName",
+    component: lazy(() => import("../ModelEditPage")),
+    auth: true,
+  },
+  {
+    path: "/adapters",
+    exact: true,
+    component: lazy(() => import("../AdapterListPage")),
+    auth: true,
+  },
+  {
+    path: "/adapters/:organizationName/:adapterName",
+    component: lazy(() => import("../AdapterEditPage")),
+    auth: true,
+  },
+  {
+    path: "/enforcers",
+    exact: true,
+    component: lazy(() => import("../EnforcerListPage")),
+    auth: true,
+  },
+  {
+    path: "/enforcers/:organizationName/:enforcerName",
+    component: lazy(() => import("../EnforcerEditPage")),
+    auth: true,
+  },
+  {
+    path: "/sessions",
+    exact: true,
+    component: lazy(() => import("../SessionListPage")),
+    auth: true,
+  },
+  {
+    path: "/tokens",
+    exact: true,
+    component: lazy(() => import("../TokenListPage")),
+    auth: true,
+  },
+  {
+    path: "/tokens/:tokenName",
+    component: lazy(() => import("../TokenEditPage")),
+    auth: true,
+  },
+  {
+    path: "/products",
+    exact: true,
+    component: lazy(() => import("../ProductListPage")),
+    auth: true,
+  },
+  {
+    path: "/products/:organizationName/:productName",
+    component: lazy(() => import("../ProductEditPage")),
+    auth: true,
+  },
+  {
+    path: "/products/:organizationName/:productName/buy",
+    component: lazy(() => import("../ProductBuyPage")),
+    auth: true,
+  },
+  {
+    path: "/records",
+    component: lazy(() => import("../RecordListPage")),
+    auth: true,
+  },
+  {
+    path: "/payments",
+    exact: true,
+    component: lazy(() => import("../PaymentListPage")),
+    auth: true,
+  },
+  {
+    path: "/payments/:organizationName/:paymentName",
+    component: lazy(() => import("../PaymentEditPage")),
+    auth: true,
+  },
+  {
+    path: "/payments/:organizationName/:paymentName/result",
+    component: lazy(() => import("../PaymentResultPage")),
+    auth: true,
+  },
+  {
+    path: "/plans",
+    exact: true,
+    component: lazy(() => import("../PlanListPage")),
+    auth: true,
+  },
+  {
+    path: "/plans/:organizationName/:planName",
+    component: lazy(() => import("../PlanEditPage")),
+    auth: true,
+  },
+  {
+    path: "/pricings",
+    exact: true,
+    component: lazy(() => import("../PricingListPage")),
+    auth: true,
+  },
+  {
+    path: "/pricings/:organizationName/:pricingName",
+    component: lazy(() => import("../PricingEditPage")),
+    auth: true,
+  },
+  {
+    path: "/subscriptions",
+    exact: true,
+    component: lazy(() => import("../SubscriptionListPage")),
+    auth: true,
+  },
+  {
+    path: "/subscriptions/:organizationName/:subscriptionName",
+    component: lazy(() => import("../SubscriptionEditPage")),
+    auth: true,
+  },
+  {
+    path: "/sysinfo",
+    exact: true,
+    component: lazy(() => import("../SystemInfo")),
+    auth: true,
+  },
+  {
+    path: "/syncers",
+    exact: true,
+    component: lazy(() => import("../SyncerListPage")),
+    auth: true,
+  },
+  {
+    path: "/syncers/:syncerName",
+    component: lazy(() => import("../SyncerEditPage")),
+    auth: true,
+  },
+  {
+    path: "/webhooks",
+    exact: true,
+    component: lazy(() => import("../WebhookListPage")),
+    auth: true,
+  },
+  {
+    path: "/webhooks/:webhookName",
+    component: lazy(() => import("../WebhookEditPage")),
+    auth: true,
+  },
+  {
+    path: "/ldap/:organizationName/:ldapId",
+    component: lazy(() => import("../LdapEditPage")),
+    auth: true,
+  },
+  {
+    path: "/ldap/sync/:organizationName/:ldapId",
+    component: lazy(() => import("../LdapSyncPage")),
+    auth: true,
+  },
+  {
+    path: "/mfa/setup",
+    exact: true,
+    component: lazy(() => import("../auth/MfaSetupPage")),
+    auth: true,
+  },
+  {
+    path: "/.well-known/openid-configuration",
+    exact: true,
+    component: lazy(() => import("../auth/OidcDiscoveryPage")),
+  },
+];
+
+export default indexRouters;

--- a/web/src/store/accountSlice.js
+++ b/web/src/store/accountSlice.js
@@ -1,0 +1,19 @@
+import {createSlice} from "@reduxjs/toolkit";
+
+export const accountSlice = createSlice({
+  name: "account",
+  initialState: {
+    value: null,
+  },
+  reducers: {
+    setAccount: (state, action) => {
+      state.value = action.payload;
+    },
+  },
+});
+
+export const {setAccount} = accountSlice.actions;
+
+export const selectAccount = (state) => state.account.value;
+
+export default accountSlice.reducer;

--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -1,0 +1,12 @@
+import {combineReducers, configureStore} from "@reduxjs/toolkit";
+import accountReducer from "./accountSlice";
+import themeReducer from "./themeSlice";
+
+const rootReducer = combineReducers({
+  account: accountReducer,
+  theme: themeReducer,
+});
+
+export default configureStore({
+  reducer: rootReducer,
+});

--- a/web/src/store/themeSlice.js
+++ b/web/src/store/themeSlice.js
@@ -1,0 +1,57 @@
+import {createSlice} from "@reduxjs/toolkit";
+import * as Conf from "../Conf";
+import * as Setting from "../Setting";
+
+function getLogo(themes) {
+  if (themes.includes("dark")) {
+    return `${Setting.StaticBaseUrl}/img/casdoor-logo_1185x256_dark.png`;
+  } else {
+    return `${Setting.StaticBaseUrl}/img/casdoor-logo_1185x256.png`;
+  }
+}
+
+export const themeSlice = createSlice({
+  name: "theme",
+  initialState: {
+    value: Conf.ThemeDefault,
+    logo: getLogo(Setting.getAlgorithmNames(Conf.ThemeDefault)),
+    themeAlgorithm: ["default"],
+  },
+  reducers: {
+    setTheme: (state, action) => {
+      state.value = action.payload;
+    },
+    setLogo(state, action) {
+      if (action.payload instanceof Array) {
+        state.logo = getLogo(action.payload);
+        return;
+      }
+      state.logo = getLogo(Setting.getAlgorithmNames(action.payload));
+    },
+    setThemeAlgorithm(state, action) {
+      if (action.payload instanceof Array) {
+        state.themeAlgorithm = action.payload.sort().reverse();
+        return;
+      }
+      state.themeAlgorithm = Setting.getAlgorithmNames(action.payload);
+    },
+    setThemeAndUpdate(state, action) {
+      state.value = action.payload?.theme;
+      state.logo = getLogo(Setting.getAlgorithmNames(action.payload));
+      state.themeAlgorithm = Setting.getAlgorithmNames(action.payload);
+    },
+  },
+});
+
+export const {
+  setTheme,
+  setLogo,
+  setThemeAlgorithm,
+  setThemeAndUpdate,
+} = themeSlice.actions;
+
+export const selectTheme = (state) => state.theme.value;
+export const selectLogo = (state) => state.theme.logo;
+export const selectThemeAlgorithm = (state) => state.theme.themeAlgorithm;
+
+export default themeSlice.reducer;

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1416,6 +1416,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.23.2":
+  version "7.23.9"
+  resolved "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
+  integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.22.5", "@babel/template@^7.3.3":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.5.tgz#0c8c4d944509875849bd0344ff0050756eefc6ec"
@@ -1660,6 +1667,11 @@
   dependencies:
     debug "^3.1.0"
     lodash.once "^4.1.1"
+
+"@discoveryjs/json-ext@0.5.7":
+  version "0.5.7"
+  resolved "https://registry.npmmirror.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
+  integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
 "@emotion/babel-plugin@^11.11.0":
   version "11.11.0"
@@ -3394,6 +3406,11 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
+"@polka/url@^1.0.0-next.24":
+  version "1.0.0-next.24"
+  resolved "https://registry.npmmirror.com/@polka/url/-/url-1.0.0-next.24.tgz#58601079e11784d20f82d0585865bb42305c4df3"
+  integrity sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==
+
 "@rc-component/color-picker@~1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@rc-component/color-picker/-/color-picker-1.2.0.tgz#964c86e85f0791703c7f1ec842e7476bcb41954d"
@@ -3471,6 +3488,16 @@
     rc-motion "^2.0.0"
     rc-resize-observer "^1.3.1"
     rc-util "^5.33.0"
+
+"@reduxjs/toolkit@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.npmmirror.com/@reduxjs/toolkit/-/toolkit-2.2.1.tgz#3dce4906fb33da9e0122468ef21438dd7f2277a9"
+  integrity sha512-8CREoqJovQW/5I4yvvijm/emUiCCmcs4Ev4XPWd4mizSO+dD3g5G6w34QK5AGeNrSH7qM8Fl66j4vuV7dpOdkw==
+  dependencies:
+    immer "^10.0.3"
+    redux "^5.0.1"
+    redux-thunk "^3.1.0"
+    reselect "^5.0.1"
 
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
@@ -4168,6 +4195,11 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.3.tgz#a136f83b0758698df454e328759dbd3d44555311"
   integrity sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==
 
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.npmmirror.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
+
 "@types/ws@^7.4.4":
   version "7.4.7"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
@@ -4601,6 +4633,11 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.0.0:
+  version "8.3.2"
+  resolved "https://registry.npmmirror.com/acorn-walk/-/acorn-walk-8.3.2.tgz#7703af9415f1b6db9315d6895503862e231d34aa"
+  integrity sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==
+
 acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
@@ -4610,6 +4647,11 @@ acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.0.4:
+  version "8.11.3"
+  resolved "https://registry.npmmirror.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
+  integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
 acorn@^8.2.4, acorn@^8.4.1, acorn@^8.7.1, acorn@^8.8.0, acorn@^8.8.2:
   version "8.9.0"
@@ -6392,6 +6434,11 @@ dayjs@^1.10.4, dayjs@^1.11.1:
   version "1.11.8"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.8.tgz#4282f139c8c19dd6d0c7bd571e30c2d0ba7698ea"
   integrity sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ==
+
+debounce@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmmirror.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
 debug@2.6.9, debug@^2.6.0:
   version "2.6.9"
@@ -8396,7 +8443,7 @@ html-entities@^2.1.0, html-entities@^2.3.2:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.3.6.tgz#966391d58e5737c77bca4025e31721b496ab7454"
   integrity sha512-9o0+dcpIw2/HxkNuYKxSJUF/MMRZQECK4GnF+oQOmJ83yCVHTWgCH5aOXxK5bozNRmM8wtgryjHD3uloPBDEGw==
 
-html-escaper@^2.0.0:
+html-escaper@^2.0.0, html-escaper@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
@@ -8569,6 +8616,13 @@ i18n-iso-countries@^7.0.0:
   dependencies:
     diacritics "1.3.0"
 
+i18next-resources-to-backend@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmmirror.com/i18next-resources-to-backend/-/i18next-resources-to-backend-1.2.0.tgz#4e0ea0c093bf1acb3eb47972a3002b84a1fec3b2"
+  integrity sha512-8f1l03s+QxDmCfpSXCh9V+AFcxAwIp0UaroWuyOx+hmmv8484GcELHs+lnu54FrNij8cDBEXvEwhzZoXsKcVpg==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
+
 i18next@^19.8.9:
   version "19.9.2"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.9.2.tgz#ea5a124416e3c5ab85fddca2c8e3c3669a8da397"
@@ -8621,6 +8675,11 @@ image-size@~0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
   integrity sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==
+
+immer@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.npmmirror.com/immer/-/immer-10.0.3.tgz#a8de42065e964aa3edf6afc282dfc7f7f34ae3c9"
+  integrity sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==
 
 immer@^9.0.7:
   version "9.0.21"
@@ -10390,6 +10449,11 @@ mri@^1.1.0:
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
   integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
+mrmime@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmmirror.com/mrmime/-/mrmime-2.0.0.tgz#151082a6e06e59a9a39b46b3e14d5cfe92b3abb4"
+  integrity sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -10716,6 +10780,11 @@ opencollective-postinstall@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
+
+opener@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.npmmirror.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
+  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -12522,6 +12591,14 @@ react-metamask-avatar@^1.2.1:
   resolved "https://registry.yarnpkg.com/react-metamask-avatar/-/react-metamask-avatar-1.2.1.tgz#f0623e00ebc90ec24b8ac91cad3a25f653e7bc25"
   integrity sha512-EQhaW27PdqGKLxCnDgpCTWnEs1bjba+l5b/ZQc1V/GSWrCznAcrQ2HrcjSPgmuud2rvDChYyrzgRB5sBU33gSw==
 
+react-redux@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.npmmirror.com/react-redux/-/react-redux-9.1.0.tgz#46a46d4cfed4e534ce5452bb39ba18e1d98a8197"
+  integrity sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==
+  dependencies:
+    "@types/use-sync-external-store" "^0.0.3"
+    use-sync-external-store "^1.0.0"
+
 react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
@@ -12704,6 +12781,16 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-thunk@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmmirror.com/redux-thunk/-/redux-thunk-3.1.0.tgz#94aa6e04977c30e14e892eae84978c1af6058ff3"
+  integrity sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==
+
+redux@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmmirror.com/redux/-/redux-5.0.1.tgz#97fa26881ce5746500125585d5642c77b6e9447b"
+  integrity sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==
+
 regenerate-unicode-properties@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz#7c3192cab6dd24e21cb4461e5ddd7dd24fa8374c"
@@ -12720,6 +12807,11 @@ regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.9:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.npmmirror.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regenerator-transform@^0.15.1:
   version "0.15.1"
@@ -12803,6 +12895,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
+reselect@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.npmmirror.com/reselect/-/reselect-5.1.0.tgz#c479139ab9dd91be4d9c764a7f3868210ef8cd21"
+  integrity sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg==
 
 resize-observer-polyfill@^1.5.1:
   version "1.5.1"
@@ -13235,6 +13332,15 @@ signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+sirv@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.npmmirror.com/sirv/-/sirv-2.0.4.tgz#5dd9a725c578e34e449f332703eb2a74e46a29b0"
+  integrity sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==
+  dependencies:
+    "@polka/url" "^1.0.0-next.24"
+    mrmime "^2.0.0"
+    totalist "^3.0.0"
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -14125,6 +14231,11 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+totalist@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.npmmirror.com/totalist/-/totalist-3.0.1.tgz#ba3a3d600c915b1a97872348f79c127475f6acf8"
+  integrity sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==
+
 tough-cookie@^4.0.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
@@ -14451,6 +14562,11 @@ use-sync-external-store@1.0.0:
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.0.0.tgz#d98f4a9c2e73d0f958e7e2d2c2bfb5f618cbd8fd"
   integrity sha512-AFVsxg5GkFg8GDcxnl+Z0lMAz9rE8DGJCc28qnBuQF7lac57B5smLcT37aXpXIIPz75rW4g3eXHPjhHwdGskOw==
 
+use-sync-external-store@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.npmmirror.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 utf-8-validate@^5.0.2:
   version "5.0.10"
   resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.10.tgz#d7d10ea39318171ca982718b6b96a8d2442571a2"
@@ -14615,6 +14731,25 @@ webidl-conversions@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
+
+webpack-bundle-analyzer@^4.10.1:
+  version "4.10.1"
+  resolved "https://registry.npmmirror.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz#84b7473b630a7b8c21c741f81d8fe4593208b454"
+  integrity sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==
+  dependencies:
+    "@discoveryjs/json-ext" "0.5.7"
+    acorn "^8.0.4"
+    acorn-walk "^8.0.0"
+    commander "^7.2.0"
+    debounce "^1.2.1"
+    escape-string-regexp "^4.0.0"
+    gzip-size "^6.0.0"
+    html-escaper "^2.0.2"
+    is-plain-object "^5.0.0"
+    opener "^1.5.2"
+    picocolors "^1.0.0"
+    sirv "^2.0.3"
+    ws "^7.3.1"
 
 webpack-dev-middleware@^5.3.1:
   version "5.3.3"
@@ -15069,7 +15204,7 @@ ws@7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
-ws@^7.4.5, ws@^7.4.6:
+ws@^7.3.1, ws@^7.4.5, ws@^7.4.6:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1668,11 +1668,6 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@discoveryjs/json-ext@0.5.7":
-  version "0.5.7"
-  resolved "https://registry.npmmirror.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
-  integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
-
 "@emotion/babel-plugin@^11.11.0":
   version "11.11.0"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz#c2d872b6a7767a9d176d007f5b31f7d504bb5d6c"
@@ -3406,11 +3401,6 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
-"@polka/url@^1.0.0-next.24":
-  version "1.0.0-next.24"
-  resolved "https://registry.npmmirror.com/@polka/url/-/url-1.0.0-next.24.tgz#58601079e11784d20f82d0585865bb42305c4df3"
-  integrity sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==
-
 "@rc-component/color-picker@~1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@rc-component/color-picker/-/color-picker-1.2.0.tgz#964c86e85f0791703c7f1ec842e7476bcb41954d"
@@ -4633,11 +4623,6 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn-walk@^8.0.0:
-  version "8.3.2"
-  resolved "https://registry.npmmirror.com/acorn-walk/-/acorn-walk-8.3.2.tgz#7703af9415f1b6db9315d6895503862e231d34aa"
-  integrity sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==
-
 acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
@@ -4647,11 +4632,6 @@ acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
-
-acorn@^8.0.4:
-  version "8.11.3"
-  resolved "https://registry.npmmirror.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
-  integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
 acorn@^8.2.4, acorn@^8.4.1, acorn@^8.7.1, acorn@^8.8.0, acorn@^8.8.2:
   version "8.9.0"
@@ -6434,11 +6414,6 @@ dayjs@^1.10.4, dayjs@^1.11.1:
   version "1.11.8"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.8.tgz#4282f139c8c19dd6d0c7bd571e30c2d0ba7698ea"
   integrity sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ==
-
-debounce@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmmirror.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
-  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
 debug@2.6.9, debug@^2.6.0:
   version "2.6.9"
@@ -8443,7 +8418,7 @@ html-entities@^2.1.0, html-entities@^2.3.2:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.3.6.tgz#966391d58e5737c77bca4025e31721b496ab7454"
   integrity sha512-9o0+dcpIw2/HxkNuYKxSJUF/MMRZQECK4GnF+oQOmJ83yCVHTWgCH5aOXxK5bozNRmM8wtgryjHD3uloPBDEGw==
 
-html-escaper@^2.0.0, html-escaper@^2.0.2:
+html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
@@ -10449,11 +10424,6 @@ mri@^1.1.0:
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
   integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
-mrmime@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmmirror.com/mrmime/-/mrmime-2.0.0.tgz#151082a6e06e59a9a39b46b3e14d5cfe92b3abb4"
-  integrity sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -10780,11 +10750,6 @@ opencollective-postinstall@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
-
-opener@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.npmmirror.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
-  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -13333,15 +13298,6 @@ signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-sirv@^2.0.3:
-  version "2.0.4"
-  resolved "https://registry.npmmirror.com/sirv/-/sirv-2.0.4.tgz#5dd9a725c578e34e449f332703eb2a74e46a29b0"
-  integrity sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==
-  dependencies:
-    "@polka/url" "^1.0.0-next.24"
-    mrmime "^2.0.0"
-    totalist "^3.0.0"
-
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -14231,11 +14187,6 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-totalist@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.npmmirror.com/totalist/-/totalist-3.0.1.tgz#ba3a3d600c915b1a97872348f79c127475f6acf8"
-  integrity sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==
-
 tough-cookie@^4.0.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
@@ -14732,25 +14683,6 @@ webidl-conversions@^6.1.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
-webpack-bundle-analyzer@^4.10.1:
-  version "4.10.1"
-  resolved "https://registry.npmmirror.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz#84b7473b630a7b8c21c741f81d8fe4593208b454"
-  integrity sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==
-  dependencies:
-    "@discoveryjs/json-ext" "0.5.7"
-    acorn "^8.0.4"
-    acorn-walk "^8.0.0"
-    commander "^7.2.0"
-    debounce "^1.2.1"
-    escape-string-regexp "^4.0.0"
-    gzip-size "^6.0.0"
-    html-escaper "^2.0.2"
-    is-plain-object "^5.0.0"
-    opener "^1.5.2"
-    picocolors "^1.0.0"
-    sirv "^2.0.3"
-    ws "^7.3.1"
-
 webpack-dev-middleware@^5.3.1:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz#efae67c2793908e7311f1d9b06f2a08dcc97e51f"
@@ -15204,7 +15136,7 @@ ws@7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
-ws@^7.3.1, ws@^7.4.5, ws@^7.4.6:
+ws@^7.4.5, ws@^7.4.6:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==


### PR DESCRIPTION
feat: #1777 #2596

This pr change lots of file, so it still need a full test and strict review, the following are the main changes
1. use redux to store account data and theme data 
2. separate main content render from App.js and use lazy load to reduce login page size
3. use splitChunks to split the main.js
4. separate getCountryCode function from Setting.js to aviod unnecessary import of i18n-iso-countries
5. use i18next-resources-to-backend to lazy load i18n translation file

with this work, the size of login page successfully reduce to ±950KB

![image](https://github.com/casdoor/casdoor/assets/47297289/986a5e1b-89f6-4661-9327-087ebaf1e742)
