### PR TITLE
feat: don't drop empty table for adapters

### DIFF
--- a/object/permission.go
+++ b/object/permission.go
@@ -181,15 +181,15 @@ func UpdatePermission(id string, permission *Permission) (bool, error) {
 			return false, err
 		}
 
-		if oldPermission.Adapter != "" && oldPermission.Adapter != permission.Adapter {
-			isEmpty, _ := ormer.Engine.IsTableEmpty(oldPermission.Adapter)
-			if isEmpty {
-				err = ormer.Engine.DropTables(oldPermission.Adapter)
-				if err != nil {
-					return false, err
-				}
-			}
-		}
+		// if oldPermission.Adapter != "" && oldPermission.Adapter != permission.Adapter {
+		// 	isEmpty, _ := ormer.Engine.IsTableEmpty(oldPermission.Adapter)
+		// 	if isEmpty {
+		// 		err = ormer.Engine.DropTables(oldPermission.Adapter)
+		// 		if err != nil {
+		// 			return false, err
+		// 		}
+		// 	}
+		// }
 
 		err = addGroupingPolicies(permission)
 		if err != nil {
@@ -312,15 +312,15 @@ func DeletePermission(permission *Permission) (bool, error) {
 			return false, err
 		}
 
-		if permission.Adapter != "" && permission.Adapter != "permission_rule" {
-			isEmpty, _ := ormer.Engine.IsTableEmpty(permission.Adapter)
-			if isEmpty {
-				err = ormer.Engine.DropTables(permission.Adapter)
-				if err != nil {
-					return false, err
-				}
-			}
-		}
+		// if permission.Adapter != "" && permission.Adapter != "permission_rule" {
+		// 	isEmpty, _ := ormer.Engine.IsTableEmpty(permission.Adapter)
+		// 	if isEmpty {
+		// 		err = ormer.Engine.DropTables(permission.Adapter)
+		// 		if err != nil {
+		// 			return false, err
+		// 		}
+		// 	}
+		// }
 	}
 
 	return affected, nil

--- a/web/src/PermissionEditPage.js
+++ b/web/src/PermissionEditPage.js
@@ -487,6 +487,7 @@ class PermissionEditPage extends React.Component {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
+            organizationName: this.state.permission.owner,
             permissionName: this.state.permission.name,
           });
 


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/3025

When a permission is deleted or the adapter attribute of the permission is changed, the program will determine whether the adapter data table that originally stored the permission is empty after the permission is deleted. If it is empty, the data table will be dropped. 

Although this operation saves storage space, it requires additional DROP permissions, which limits the application scenarios of Casdoor.