### PR TITLE
feat: fix the top Navbar UI is broken issue

### DIFF
--- a/web/src/ManagementPage.js
+++ b/web/src/ManagementPage.js
@@ -411,7 +411,7 @@ function ManagementPage(props) {
     return Setting.isMobile() || window.location.pathname.startsWith("/trees");
   }
 
-  const menuStyleRight = Setting.isAdminUser(props.account) && !Setting.isMobile() ? "calc(180px + 280px)" : "280px";
+  const menuStyleRight = Setting.isAdminUser(props.account) && !Setting.isMobile() ? "calc(180px + 280px)" : "320px";
 
   const onClose = () => {
     setMenuVisible(false);


### PR DESCRIPTION
fix: https://github.com/casdoor/casdoor/issues/2995

The non-built-in user interface icons are not fully displayed because the top bar is set to 280px. Setting it to 300px allows for perfect display without affecting other items.