### PR TITLE
fix: Ensure /api/get-app-login Returns Captcha Provider for Applications Configured with Captcha

### DIFF
--- a/object/application.go
+++ b/object/application.go
@@ -505,7 +505,7 @@ func GetMaskedApplication(application *Application, userId string) *Application 
 
 	providerItems := []*ProviderItem{}
 	for _, providerItem := range application.Providers {
-		if providerItem.Provider != nil && (providerItem.Provider.Category == "OAuth" || providerItem.Provider.Category == "Web3") {
+		if providerItem.Provider != nil && (providerItem.Provider.Category == "OAuth" || providerItem.Provider.Category == "Web3" || providerItem.Provider.Category == "Captcha") {
 			providerItems = append(providerItems, providerItem)
 		}
 	}


### PR DESCRIPTION
If the Application is configured with a Captcha Provider, then the /api/get-app-login endpoint needs to return a Captcha type Provider during login. Otherwise, the frontend cannot trigger Captcha during login.

In LoginPage.js, the line 92:const captchaProviderItems = this.getCaptchaProviderItems(this.props.application); 
captchaProviderItems have no Captcha Provider.