### PR TITLE
feat: fix bug in obtaining Casdoor version in Docker

### DIFF
--- a/controllers/system_info.go
+++ b/controllers/system_info.go
@@ -46,10 +46,10 @@ func (c *ApiController) GetSystemInfo() {
 // @Success 200 {object} util.VersionInfo The Response object
 // @router /get-version-info [get]
 func (c *ApiController) GetVersionInfo() {
+	errInfo := ""
 	versionInfo, err := util.GetVersionInfo()
 	if err != nil {
-		c.ResponseError(err.Error())
-		return
+		errInfo = "Git error: " + err.Error()
 	}
 
 	if versionInfo.Version != "" {
@@ -59,9 +59,11 @@ func (c *ApiController) GetVersionInfo() {
 
 	versionInfo, err = util.GetVersionInfoFromFile()
 	if err != nil {
-		c.ResponseError(err.Error())
+		errInfo = errInfo + ", File error: " + err.Error()
+		c.ResponseError(errInfo)
 		return
 	}
+
 	c.ResponseOk(versionInfo)
 }
 


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/2981

The docker container does not contain the Git repository, which causes the program to get the version information through Git to report an error.
The original processing program will directly return the exception information after Git reports an error, causing the program to be unable to use the version_info.txt file to obtain the correct version information.
So the program's exception handling logic is changed to: the program returns the exception information only when Git throws an exception and the file fails to obtain the version information.