### PR TITLE
feat: add an idp for cstnet, which is used inside of branches of cas.cn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@ commentsRouter*.go
 casdoor
 server
 
+casdoor.db
 # include helm-chart
 !manifests/casdoor

--- a/conf/app.conf
+++ b/conf/app.conf
@@ -29,3 +29,4 @@ radiusSecret = "secret"
 quota = {"organization": -1, "user": -1, "application": -1, "provider": -1}
 logConfig = {"filename": "logs/casdoor.log", "maxdays":99999, "perm":"0770"}
 initDataFile = "./init_data.json"
+frontendBaseDir = "../casdoor"

--- a/conf/app.conf
+++ b/conf/app.conf
@@ -29,4 +29,3 @@ radiusSecret = "secret"
 quota = {"organization": -1, "user": -1, "application": -1, "provider": -1}
 logConfig = {"filename": "logs/casdoor.log", "maxdays":99999, "perm":"0770"}
 initDataFile = "./init_data.json"
-frontendBaseDir = "../casdoor"

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -1083,7 +1083,6 @@ func (c *ApiController) GetCaptchaStatus() {
 func (c *ApiController) Callback() {
 	code := c.GetString("code")
 	state := c.GetString("state")
-
 	frontendCallbackUrl := fmt.Sprintf("/callback?code=%s&state=%s", code, state)
 	c.Ctx.Redirect(http.StatusFound, frontendCallbackUrl)
 }

--- a/idp/cstnet.go
+++ b/idp/cstnet.go
@@ -1,0 +1,213 @@
+package idp
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/beego/beego/logs"
+	"golang.org/x/oauth2"
+)
+
+type CSTNETIdProvider struct {
+	Client *http.Client
+	Config *oauth2.Config
+}
+
+func NewCSTNETIdProvider(clientId string, clientSecret string, redirectUrl string) *CSTNETIdProvider {
+	idp := &CSTNETIdProvider{}
+	idp.Config = idp.getConfig(clientId, clientSecret, redirectUrl)
+	return idp
+}
+
+func (idp *CSTNETIdProvider) SetHttpClient(client *http.Client) {
+	idp.Client = client
+}
+
+func (idp *CSTNETIdProvider) getConfig(clientId string, clientSecret string, redirectUrl string) *oauth2.Config {
+	endpoint := oauth2.Endpoint{
+		AuthURL:  "https://passport.escience.cn/oauth2/authorize",
+		TokenURL: "https://passport.escience.cn/oauth2/token",
+	}
+
+	config := &oauth2.Config{
+		ClientID:     clientId,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectUrl,
+		Scopes:       []string{"all"},
+		Endpoint:     endpoint,
+	}
+
+	return config
+}
+
+func (idp *CSTNETIdProvider) GetToken(code string) (*oauth2.Token, error) {
+
+	values := url.Values{}
+	values.Set("grant_type", "authorization_code")
+	values.Set("code", code)
+	values.Set("client_id", idp.Config.ClientID)
+	values.Set("client_secret", idp.Config.ClientSecret)
+	values.Set("redirect_uri", idp.Config.RedirectURL)
+
+	resp, err := idp.Client.PostForm(idp.Config.Endpoint.TokenURL, values)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var tokenResp struct {
+		AccessToken  string `json:"access_token"`
+		ExpiresIn    int    `json:"expires_in"`
+		RefreshToken string `json:"refresh_token"`
+		UserInfo     string `json:"userInfo"`
+	}
+
+	err = json.Unmarshal(body, &tokenResp)
+	if err != nil {
+		return nil, err
+	}
+
+	token := &oauth2.Token{
+		AccessToken:  tokenResp.AccessToken,
+		Expiry:       time.Unix(time.Now().Unix()+int64(tokenResp.ExpiresIn), 0),
+		RefreshToken: tokenResp.RefreshToken,
+	}
+	extraInfo := map[string]interface{}{
+		"UserInfo": tokenResp.UserInfo,
+	}
+	newToken := token.WithExtra(extraInfo)
+
+	return newToken, nil
+}
+
+/*
+{"truename":"刘侃","umtId":"11253866","isPhoneVerified":"true","cstnetId":"liukan@wbgcas.cn","passwordType":"password_core_mail","type":"coreMail","cstnetIdStatus":"active","isIdCardVerified":false}
+*/
+type CSTNETUserInfo struct {
+	Truename         string   `json:"truename"`
+	UmtId            string   `json:"umtId"`
+	IsPhoneVerified  Bool     `json:"isPhoneVerified"`
+	CstnetId         string   `json:"cstnetId"`
+	PasswordType     string   `json:"passwordType"`
+	Type             string   `json:"type"`
+	CstnetIdStatus   string   `json:"cstnetIdStatus"`
+	IsIdCardVerified bool     `json:"isIdCardVerified"`
+	SecurityEmail    string   `json:"securityEmail"`
+	SecondaryEmails  []string `json:"secondaryEmails"`
+}
+type Bool bool
+
+func (b *Bool) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	*b = s == "true"
+	return nil
+}
+
+func hasGravatar(client *http.Client, email string) (bool, error) {
+	// Clean and lowercase the email
+	email = strings.TrimSpace(strings.ToLower(email))
+
+	// Generate MD5 hash of the email
+	hash := md5.New()
+	io.WriteString(hash, email)
+	hashedEmail := fmt.Sprintf("%x", hash.Sum(nil))
+
+	// Create Gravatar URL with d=404 parameter
+	gravatarURL := fmt.Sprintf("https://www.gravatar.com/avatar/%s?d=404", hashedEmail)
+
+	// Send a request to Gravatar
+	req, err := http.NewRequest("GET", gravatarURL, nil)
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	// Check if the user has a custom Gravatar image
+	if resp.StatusCode == http.StatusOK {
+		return true, nil
+	} else if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	} else {
+		return false, fmt.Errorf("failed to fetch gravatar image: %s", resp.Status)
+	}
+}
+func getGravatarURL(email string) (string, error) {
+	// Clean and lowercase the email
+	email = strings.TrimSpace(strings.ToLower(email))
+
+	// Generate MD5 hash of the email
+	hash := md5.New()
+	_, err := io.WriteString(hash, email)
+	if err != nil {
+		logs.Debug("getGravatarURL error: %s", err)
+		return "", err
+	}
+	hashedEmail := fmt.Sprintf("%x", hash.Sum(nil))
+	// Create Gravatar URL
+	gravatarUrl := fmt.Sprintf("https://www.gravatar.com/avatar/%s", hashedEmail)
+	return gravatarUrl, nil
+}
+
+func (idp *CSTNETIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error) {
+
+	tokenUserInfo := token.Extra("UserInfo")
+	extraString := fmt.Sprintf("%v", tokenUserInfo)
+
+	/*
+		{"truename":"刘侃","umtId":"11253866","isPhoneVerified":"true","cstnetId":"liukan@wbgcas.cn","passwordType":"password_core_mail","type":"coreMail","cstnetIdStatus":"active","isIdCardVerified":false}
+	*/
+
+	cstnetInfo := &CSTNETUserInfo{}
+	if err := json.Unmarshal([]byte(extraString), cstnetInfo); err != nil {
+		return nil, err
+	}
+	gravatarUrl := ""
+	// hasGravatar, err := hasGravatar(idp.Client, cstnetInfo.CstnetId)
+	// if err != nil {
+	// 	logs.Debug("hasGravatar error: %s", err)
+	// } else if hasGravatar {
+	// 	gravatarUrl, _ = getGravatarURL(cstnetInfo.CstnetId)
+	// }
+	/*
+		type UserInfo struct {
+			Id          string
+			Username    string
+			DisplayName string
+			UnionId     string
+			Email       string
+			Phone       string
+			CountryCode string
+			AvatarUrl   string
+			Extra       map[string]string
+		}
+	*/
+	userInfo := &UserInfo{
+		Id:          cstnetInfo.CstnetId,
+		Username:    cstnetInfo.CstnetId,
+		DisplayName: cstnetInfo.Truename,
+		UnionId:     cstnetInfo.UmtId,
+		Email:       cstnetInfo.CstnetId,
+		AvatarUrl:   gravatarUrl, // CSTNET doesn't provide avatar information
+	}
+
+	return userInfo, nil
+}

--- a/idp/provider.go
+++ b/idp/provider.go
@@ -115,6 +115,8 @@ func GetIdProvider(idpInfo *ProviderInfo, redirectUrl string) (IdProvider, error
 		return NewDouyinIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl), nil
 	case "Bilibili":
 		return NewBilibiliIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl), nil
+	case "CSTNET":
+		return NewCSTNETIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl), nil
 	case "MetaMask":
 		return NewMetaMaskIdProvider(), nil
 	case "Web3Onboard":

--- a/object/user.go
+++ b/object/user.go
@@ -127,6 +127,7 @@ type User struct {
 	Slack           string `xorm:"slack varchar(100)" json:"slack"`
 	Steam           string `xorm:"steam varchar(100)" json:"steam"`
 	Bilibili        string `xorm:"bilibili varchar(100)" json:"bilibili"`
+	CSTNET          string `xorm:"cstnet varchar(100)" json:"cstnet"`
 	Okta            string `xorm:"okta varchar(100)" json:"okta"`
 	Douyin          string `xorm:"douyin varchar(100)" json:"douyin"`
 	Line            string `xorm:"line varchar(100)" json:"line"`
@@ -691,7 +692,7 @@ func UpdateUser(id string, user *User, columns []string, isAdmin bool) (bool, er
 			"is_admin", "is_forbidden", "is_deleted", "hash", "is_default_avatar", "properties", "webauthnCredentials", "managedAccounts", "face_ids", "mfaAccounts",
 			"signin_wrong_times", "last_signin_wrong_time", "groups", "access_key", "access_secret", "mfa_phone_enabled", "mfa_email_enabled",
 			"github", "google", "qq", "wechat", "facebook", "dingtalk", "weibo", "gitee", "linkedin", "wecom", "lark", "gitlab", "adfs",
-			"baidu", "alipay", "casdoor", "infoflow", "apple", "azuread", "azureadb2c", "slack", "steam", "bilibili", "okta", "douyin", "line", "amazon",
+			"baidu", "alipay", "casdoor", "infoflow", "apple", "azuread", "azureadb2c", "slack", "steam", "bilibili", "cstnet", "okta", "douyin", "line", "amazon",
 			"auth0", "battlenet", "bitbucket", "box", "cloudfoundry", "dailymotion", "deezer", "digitalocean", "discord", "dropbox",
 			"eveonline", "fitbit", "gitea", "heroku", "influxcloud", "instagram", "intercom", "kakao", "lastfm", "mailru", "meetup",
 			"microsoftonline", "naver", "nextcloud", "onedrive", "oura", "patreon", "paypal", "salesforce", "shopify", "soundcloud",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -7401,6 +7401,9 @@
                 "bilibili": {
                     "type": "string"
                 },
+                "cstnet": {
+                    "type": "string"
+                },
                 "bio": {
                     "type": "string"
                 },

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -4876,6 +4876,8 @@ definitions:
         type: string
       bilibili:
         type: string
+      cstnet:
+        type: string
       bio:
         type: string
       birthday:

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -976,6 +976,7 @@ export function getProviderTypeOptions(category) {
         {id: "Slack", name: "Slack"},
         {id: "Steam", name: "Steam"},
         {id: "Bilibili", name: "Bilibili"},
+        {id: "CSTNET", name: "CSTNET"},
         {id: "Okta", name: "Okta"},
         {id: "Douyin", name: "Douyin"},
         {id: "Line", name: "Line"},

--- a/web/src/auth/CSTNETLoginButton.js
+++ b/web/src/auth/CSTNETLoginButton.js
@@ -1,0 +1,32 @@
+// Copyright 2021 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {createButton} from "react-social-login-buttons";
+import {StaticBaseUrl} from "../Setting";
+
+function Icon({width = 24, height = 24, color}) {
+  return <img src={`${StaticBaseUrl}/buttons/cstnet.svg`} alt="Sign in with CSTNET" />;
+}
+
+const config = {
+  text: "Sign in with CSTNET",
+  icon: Icon,
+  iconFormat: name => `fa fa-${name}`,
+  style: {background: "#0191e0"},
+  activeStyle: {background: "rgb(76,143,208)"},
+};
+
+const CSTNETLoginButton = createButton(config);
+
+export default CSTNETLoginButton;

--- a/web/src/auth/Provider.js
+++ b/web/src/auth/Provider.js
@@ -125,6 +125,9 @@ const authInfo = {
   Bilibili: {
     endpoint: "https://passport.bilibili.com/register/pc_oauth2.html",
   },
+  CSTNET: {
+    endpoint: "https://passport.escience.cn/oauth2/authorize",
+  },
   Line: {
     scope: "profile%20openid%20email",
     endpoint: "https://access.line.me/oauth2/v2.1/authorize",
@@ -474,6 +477,8 @@ export function getAuthUrl(application, provider, method, code) {
     return `${provider.customAuthUrl}?client_id=${provider.clientId}&redirect_uri=${redirectUri}&scope=${provider.scopes}&response_type=code&state=${state}`;
   } else if (provider.type === "Bilibili") {
     return `${endpoint}#/?client_id=${provider.clientId}&return_url=${redirectUri}&state=${state}&response_type=code`;
+  } else if (provider.type === "CSTNET") {
+    return `${endpoint}?response_type=code&client_id=${provider.clientId}&redirect_uri=${redirectUri}&state=${state}&theme=full`;
   } else if (provider.type === "Deezer") {
     return `${endpoint}?app_id=${provider.clientId}&redirect_uri=${redirectUri}&perms=${scope}`;
   } else if (provider.type === "Lastfm") {

--- a/web/src/auth/ProviderButton.js
+++ b/web/src/auth/ProviderButton.js
@@ -38,6 +38,7 @@ import AzureADB2CLoginButton from "./AzureADB2CLoginButton";
 import SlackLoginButton from "./SlackLoginButton";
 import SteamLoginButton from "./SteamLoginButton";
 import BilibiliLoginButton from "./BilibiliLoginButton";
+import CSTNETLoginButton from "./CSTNETLoginButton";
 import OktaLoginButton from "./OktaLoginButton";
 import DouyinLoginButton from "./DouyinLoginButton";
 import LoginButton from "./LoginButton";
@@ -92,6 +93,8 @@ function getSigninButton(provider) {
     return <SteamLoginButton text={text} align={"center"} />;
   } else if (provider.type === "Bilibili") {
     return <BilibiliLoginButton text={text} align={"center"} />;
+  } else if (provider.type === "CSTNET") {
+    return <CSTNETLoginButton text={text} align={"center"} />;
   } else if (provider.type === "Okta") {
     return <OktaLoginButton text={text} align={"center"} />;
   } else if (provider.type === "Douyin") {


### PR DESCRIPTION
[CSTCloud Passport](https://passport.escience.cn/) is a widely used OAuth authentication tool within the Chinese Academy of Sciences and its affiliated systems. It uses a modified version of the OAuth protocol, with only two https requests required for a single authentication process.