### PR TITLE
feat: certEditPage will be redirected to 404 when name is changed

### DIFF
--- a/web/src/CertEditPage.js
+++ b/web/src/CertEditPage.js
@@ -288,14 +288,14 @@ class CertEditPage extends React.Component {
           Setting.showMessage("success", i18next.t("general:Successfully saved"));
           this.setState({
             certName: this.state.cert.name,
+          }, () => {
+            if (exitAfterSave) {
+              this.props.history.push("/certs");
+            } else {
+              this.props.history.push(`/certs/${this.state.cert.owner}/${this.state.cert.name}`);
+              this.getCert();
+            }
           });
-
-          if (exitAfterSave) {
-            this.props.history.push("/certs");
-          } else {
-            this.props.history.push(`/certs/${this.state.cert.owner}/${this.state.cert.name}`);
-            this.getCert();
-          }
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
           this.updateCertField("name", this.state.certName);


### PR DESCRIPTION
fix: certEditPage will be redirected to 404 when change name due to setState is an async function, and certName hasn't update when execute getCert()

**Before**

https://github.com/user-attachments/assets/a94013b5-4e4d-4b7f-acac-8ba1853c01fe

**After**

https://github.com/user-attachments/assets/8da577bf-5219-403c-add3-7904a60898a7

