### PR TITLE
feat: use minWidth for a better display effect in org select 

### DIFF
--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -1173,7 +1173,7 @@ class LoginPage extends React.Component {
     };
 
     return (
-      <div style={{height: 300}}>
+      <div style={{height: 300, minWidth: 320}}>
         {renderChoiceBox()}
       </div>
     );


### PR DESCRIPTION
feat: use minWidth for a better display effect in org select  when using chinese or other language which is short to display

before
![061ab39753828a9616004311df0ac407](https://github.com/casdoor/casdoor/assets/47297289/0f3444a4-1882-407c-8450-ecfcfa69999f)

now
![9925607fb0c4891743d0013a093add7a](https://github.com/casdoor/casdoor/assets/47297289/bc64cb68-4cda-4382-9947-0fc2174bd20c)
