### PR TITLE
fix: fix init data not saved to database (#2885)

### DIFF
--- a/object/init.go
+++ b/object/init.go
@@ -71,7 +71,7 @@ func getBuiltInAccountItems() []*AccountItem {
 		{Name: "Permissions", Visible: true, ViewRule: "Public", ModifyRule: "Immutable"},
 		{Name: "Groups", Visible: true, ViewRule: "Public", ModifyRule: "Admin"},
 		{Name: "3rd-party logins", Visible: true, ViewRule: "Self", ModifyRule: "Self"},
-		{Name: "Properties", Visible: false, ViewRule: "Admin", ModifyRule: "Admin"},
+		{Name: "Properties", Visible: true, ViewRule: "Admin", ModifyRule: "Admin"},
 		{Name: "Is admin", Visible: true, ViewRule: "Admin", ModifyRule: "Admin"},
 		{Name: "Is forbidden", Visible: true, ViewRule: "Admin", ModifyRule: "Admin"},
 		{Name: "Is deleted", Visible: true, ViewRule: "Admin", ModifyRule: "Admin"},

--- a/object/init_data.go
+++ b/object/init_data.go
@@ -303,7 +303,9 @@ func initDefinedUser(user *User) {
 	}
 	user.CreatedTime = util.GetCurrentTime()
 	user.Id = util.GenerateId()
-	user.Properties = make(map[string]string)
+	if user.Properties == nil {
+		user.Properties = make(map[string]string)
+	}
 	_, err = AddUser(user)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/2885

I think the `Properties` of `AccountItem` is defined for using, so I change the default value of `visible` to `true`. The change of `initDefinedUser` is compatible with old code.
