### PR TITLE
feat: allow custom Domain of Google Cloud Storage Provider

### DIFF
--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -906,7 +906,7 @@ class ProviderEditPage extends React.Component {
                 </Col>
               </Row>
             )}
-            {["Custom HTTP SMS", "Google Cloud Storage", "Qiniu Cloud Kodo", "Synology"].includes(this.state.provider.type) ? null : (
+            {["Custom HTTP SMS", "Qiniu Cloud Kodo", "Synology"].includes(this.state.provider.type) ? null : (
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={2}>
                   {Setting.getLabel(i18next.t("provider:Domain"), i18next.t("provider:Domain - Tooltip"))} :


### PR DESCRIPTION
The Storage Provider - "Google Cloud Storage" not allow custom Domain, it will always set the Endpoint value to Domain and I can't change it. https://github.com/casdoor/casdoor/blob/9b9a58e7ac2e27486dd90ee9ce290dfbdef9ffc1/object/storage.go#L120

Currently, I get error when uploading file to GCS, the fileUrl (= provider.Domain + filePath) response not include the bucket name, but I can't change the provider.Domain.