### PR TITLE
feat: support reCAPTCHA v3 captcha provider

### DIFF
--- a/captcha/provider.go
+++ b/captcha/provider.go
@@ -24,7 +24,9 @@ func GetCaptchaProvider(captchaType string) CaptchaProvider {
 	switch captchaType {
 	case "Default":
 		return NewDefaultCaptchaProvider()
-	case "reCAPTCHA":
+	case "reCAPTCHA v2":
+		return NewReCaptchaProvider()
+	case "reCAPTCHA v3":
 		return NewReCaptchaProvider()
 	case "Aliyun Captcha":
 		return NewAliyunCaptchaProvider()

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -279,7 +279,11 @@ export const OtherProviderInfo = {
       logo: `${StaticBaseUrl}/img/captcha_default.png`,
       url: "https://pkg.go.dev/github.com/dchest/captcha",
     },
-    "reCAPTCHA": {
+    "reCAPTCHA v2": {
+      logo: `${StaticBaseUrl}/img/social_recaptcha.png`,
+      url: "https://www.google.com/recaptcha",
+    },
+    "reCAPTCHA v3": {
       logo: `${StaticBaseUrl}/img/social_recaptcha.png`,
       url: "https://www.google.com/recaptcha",
     },
@@ -1083,7 +1087,8 @@ export function getProviderTypeOptions(category) {
   } else if (category === "Captcha") {
     return ([
       {id: "Default", name: "Default"},
-      {id: "reCAPTCHA", name: "reCAPTCHA"},
+      {id: "reCAPTCHA v2", name: "reCAPTCHA v2"},
+      {id: "reCAPTCHA v3", name: "reCAPTCHA v3"},
       {id: "hCaptcha", name: "hCaptcha"},
       {id: "Aliyun Captcha", name: "Aliyun Captcha"},
       {id: "GEETEST", name: "GEETEST"},

--- a/web/src/common/CaptchaWidget.js
+++ b/web/src/common/CaptchaWidget.js
@@ -27,7 +27,7 @@ export const CaptchaWidget = (props) => {
 
   useEffect(() => {
     switch (captchaType) {
-    case "reCAPTCHA": {
+    case "reCAPTCHA v2": {
       const reTimer = setInterval(() => {
         if (!window.grecaptcha) {
           loadScript("https://recaptcha.net/recaptcha/api.js");
@@ -36,6 +36,20 @@ export const CaptchaWidget = (props) => {
           window.grecaptcha.render("captcha", {
             sitekey: siteKey,
             callback: onChange,
+          });
+          clearInterval(reTimer);
+        }
+      }, 300);
+      break;
+    }
+    case "reCAPTCHA v3": {
+      const reTimer = setInterval(() => {
+        if (!window.grecaptcha) {
+          loadScript(`https://recaptcha.net/recaptcha/api.js?render=${siteKey}`);
+        }
+        if (window.grecaptcha && window.grecaptcha.execute) {
+          window.grecaptcha.execute(siteKey, {action: "submit"}).then(function(token) {
+            onChange(token);
           });
           clearInterval(reTimer);
         }


### PR DESCRIPTION
fix: https://github.com/casdoor/casdoor/issues/3122

Add reCAPTCHA v3 to the provider type and change the previous type reCAPTCHA to reCAPTCHA v2.

The backend verification logic of google reCAPTCHA v3 and v2 is the same, so the backend code is not modified. Only the captcha operation code is added to the frontend for the v3 version.