### PR TITLE
fix: solve the problem of update operation returning 'unaffected'

### DIFF
--- a/web/src/PermissionEditPage.js
+++ b/web/src/PermissionEditPage.js
@@ -487,6 +487,7 @@ class PermissionEditPage extends React.Component {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
+            organizationName: this.state.permission.owner,
             permissionName: this.state.permission.name,
           });
 


### PR DESCRIPTION
Bug: https://github.com/casdoor/casdoor/issues/3034

After clicking the Save button, the frontend will send an update request. After the first update request, the backend has updated the data in the database but the frontend has not synchronized the organizationName field.

This causes the frontend to send outdated messages to the backend in subsequent changes. The backend cannot obtain the permission record based on the outdated message, so the return value is "unaffected"
