### PR TITLE
feat: support "Use Email as username" in org

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -169,7 +169,11 @@ func (c *ApiController) Signup() {
 
 	username := authForm.Username
 	if !application.IsSignupItemVisible("Username") {
-		username = id
+		if organization.UseEmailAsUsername && application.IsSignupItemVisible("Email") {
+			username = authForm.Email
+		} else {
+			username = id
+		}
 	}
 
 	initScore, err := organization.GetInitScore()

--- a/object/init.go
+++ b/object/init.go
@@ -108,6 +108,7 @@ func initBuiltInOrganization() bool {
 		AccountItems:       getBuiltInAccountItems(),
 		EnableSoftDeletion: false,
 		IsProfilePublic:    false,
+		UseEmailAsUsername: false,
 	}
 	_, err = AddOrganization(organization)
 	if err != nil {

--- a/object/organization.go
+++ b/object/organization.go
@@ -72,6 +72,7 @@ type Organization struct {
 	InitScore              int        `json:"initScore"`
 	EnableSoftDeletion     bool       `json:"enableSoftDeletion"`
 	IsProfilePublic        bool       `json:"isProfilePublic"`
+	UseEmailAsUsername     bool       `json:"useEmailAsUsername"`
 
 	MfaItems     []*MfaItem     `xorm:"varchar(300)" json:"mfaItems"`
 	AccountItems []*AccountItem `xorm:"varchar(5000)" json:"accountItems"`

--- a/web/src/OrganizationEditPage.js
+++ b/web/src/OrganizationEditPage.js
@@ -437,6 +437,16 @@ class OrganizationEditPage extends React.Component {
           </Col>
         </Row>
         <Row style={{marginTop: "20px"}} >
+          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 19 : 2}>
+            {Setting.getLabel(i18next.t("organization:Use Email as username"), i18next.t("organization:Use Email as username - Tooltip"))} :
+          </Col>
+          <Col span={1} >
+            <Switch checked={this.state.organization.useEmailAsUsername} onChange={checked => {
+              this.updateOrganizationField("useEmailAsUsername", checked);
+            }} />
+          </Col>
+        </Row>
+        <Row style={{marginTop: "20px"}} >
           <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
             {Setting.getLabel(i18next.t("organization:Account items"), i18next.t("organization:Account items - Tooltip"))} :
           </Col>

--- a/web/src/locales/ar/data.json
+++ b/web/src/locales/ar/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "When enabled, deleting users will not completely remove them from the database. Instead, they will be marked as deleted",
     "Tags": "Tags",
     "Tags - Tooltip": "Collection of tags available for users to choose from",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "View rule",
     "Visible": "Visible",
     "Website URL": "Website URL",

--- a/web/src/locales/de/data.json
+++ b/web/src/locales/de/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "Wenn aktiviert, werden gelöschte Benutzer nicht vollständig aus der Datenbank entfernt. Stattdessen werden sie als gelöscht markiert",
     "Tags": "Tags",
     "Tags - Tooltip": "Sammlung von Tags, die für Benutzer zur Auswahl zur Verfügung stehen",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "Ansichtsregel",
     "Visible": "Sichtbar",
     "Website URL": "Website-URL",

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "When enabled, deleting users will not completely remove them from the database. Instead, they will be marked as deleted",
     "Tags": "Tags",
     "Tags - Tooltip": "Collection of tags available for users to choose from",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "View rule",
     "Visible": "Visible",
     "Website URL": "Website URL",

--- a/web/src/locales/es/data.json
+++ b/web/src/locales/es/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "Cuando se habilita, la eliminación de usuarios no los eliminará por completo de la base de datos. En su lugar, se marcarán como eliminados",
     "Tags": "Etiquetas",
     "Tags - Tooltip": "Colección de etiquetas disponibles para que los usuarios elijan",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "Regla de visualización",
     "Visible": "Visible  - Visible",
     "Website URL": "URL del sitio web",

--- a/web/src/locales/fa/data.json
+++ b/web/src/locales/fa/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "When enabled, deleting users will not completely remove them from the database. Instead, they will be marked as deleted",
     "Tags": "Tags",
     "Tags - Tooltip": "Collection of tags available for users to choose from",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "View rule",
     "Visible": "Visible",
     "Website URL": "Website URL",

--- a/web/src/locales/fi/data.json
+++ b/web/src/locales/fi/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "When enabled, deleting users will not completely remove them from the database. Instead, they will be marked as deleted",
     "Tags": "Tags",
     "Tags - Tooltip": "Collection of tags available for users to choose from",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "View rule",
     "Visible": "Visible",
     "Website URL": "Website URL",

--- a/web/src/locales/fr/data.json
+++ b/web/src/locales/fr/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "Lorsque c'est activée, la suppression de compte ne les retirera pas complètement de la base de données. Au lieu de cela, ils seront marqués comme supprimés",
     "Tags": "Étiquettes",
     "Tags - Tooltip": "Collection d'étiquettes disponibles pour les comptes",
+    "Use Email as username": "Utiliser l'e-mail comme identifiant",
+    "Use Email as username - Tooltip": "Utiliser l'adresse e-mail comme identifiant pour les comptes lorsque l'identifiant ne fait pas partie des champs d'inscription",
     "View rule": "Règle de visibilité",
     "Visible": "Visible",
     "Website URL": "URL du site web",

--- a/web/src/locales/he/data.json
+++ b/web/src/locales/he/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "When enabled, deleting users will not completely remove them from the database. Instead, they will be marked as deleted",
     "Tags": "Tags",
     "Tags - Tooltip": "Collection of tags available for users to choose from",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "View rule",
     "Visible": "Visible",
     "Website URL": "Website URL",

--- a/web/src/locales/id/data.json
+++ b/web/src/locales/id/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "Ketika diaktifkan, menghapus pengguna tidak akan sepenuhnya menghapus mereka dari database. Sebaliknya, mereka akan ditandai sebagai dihapus",
     "Tags": "Tag-tag",
     "Tags - Tooltip": "Kumpulan tag yang tersedia bagi pengguna untuk dipilih",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "Aturan tampilan",
     "Visible": "Terlihat",
     "Website URL": "URL situs web",

--- a/web/src/locales/it/data.json
+++ b/web/src/locales/it/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "When enabled, deleting users will not completely remove them from the database. Instead, they will be marked as deleted",
     "Tags": "Tags",
     "Tags - Tooltip": "Collection of tags available for users to choose from",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "View rule",
     "Visible": "Visible",
     "Website URL": "Website URL",

--- a/web/src/locales/ja/data.json
+++ b/web/src/locales/ja/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "有効になっている場合、ユーザーを削除しても完全にデータベースから削除されません。代わりに、削除されたとマークされます",
     "Tags": "タグ",
     "Tags - Tooltip": "ユーザーが選択できるタグのコレクション",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "ビュールール",
     "Visible": "見える",
     "Website URL": "ウェブサイトのURL",

--- a/web/src/locales/kk/data.json
+++ b/web/src/locales/kk/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "When enabled, deleting users will not completely remove them from the database. Instead, they will be marked as deleted",
     "Tags": "Tags",
     "Tags - Tooltip": "Collection of tags available for users to choose from",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "View rule",
     "Visible": "Visible",
     "Website URL": "Website URL",

--- a/web/src/locales/ko/data.json
+++ b/web/src/locales/ko/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "사용 가능한 경우, 사용자 삭제 시 데이터베이스에서 완전히 삭제되지 않습니다. 대신 삭제됨으로 표시됩니다",
     "Tags": "태그",
     "Tags - Tooltip": "사용자가 선택할 수 있는 태그 컬렉션",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "보기 규칙",
     "Visible": "보이는",
     "Website URL": "웹사이트 URL",

--- a/web/src/locales/ms/data.json
+++ b/web/src/locales/ms/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "When enabled, deleting users will not completely remove them from the database. Instead, they will be marked as deleted",
     "Tags": "Tags",
     "Tags - Tooltip": "Collection of tags available for users to choose from",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "View rule",
     "Visible": "Visible",
     "Website URL": "Website URL",

--- a/web/src/locales/nl/data.json
+++ b/web/src/locales/nl/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "When enabled, deleting users will not completely remove them from the database. Instead, they will be marked as deleted",
     "Tags": "Tags",
     "Tags - Tooltip": "Collection of tags available for users to choose from",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "View rule",
     "Visible": "Visible",
     "Website URL": "Website URL",

--- a/web/src/locales/pl/data.json
+++ b/web/src/locales/pl/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "When enabled, deleting users will not completely remove them from the database. Instead, they will be marked as deleted",
     "Tags": "Tags",
     "Tags - Tooltip": "Collection of tags available for users to choose from",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "View rule",
     "Visible": "Visible",
     "Website URL": "Website URL",

--- a/web/src/locales/pt/data.json
+++ b/web/src/locales/pt/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "Quando ativada, a exclusão de usuários não os removerá completamente do banco de dados. Em vez disso, eles serão marcados como excluídos",
     "Tags": "Tags",
     "Tags - Tooltip": "Coleção de tags disponíveis para os usuários escolherem",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "Ver regra",
     "Visible": "Visível",
     "Website URL": "URL do website",

--- a/web/src/locales/ru/data.json
+++ b/web/src/locales/ru/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "Когда включено, удаление пользователей не полностью удаляет их из базы данных. Вместо этого они будут помечены как удаленные",
     "Tags": "Теги",
     "Tags - Tooltip": "Коллекция тегов, доступных для выбора пользователями",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "Правило просмотра",
     "Visible": "Видимый",
     "Website URL": "Веб-адрес сайта",

--- a/web/src/locales/sv/data.json
+++ b/web/src/locales/sv/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "When enabled, deleting users will not completely remove them from the database. Instead, they will be marked as deleted",
     "Tags": "Tags",
     "Tags - Tooltip": "Collection of tags available for users to choose from",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "View rule",
     "Visible": "Visible",
     "Website URL": "Website URL",

--- a/web/src/locales/tr/data.json
+++ b/web/src/locales/tr/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "When enabled, deleting users will not completely remove them from the database. Instead, they will be marked as deleted",
     "Tags": "Tags",
     "Tags - Tooltip": "Collection of tags available for users to choose from",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "View rule",
     "Visible": "Görünür",
     "Website URL": "Web Sitesi URL'si",

--- a/web/src/locales/uk/data.json
+++ b/web/src/locales/uk/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "Якщо ввімкнено, видалення користувачів не призведе до їх повного видалення з бази даних. ",
     "Tags": "Теги",
     "Tags - Tooltip": "Колекція тегів, доступна для вибору користувачами",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "Переглянути правило",
     "Visible": "Видно",
     "Website URL": "адреса вебсайту",

--- a/web/src/locales/vi/data.json
+++ b/web/src/locales/vi/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "Khi được bật, việc xóa người dùng sẽ không hoàn toàn loại bỏ họ khỏi cơ sở dữ liệu. Thay vào đó, họ sẽ được đánh dấu là đã bị xóa",
     "Tags": "Thẻ",
     "Tags - Tooltip": "Bộ sưu tập các thẻ có sẵn cho người dùng lựa chọn",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "Xem quy tắc",
     "Visible": "Rõ ràng",
     "Website URL": "Địa chỉ trang web",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -576,6 +576,8 @@
     "Soft deletion - Tooltip": "启用后，删除一个用户时不会在数据库彻底清除，只会标记为已删除状态",
     "Tags": "标签集合",
     "Tags - Tooltip": "可供用户选择的标签集合",
+    "Use Email as username": "Use Email as username",
+    "Use Email as username - Tooltip": "Use Email as username if the username field is not visible at signup",
     "View rule": "查看规则",
     "Visible": "是否可见",
     "Website URL": "主页地址",


### PR DESCRIPTION
Adds the possibility to use the email address as the username if the username field is not visible at signup.
The option can be checked at the organization level.

closes #2756