### PR TITLE
feat: add verification code step when submit set-password api

### DIFF
--- a/controllers/user.go
+++ b/controllers/user.go
@@ -489,6 +489,11 @@ func (c *ApiController) SetPassword() {
 			c.ResponseError(c.T("general:Missing parameter"))
 			return
 		}
+		record, err := object.GetVerificationRecordByCode(userName, code)
+		if err != nil || record == nil {
+			c.ResponseError(c.T("general:Wrong target user"))
+			return
+		}
 		c.SetSession("verifiedCode", "")
 	}
 

--- a/object/verification.go
+++ b/object/verification.go
@@ -343,3 +343,16 @@ func GetVerification(id string) (*VerificationRecord, error) {
 	owner, name := util.GetOwnerAndNameFromId(id)
 	return getVerification(owner, name)
 }
+
+func GetVerificationRecordByCode(dest, code string) (*VerificationRecord, error) {
+	var record VerificationRecord
+	record.Receiver = dest
+	has, err := ormer.Engine.Desc("time").Where("code = ?", code).Get(&record)
+	if err != nil {
+		return nil, err
+	}
+	if !has {
+		return nil, nil
+	}
+	return &record, nil
+}


### PR DESCRIPTION
Add verification step when received set-password call, validate whether target user with verification code is valid with record in verification_record