### PR TITLE
fix: "fs" Module Not Found Error in Browser with face-api.js

### DIFF
--- a/web/craco.config.js
+++ b/web/craco.config.js
@@ -38,7 +38,7 @@ module.exports = {
       "/scim": {
         target: "http://localhost:8000",
         changeOrigin: true,
-      }
+      },
     },
   },
   plugins: [
@@ -62,10 +62,10 @@ module.exports = {
         function ignoreSourcemapsloaderWarnings(warning) {
           return (
             warning.module &&
-            warning.module.resource.includes('node_modules') &&
+            warning.module.resource.includes("node_modules") &&
             warning.details &&
-            warning.details.includes('source-map-loader')
-          )
+            warning.details.includes("source-map-loader")
+          );
         },
       ],
       // use polyfill Buffer with Webpack 5
@@ -81,7 +81,7 @@ module.exports = {
           // "http": require.resolve("stream-http"),
           // "https": require.resolve("https-browserify"),
           // "assert": require.resolve("assert/"),
-          "buffer": require.resolve('buffer/'),    
+          "buffer": require.resolve("buffer/"),
           "process": false,
           "util": false,
           "url": false,
@@ -90,11 +90,12 @@ module.exports = {
           "http": false,
           "https": false,
           "assert": false,
-          "buffer": false,
+          // "buffer": false, // this is duplicated
           "crypto": false,
           "os": false,
+          "fs": false,
         },
-      }
+      },
     },
-  }
+  },
 };


### PR DESCRIPTION
face-api.js library is trying to require the fs module, which is a core Node.js module that provides an API for interacting with the file system. However, this module is not available in the browser environment.

This might be resolved by including the following line in the webpack.configure.resolve.fallback field of the craco.config.js file:
```json
"fs": false
```

and the second "buffer" might be redundant，I made a note.