### PR TITLE
Separate two Dockerfiles

### DIFF
--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -1,0 +1,24 @@
+FROM debian:latest AS db
+RUN apt update \
+    && apt install -y \
+        mariadb-server \
+        mariadb-client \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM db AS ALLINONE
+LABEL MAINTAINER="https://casdoor.org/"
+
+RUN apt update
+RUN apt install -y ca-certificates && update-ca-certificates
+
+WORKDIR /
+COPY --from=BACK /go/src/casdoor/server ./server
+COPY --from=BACK /go/src/casdoor/swagger ./swagger
+COPY --from=BACK /go/src/casdoor/docker-entrypoint.sh /docker-entrypoint.sh
+COPY --from=BACK /go/src/casdoor/conf/app.conf ./conf/app.conf
+COPY --from=BACK /go/src/casdoor/version_info.txt ./go/src/casdoor/version_info.txt
+COPY --from=FRONT /web/build ./web/build
+
+ENTRYPOINT ["/bin/bash"]
+CMD ["/docker-entrypoint.sh"]

--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -3,7 +3,6 @@ WORKDIR /web
 COPY ./web .
 RUN yarn install --frozen-lockfile --network-timeout 1000000 && yarn run build
 
-
 FROM golang:1.20.12 AS BACK
 WORKDIR /go/src/casdoor
 COPY . .
@@ -35,29 +34,3 @@ COPY --from=BACK --chown=$USER:$USER /go/src/casdoor/version_info.txt ./go/src/c
 COPY --from=FRONT --chown=$USER:$USER /web/build ./web/build
 
 ENTRYPOINT ["/server"]
-
-
-FROM debian:latest AS db
-RUN apt update \
-    && apt install -y \
-        mariadb-server \
-        mariadb-client \
-    && rm -rf /var/lib/apt/lists/*
-
-
-FROM db AS ALLINONE
-LABEL MAINTAINER="https://casdoor.org/"
-
-RUN apt update
-RUN apt install -y ca-certificates && update-ca-certificates
-
-WORKDIR /
-COPY --from=BACK /go/src/casdoor/server ./server
-COPY --from=BACK /go/src/casdoor/swagger ./swagger
-COPY --from=BACK /go/src/casdoor/docker-entrypoint.sh /docker-entrypoint.sh
-COPY --from=BACK /go/src/casdoor/conf/app.conf ./conf/app.conf
-COPY --from=BACK /go/src/casdoor/version_info.txt ./go/src/casdoor/version_info.txt
-COPY --from=FRONT /web/build ./web/build
-
-ENTRYPOINT ["/bin/bash"]
-CMD ["/docker-entrypoint.sh"]


### PR DESCRIPTION
Building an all-in-one image with `Dockerfile.allinone`
Building a standard image with `Dockerfile.main`
casdoor-website has synchronously submitted [PR](https://github.com/casdoor/casdoor-website/pull/616)