### PR TITLE
fix: version cannot be displayed in docker image

### DIFF
--- a/controllers/system_info.go
+++ b/controllers/system_info.go
@@ -15,6 +15,7 @@
 package controllers
 
 import (
+	"github.com/casdoor/casdoor/conf"
 	"github.com/casdoor/casdoor/util"
 )
 
@@ -46,18 +47,17 @@ func (c *ApiController) GetSystemInfo() {
 // @Success 200 {object} util.VersionInfo The Response object
 // @router /get-version-info [get]
 func (c *ApiController) GetVersionInfo() {
-	versionInfo, err := util.GetVersionInfo()
-	if err != nil {
-		c.ResponseError(err.Error())
-		return
+	var versionInfo *util.VersionInfo
+	var err error
+
+	runMode := conf.GetConfigString("runmode")
+
+	if runMode == "dev" {
+		versionInfo, err = util.GetVersionInfo()
+	} else if runMode == "prod" {
+		versionInfo, err = util.GetVersionInfoFromFile()
 	}
 
-	if versionInfo.Version != "" {
-		c.ResponseOk(versionInfo)
-		return
-	}
-
-	versionInfo, err = util.GetVersionInfoFromFile()
 	if err != nil {
 		c.ResponseError(err.Error())
 		return


### PR DESCRIPTION
fix: #2981 

I think this interface should determine which method to use to obtain the version based on the `runmode` in `conf/app.conf`. If it is `dev`, then obtain the version through Git History; If it is `prod`, then obtain the version through `version_info.txt`.

If users run Casdoor through compilation and in `Production Mode`, they should be required to generate `version_info.txt` after `go build`. I also create a PR in the [Git repository of the Casdoor Document](https://github.com/casdoor/casdoor-website/pull/622).