### PR TITLE
wip: fix: detect app user with admin/prefix

### DIFF
--- a/object/user_util.go
+++ b/object/user_util.go
@@ -481,7 +481,7 @@ func (user *User) IsAdminUser() bool {
 }
 
 func IsAppUser(userId string) bool {
-	if strings.HasPrefix(userId, "app/") {
+	if strings.HasPrefix(userId, "admin/") {
 		return true
 	}
 	return false


### PR DESCRIPTION
Produce error:

1. Create a new application with grant type is client_credentials
2. Get access token via endpoint: /api/login/oauth/access_token
   
<img width="1064" alt="image" src="https://github.com/casdoor/casdoor/assets/13352088/19c665f5-e44e-4b48-b817-2131431c107e">
3. Get user by email via API: /api/get-user with above access token

Actual result:
```json
{
    "status": "error",
    "msg": "Session outdated, please login again",
    "sub": "",
    "name": "",
    "data": null,
    "data2": null
}
```

Expected result:
info of user