### PR TITLE
Fix: allow Keycloak table input to be editable

### DIFF
--- a/web/src/SyncerEditPage.js
+++ b/web/src/SyncerEditPage.js
@@ -434,10 +434,7 @@ class SyncerEditPage extends React.Component {
             {Setting.getLabel(i18next.t("syncer:Table"), i18next.t("syncer:Table - Tooltip"))} :
           </Col>
           <Col span={22} >
-            <Input value={this.state.syncer.table}
-              disabled={this.state.syncer.type === "Keycloak"} onChange={e => {
-                this.updateSyncerField("table", e.target.value);
-              }} />
+            <Input value={this.state.syncer.table} onChange={e => {this.updateSyncerField("table", e.target.value);}} />
           </Col>
         </Row>
         <Row style={{marginTop: "20px"}} >


### PR DESCRIPTION
To solve https://github.com/casdoor/casdoor/issues/3171, the table name can be edited when the type is Keycloak.