### PR TITLE
feat: use dynamic import to load web3Auth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,7 @@ jobs:
         working-directory: ./web
       - uses: cypress-io/github-action@v5
         with:
+          browser: chrome
           start: yarn start
           wait-on: 'http://localhost:7001'
           wait-on-timeout: 210

--- a/web/src/auth/ProviderButton.js
+++ b/web/src/auth/ProviderButton.js
@@ -121,15 +121,19 @@ function goToSamlUrl(provider, location) {
   });
 }
 
-export async function goToWeb3Url(application, provider, method) {
+export function goToWeb3Url(application, provider, method) {
   if (provider.type === "MetaMask") {
-    const authViaMetaMask = await import("./Web3Auth")
-      .then(module => module.authViaMetaMask);
-    await authViaMetaMask(application, provider, method);
+    import("./Web3Auth")
+      .then(module => {
+        const authViaMetaMask = module.authViaMetaMask;
+        authViaMetaMask(application, provider, method);
+      });
   } else if (provider.type === "Web3Onboard") {
-    const authViaWeb3Onboard = await import("./Web3Auth")
-      .then(module => module.authViaWeb3Onboard);
-    await authViaWeb3Onboard(application, provider, method);
+    import("./Web3Auth")
+      .then(module => {
+        const authViaWeb3Onboard = module.authViaWeb3Onboard;
+        authViaWeb3Onboard(application, provider, method);
+      });
   }
 }
 

--- a/web/src/auth/ProviderButton.js
+++ b/web/src/auth/ProviderButton.js
@@ -179,7 +179,6 @@ export function renderProviderLogo(provider, application, width, margin, size, l
         </a>
       );
     } else if (provider.category === "Web3") {
-      import("./Web3Auth");
       return (
         <a key={provider.displayName} onClick={() => goToWeb3Url(application, provider, "signup")}>
           <img width={width} height={width} src={getProviderLogoURL(provider)} alt={provider.displayName} className="provider-img" style={{margin: margin}} />
@@ -225,7 +224,6 @@ export function renderProviderLogo(provider, application, width, margin, size, l
         </div>
       );
     } else if (provider.category === "Web3") {
-      import("./Web3Auth");
       return (
         <div key={provider.displayName} className="provider-big-img">
           <a onClick={() => goToWeb3Url(application, provider, "signup")}>

--- a/web/src/auth/ProviderButton.js
+++ b/web/src/auth/ProviderButton.js
@@ -17,7 +17,6 @@ import i18next from "i18next";
 import * as Provider from "./Provider";
 import {getProviderLogoURL} from "../Setting";
 import {GithubLoginButton, GoogleLoginButton} from "react-social-login-buttons";
-import {authViaMetaMask, authViaWeb3Onboard} from "./Web3Auth";
 import QqLoginButton from "./QqLoginButton";
 import FacebookLoginButton from "./FacebookLoginButton";
 import WeiboLoginButton from "./WeiboLoginButton";
@@ -122,11 +121,15 @@ function goToSamlUrl(provider, location) {
   });
 }
 
-export function goToWeb3Url(application, provider, method) {
+export async function goToWeb3Url(application, provider, method) {
   if (provider.type === "MetaMask") {
-    authViaMetaMask(application, provider, method);
+    const authViaMetaMask = await import("./Web3Auth")
+      .then(module => module.authViaMetaMask);
+    await authViaMetaMask(application, provider, method);
   } else if (provider.type === "Web3Onboard") {
-    authViaWeb3Onboard(application, provider, method);
+    const authViaWeb3Onboard = await import("./Web3Auth")
+      .then(module => module.authViaWeb3Onboard);
+    await authViaWeb3Onboard(application, provider, method);
   }
 }
 
@@ -176,6 +179,7 @@ export function renderProviderLogo(provider, application, width, margin, size, l
         </a>
       );
     } else if (provider.category === "Web3") {
+      import("./Web3Auth");
       return (
         <a key={provider.displayName} onClick={() => goToWeb3Url(application, provider, "signup")}>
           <img width={width} height={width} src={getProviderLogoURL(provider)} alt={provider.displayName} className="provider-img" style={{margin: margin}} />
@@ -221,6 +225,7 @@ export function renderProviderLogo(provider, application, width, margin, size, l
         </div>
       );
     } else if (provider.category === "Web3") {
+      import("./Web3Auth");
       return (
         <div key={provider.displayName} className="provider-big-img">
           <a onClick={() => goToWeb3Url(application, provider, "signup")}>

--- a/web/src/common/OAuthWidget.js
+++ b/web/src/common/OAuthWidget.js
@@ -146,13 +146,6 @@ class OAuthWidget extends React.Component {
       linkButtonWidth = "160px";
     }
 
-    if (provider.category === "Web3" && this.state.web3AuthImported === false) {
-      import("../auth/Web3Auth");
-      this.setState({
-        web3AuthImported: true,
-      });
-    }
-
     return (
       <Row key={provider.name} style={{marginTop: "20px"}} >
         <Col style={{marginTop: "5px"}} span={this.props.labelSpan}>

--- a/web/src/common/OAuthWidget.js
+++ b/web/src/common/OAuthWidget.js
@@ -29,6 +29,7 @@ class OAuthWidget extends React.Component {
       classes: props,
       addressOptions: [],
       affiliationOptions: [],
+      web3AuthImported: false,
     };
   }
 
@@ -145,8 +146,11 @@ class OAuthWidget extends React.Component {
       linkButtonWidth = "160px";
     }
 
-    if (provider.category === "Web3") {
+    if (provider.category === "Web3" && this.state.web3AuthImported === false) {
       import("../auth/Web3Auth");
+      this.setState({
+        web3AuthImported: true,
+      });
     }
 
     return (

--- a/web/src/common/OAuthWidget.js
+++ b/web/src/common/OAuthWidget.js
@@ -20,7 +20,6 @@ import * as Setting from "../Setting";
 import * as Provider from "../auth/Provider";
 import * as AuthBackend from "../auth/AuthBackend";
 import {goToWeb3Url} from "../auth/ProviderButton";
-import {delWeb3AuthToken} from "../auth/Web3Auth";
 import AccountAvatar from "../account/AccountAvatar";
 
 class OAuthWidget extends React.Component {
@@ -91,14 +90,16 @@ class OAuthWidget extends React.Component {
     return user.properties[key];
   }
 
-  unlinkUser(providerType, linkedValue) {
+  async unlinkUser(providerType, linkedValue) {
     const body = {
       providerType: providerType,
       // should add the unlink user's info, cause the user may not be logged in, but a admin want to unlink the user.
       user: this.props.user,
     };
     if (providerType === "MetaMask" || providerType === "Web3Onboard") {
-      delWeb3AuthToken(linkedValue);
+      const delWeb3AuthToken = await import("../auth/Web3Auth")
+        .then(module => module.delWeb3AuthToken);
+      await delWeb3AuthToken(linkedValue);
     }
     AuthBackend.unlink(body)
       .then((res) => {
@@ -142,6 +143,10 @@ class OAuthWidget extends React.Component {
     let linkButtonWidth = "110px";
     if (Setting.getLanguage() === "id") {
       linkButtonWidth = "160px";
+    }
+
+    if (provider.category === "Web3") {
+      import("../auth/Web3Auth");
     }
 
     return (


### PR DESCRIPTION
feat: use dynamic import to load web3Auth and successfully reduce the size of signIn page to 750KB when web3 idp is disabled

![image](https://github.com/casdoor/casdoor/assets/47297289/dc90f3a6-b62e-4187-b1a8-3f66f1c4d523)
