### PR TITLE
feat: Users added through LDAP cannot log in using the set password

### DIFF
--- a/object/check.go
+++ b/object/check.go
@@ -354,7 +354,7 @@ func CheckUserPassword(organization string, username string, password string, la
 		}
 	}
 
-	if (user.Ldap != "" && isSigninViaLdap) || (user.Password == "" && user.Ldap != "") {
+	if user.Ldap != "" && (isSigninViaLdap || user.Password == "") {
 		if !isPasswordWithLdapEnabled {
 			return nil, fmt.Errorf(i18n.Translate(lang, "check:password or code is incorrect"))
 		}

--- a/object/check.go
+++ b/object/check.go
@@ -354,8 +354,8 @@ func CheckUserPassword(organization string, username string, password string, la
 		}
 	}
 
-	if user.Ldap != "" {
-		if !isSigninViaLdap && !isPasswordWithLdapEnabled {
+	if (user.Ldap != "" && isSigninViaLdap) || (user.Password == "" && user.Ldap != "") {
+		if !isPasswordWithLdapEnabled {
 			return nil, fmt.Errorf(i18n.Translate(lang, "check:password or code is incorrect"))
 		}
 


### PR DESCRIPTION
fix: #3174 
now casdoor will prioritize the use of password set by user in casdoor and use ldap password when users never change their password or use ldap signin method to login