### PR TITLE
feat: fix isPasswordWithLdapEnabled logic in handleBind() for redirecting to other LDAP sources

### DIFF
--- a/ldap/server.go
+++ b/ldap/server.go
@@ -59,7 +59,13 @@ func handleBind(w ldap.ResponseWriter, m *ldap.Message) {
 		}
 
 		bindPassword := string(r.AuthenticationSimple())
-		bindUser, err := object.CheckUserPassword(bindOrg, bindUsername, bindPassword, "en")
+		
+		var enableCaptcha, isSigninViaLdap, isPasswordWithLdapEnabled bool = false, false, false
+		if bindPassword != "" {
+			isPasswordWithLdapEnabled = true
+		}
+
+		bindUser, err := object.CheckUserPassword(bindOrg, bindUsername, bindPassword, "en", enableCaptcha, isSigninViaLdap, isPasswordWithLdapEnabled)
 		if err != nil {
 			log.Printf("Bind failed User=%s, Pass=%#v, ErrMsg=%s", string(r.Name()), r.Authentication(), err)
 			res.SetResultCode(ldap.LDAPResultInvalidCredentials)

--- a/ldap/server.go
+++ b/ldap/server.go
@@ -59,8 +59,10 @@ func handleBind(w ldap.ResponseWriter, m *ldap.Message) {
 		}
 
 		bindPassword := string(r.AuthenticationSimple())
-		
-		var enableCaptcha, isSigninViaLdap, isPasswordWithLdapEnabled bool = false, false, false
+
+		enableCaptcha := false
+		isSigninViaLdap := false
+		isPasswordWithLdapEnabled := false
 		if bindPassword != "" {
 			isPasswordWithLdapEnabled = true
 		}


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/3032

Added needed parameters so that the internal LDAP server can redirect to other LDAP sources correctly and not run into the "wrong credentials" error every time.

Unsure if this is the best way of going about it, so feel free to edit this accordingly. I have tested it on an internal server and it works - for both local and LDAP-synced users. This should not break any existing logic with how little is changed.