### PR TITLE
fix: fix theme switch bug

### DIFF
--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -69,7 +69,7 @@ export function getThemeData(organization, application) {
 }
 
 export function getAlgorithm(themeAlgorithmNames) {
-  return themeAlgorithmNames.map((algorithmName) => {
+  return themeAlgorithmNames.sort().reverse().map((algorithmName) => {
     if (algorithmName === "dark") {
       return theme.darkAlgorithm;
     }


### PR DESCRIPTION
fix: fix bug in theme swich

**before**

https://github.com/casdoor/casdoor/assets/47297289/d968d28e-0db6-403c-b638-f7c47acf83bb

**now**

https://github.com/casdoor/casdoor/assets/47297289/2cf2a7d6-36c3-467d-893d-4c7d93a8106e


in previous version ,when you change theme to dark, compact them swich back to default, compact, the compact mode will not take affect
