### PR TITLE
feat: add back arm64 support in Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,7 @@ jobs:
         with:
           context: .
           target: STANDARD
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: casbin/casdoor:${{steps.get-current-tag.outputs.tag }},casbin/casdoor:latest
 
@@ -204,7 +204,7 @@ jobs:
         with:
           context: .
           target: ALLINONE
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: casbin/casdoor-all-in-one:${{steps.get-current-tag.outputs.tag }},casbin/casdoor-all-in-one:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:18.19.0 AS FRONT
+FROM --platform=$BUILDPLATFORM node:18.19.0 AS FRONT
 WORKDIR /web
 COPY ./web .
 RUN yarn install --frozen-lockfile --network-timeout 1000000 && yarn run build
 
 
-FROM golang:1.20.12 AS BACK
+FROM --platform=$BUILDPLATFORM golang:1.20.12 AS BACK
 WORKDIR /go/src/casdoor
 COPY . .
 RUN ./build.sh
@@ -13,6 +13,9 @@ RUN go test -v -run TestGetVersionInfo ./util/system_test.go ./util/system.go > 
 FROM alpine:latest AS STANDARD
 LABEL MAINTAINER="https://casdoor.org/"
 ARG USER=casdoor
+ARG TARGETOS
+ARG TARGETARCH
+ENV BUILDX_ARCH="${TARGETOS:-linux}_${TARGETARCH:-amd64}"
 
 RUN sed -i 's/https/http/' /etc/apk/repositories
 RUN apk add --update sudo
@@ -28,7 +31,7 @@ RUN adduser -D $USER -u 1000 \
 
 USER 1000
 WORKDIR /
-COPY --from=BACK --chown=$USER:$USER /go/src/casdoor/server ./server
+COPY --from=BACK --chown=$USER:$USER /go/src/casdoor/server_${BUILDX_ARCH} ./server
 COPY --from=BACK --chown=$USER:$USER /go/src/casdoor/swagger ./swagger
 COPY --from=BACK --chown=$USER:$USER /go/src/casdoor/conf/app.conf ./conf/app.conf
 COPY --from=BACK --chown=$USER:$USER /go/src/casdoor/version_info.txt ./go/src/casdoor/version_info.txt
@@ -47,12 +50,15 @@ RUN apt update \
 
 FROM db AS ALLINONE
 LABEL MAINTAINER="https://casdoor.org/"
+ARG TARGETOS
+ARG TARGETARCH
+ENV BUILDX_ARCH="${TARGETOS:-linux}_${TARGETARCH:-amd64}"
 
 RUN apt update
 RUN apt install -y ca-certificates && update-ca-certificates
 
 WORKDIR /
-COPY --from=BACK /go/src/casdoor/server ./server
+COPY --from=BACK /go/src/casdoor/server_${BUILDX_ARCH} ./server
 COPY --from=BACK /go/src/casdoor/swagger ./swagger
 COPY --from=BACK /go/src/casdoor/docker-entrypoint.sh /docker-entrypoint.sh
 COPY --from=BACK /go/src/casdoor/conf/app.conf ./conf/app.conf

--- a/build.sh
+++ b/build.sh
@@ -8,4 +8,6 @@ else
     echo "Google is blocked, Go proxy is enabled: GOPROXY=https://goproxy.cn,direct"
     export GOPROXY="https://goproxy.cn,direct"
 fi
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o server .
+
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o server_linux_amd64 .
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-w -s" -o server_linux_arm64 .


### PR DESCRIPTION
Hey, I saw you had support for ARM64 in the past but dropped it because of [performance concerns](https://github.com/casdoor/casdoor/pull/2390).

I optimized the Dockerfile to significantly speed up the ARM64 build process. Now it should only take around the same time as a build just for AMD64. I did that by specifying the `BUILDPLATFORM`. With that, the GitHub runner does not have to emulate ARM64 during the build of the go binaries and the frontend. Beforehand, every step of the Dockerfile was executed twice. The frontend was built on AMD64 and ARM64, as well as the both go binaries. Now, everything is only built once on AMD64.

[Example pipeline run](https://github.com/AlexanderBabel/casdoor/actions/runs/9235557094/job/25410488736)

|                         | Build Time                                                                 |
| ----------------------- | -------------------------------------------------------------------------- |
| Current build (1.622.0) | [7m6s](https://github.com/casdoor/casdoor/actions/runs/9221672637)         |
| Previous ARM64 build    | [5h12m](https://github.com/casdoor/casdoor/actions/runs/6324483447)        |
| New ARM64 build         | [9m22s](https://github.com/AlexanderBabel/casdoor/actions/runs/9235557094) |


I really hope the team reconsiders the previous standpoint in https://github.com/casdoor/casdoor/issues/2416#issuecomment-2041381467 and considers this Pull Request as a solution for the ARM64 topic. If you have any feedback/adjustment wishes, I am happy to help.

