### PR TITLE
feat: use orgnization logo as tour logo and allow to configure whether to enable tour in organization edit page

### DIFF
--- a/object/organization.go
+++ b/object/organization.go
@@ -73,6 +73,7 @@ type Organization struct {
 	EnableSoftDeletion     bool       `json:"enableSoftDeletion"`
 	IsProfilePublic        bool       `json:"isProfilePublic"`
 	UseEmailAsUsername     bool       `json:"useEmailAsUsername"`
+	EnableTour             bool       `json:"enableTour"`
 
 	MfaItems     []*MfaItem     `xorm:"varchar(300)" json:"mfaItems"`
 	AccountItems []*AccountItem `xorm:"varchar(5000)" json:"accountItems"`

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -16,6 +16,7 @@ import React, {Component, Suspense, lazy} from "react";
 import "./App.less";
 import {Helmet} from "react-helmet";
 import * as Setting from "./Setting";
+import {setIsTourVisible, setTourLogo} from "./TourConfig";
 import {StyleProvider, legacyLogicalPropertiesTransformer} from "@ant-design/cssinjs";
 import {GithubOutlined, InfoCircleFilled, ShareAltOutlined} from "@ant-design/icons";
 import {Alert, Button, ConfigProvider, Drawer, FloatButton, Layout, Result, Tooltip} from "antd";
@@ -247,6 +248,8 @@ class App extends Component {
 
           this.setLanguage(account);
           this.setTheme(Setting.getThemeData(account.organization), Conf.InitThemeAlgorithm);
+          setTourLogo(account.organization.logo);
+          setIsTourVisible(account.organization.enableTour);
         } else {
           if (res.data !== "Please login first") {
             Setting.showMessage("error", `${i18next.t("application:Failed to sign in")}: ${res.msg}`);

--- a/web/src/OrganizationEditPage.js
+++ b/web/src/OrganizationEditPage.js
@@ -447,6 +447,16 @@ class OrganizationEditPage extends React.Component {
           </Col>
         </Row>
         <Row style={{marginTop: "20px"}} >
+          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 19 : 2}>
+            {Setting.getLabel(i18next.t("general:Enable tour"), i18next.t("general:Enable tour - Tooltip"))} :
+          </Col>
+          <Col span={1} >
+            <Switch checked={this.state.organization.enableTour} onChange={checked => {
+              this.updateOrganizationField("enableTour", checked);
+            }} />
+          </Col>
+        </Row>
+        <Row style={{marginTop: "20px"}} >
           <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
             {Setting.getLabel(i18next.t("organization:Account items"), i18next.t("organization:Account items - Tooltip"))} :
           </Col>

--- a/web/src/OrganizationListPage.js
+++ b/web/src/OrganizationListPage.js
@@ -44,6 +44,7 @@ class OrganizationListPage extends BaseListPage {
       defaultPassword: "",
       enableSoftDeletion: false,
       isProfilePublic: true,
+      enableTour: true,
       accountItems: [
         {name: "Organization", visible: true, viewRule: "Public", modifyRule: "Admin"},
         {name: "ID", visible: true, viewRule: "Public", modifyRule: "Immutable"},

--- a/web/src/TourConfig.js
+++ b/web/src/TourConfig.js
@@ -208,6 +208,12 @@ export function setIsTourVisible(visible) {
   window.dispatchEvent(new Event("storageTourChanged"));
 }
 
+export function setTourLogo(tourLogoSrc) {
+  if (tourLogoSrc !== "") {
+    TourObj["home"][0]["cover"] = (<img alt="casdoor.png" src={tourLogoSrc} />);
+  }
+}
+
 export function getTourVisible() {
   return localStorage.getItem("isTourVisible") !== "false";
 }


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/3026

The enable tour switch has been added to the organization edit page to configure whether the tour is displayed when the organization's users log in.

The tour logo will use the organization logo instead of default logo.