### PR TITLE
feat: Make MFA instructions clear for SMS and Email

### DIFF
--- a/web/src/auth/mfa/MfaAuthVerifyForm.js
+++ b/web/src/auth/mfa/MfaAuthVerifyForm.js
@@ -106,7 +106,7 @@ export function MfaAuthVerifyForm({
           <div>
             <div style={{marginBottom: 24}}>
               {i18next.t(
-                "mfa:You have enabled multi-factor authentication, please enter the authentication code"
+                "mfa:You have enabled Multi-Factor Authentication, please enter the TOTP code"
               )}
             </div>
             <MfaVerifyTotpForm mfaProps={mfaProps} onFinish={verify} />

--- a/web/src/auth/mfa/MfaAuthVerifyForm.js
+++ b/web/src/auth/mfa/MfaAuthVerifyForm.js
@@ -24,7 +24,14 @@ import MfaVerifyTotpForm from "./MfaVerifyTotpForm";
 export const NextMfa = "NextMfa";
 export const RequiredMfa = "RequiredMfa";
 
-export function MfaAuthVerifyForm({formValues, authParams, mfaProps, application, onSuccess, onFail}) {
+export function MfaAuthVerifyForm({
+  formValues,
+  authParams,
+  mfaProps,
+  application,
+  onSuccess,
+  onFail,
+}) {
   formValues.password = "";
   formValues.username = "";
   const [loading, setLoading] = useState(false);
@@ -34,48 +41,58 @@ export function MfaAuthVerifyForm({formValues, authParams, mfaProps, application
   const verify = ({passcode}) => {
     setLoading(true);
     const values = {...formValues, passcode, mfaType};
-    const loginFunction = formValues.type === "cas" ? AuthBackend.loginCas : AuthBackend.login;
-    loginFunction(values, authParams).then((res) => {
-      if (res.status === "ok") {
-        onSuccess(res);
-      } else {
-        onFail(res.msg);
-      }
-    }).catch((res) => {
-      onFail(res.message);
-    }).finally(() => {
-      setLoading(false);
-    });
+    const loginFunction =
+      formValues.type === "cas" ? AuthBackend.loginCas : AuthBackend.login;
+    loginFunction(values, authParams)
+      .then((res) => {
+        if (res.status === "ok") {
+          onSuccess(res);
+        } else {
+          onFail(res.msg);
+        }
+      })
+      .catch((res) => {
+        onFail(res.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   };
 
   const recover = () => {
     setLoading(true);
     const values = {...formValues, recoveryCode};
-    const loginFunction = formValues.type === "cas" ? AuthBackend.loginCas : AuthBackend.login;
-    loginFunction(values, authParams).then((res) => {
-      if (res.status === "ok") {
-        onSuccess(res);
-      } else {
-        onFail(res.msg);
-      }
-    }).catch((res) => {
-      onFail(res.message);
-    }).finally(() => {
-      setLoading(false);
-    });
+    const loginFunction =
+      formValues.type === "cas" ? AuthBackend.loginCas : AuthBackend.login;
+    loginFunction(values, authParams)
+      .then((res) => {
+        if (res.status === "ok") {
+          onSuccess(res);
+        } else {
+          onFail(res.msg);
+        }
+      })
+      .catch((res) => {
+        onFail(res.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   };
 
   if (mfaType !== RecoveryMfaType) {
     return (
       <div style={{width: 300, height: 350}}>
-        <div style={{marginBottom: 24, textAlign: "center", fontSize: "24px"}}>
+        <div
+          style={{marginBottom: 24, textAlign: "center", fontSize: "24px"}}
+        >
           {i18next.t("mfa:Multi-factor authentication")}
         </div>
         {mfaType === SmsMfaType || mfaType === EmailMfaType ? (
           <div>
             <div style={{marginBottom: 24}}>
               {i18next.t(
-                "mfa:You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process"
+                "mfa:You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue"
               )}
             </div>
             <MfaVerifySmsForm
@@ -97,9 +114,11 @@ export function MfaAuthVerifyForm({formValues, authParams, mfaProps, application
         )}
         <span style={{float: "right"}}>
           {i18next.t("mfa:Have problems?")}
-          <a onClick={() => {
-            setMfaType("recovery");
-          }}>
+          <a
+            onClick={() => {
+              setMfaType("recovery");
+            }}
+          >
             {i18next.t("mfa:Use a recovery code")}
           </a>
         </span>
@@ -108,28 +127,39 @@ export function MfaAuthVerifyForm({formValues, authParams, mfaProps, application
   } else {
     return (
       <div style={{width: 300, height: 350}}>
-        <div style={{marginBottom: 24, textAlign: "center", fontSize: "24px"}}>
+        <div
+          style={{marginBottom: 24, textAlign: "center", fontSize: "24px"}}
+        >
           {i18next.t("mfa:Multi-factor recover")}
         </div>
         <div style={{marginBottom: 24}}>
           {i18next.t("mfa:Multi-factor recover description")}
         </div>
-        <Input placeholder={i18next.t("mfa:Recovery code")}
+        <Input
+          placeholder={i18next.t("mfa:Recovery code")}
           style={{marginBottom: 24}}
           type={"passcode"}
           size={"large"}
-          onChange={event => setRecoveryCode(event.target.value)}
+          onChange={(event) => setRecoveryCode(event.target.value)}
         />
-        <Button style={{width: "100%", marginBottom: 20}} size={"large"} loading={loading}
-          type={"primary"} onClick={() => {
+        <Button
+          style={{width: "100%", marginBottom: 20}}
+          size={"large"}
+          loading={loading}
+          type={"primary"}
+          onClick={() => {
             recover();
-          }}>{i18next.t("forget:Verify")}
+          }}
+        >
+          {i18next.t("forget:Verify")}
         </Button>
         <span style={{float: "right"}}>
           {i18next.t("mfa:Have problems?")}
-          <a onClick={() => {
-            setMfaType(mfaProps.mfaType);
-          }}>
+          <a
+            onClick={() => {
+              setMfaType(mfaProps.mfaType);
+            }}
+          >
             {i18next.t("mfa:Use SMS verification code")}
           </a>
         </span>

--- a/web/src/auth/mfa/MfaAuthVerifyForm.js
+++ b/web/src/auth/mfa/MfaAuthVerifyForm.js
@@ -24,14 +24,7 @@ import MfaVerifyTotpForm from "./MfaVerifyTotpForm";
 export const NextMfa = "NextMfa";
 export const RequiredMfa = "RequiredMfa";
 
-export function MfaAuthVerifyForm({
-  formValues,
-  authParams,
-  mfaProps,
-  application,
-  onSuccess,
-  onFail,
-}) {
+export function MfaAuthVerifyForm({formValues, authParams, mfaProps, application, onSuccess, onFail}) {
   formValues.password = "";
   formValues.username = "";
   const [loading, setLoading] = useState(false);
@@ -41,54 +34,43 @@ export function MfaAuthVerifyForm({
   const verify = ({passcode}) => {
     setLoading(true);
     const values = {...formValues, passcode, mfaType};
-    const loginFunction =
-      formValues.type === "cas" ? AuthBackend.loginCas : AuthBackend.login;
-    loginFunction(values, authParams)
-      .then((res) => {
-        if (res.status === "ok") {
-          onSuccess(res);
-        } else {
-          onFail(res.msg);
-        }
-      })
-      .catch((res) => {
-        onFail(res.message);
-      })
-      .finally(() => {
-        setLoading(false);
-      });
+    const loginFunction = formValues.type === "cas" ? AuthBackend.loginCas : AuthBackend.login;
+    loginFunction(values, authParams).then((res) => {
+      if (res.status === "ok") {
+        onSuccess(res);
+      } else {
+        onFail(res.msg);
+      }
+    }).catch((res) => {
+      onFail(res.message);
+    }).finally(() => {
+      setLoading(false);
+    });
   };
 
   const recover = () => {
     setLoading(true);
     const values = {...formValues, recoveryCode};
-    const loginFunction =
-      formValues.type === "cas" ? AuthBackend.loginCas : AuthBackend.login;
-    loginFunction(values, authParams)
-      .then((res) => {
-        if (res.status === "ok") {
-          onSuccess(res);
-        } else {
-          onFail(res.msg);
-        }
-      })
-      .catch((res) => {
-        onFail(res.message);
-      })
-      .finally(() => {
-        setLoading(false);
-      });
+    const loginFunction = formValues.type === "cas" ? AuthBackend.loginCas : AuthBackend.login;
+    loginFunction(values, authParams).then((res) => {
+      if (res.status === "ok") {
+        onSuccess(res);
+      } else {
+        onFail(res.msg);
+      }
+    }).catch((res) => {
+      onFail(res.message);
+    }).finally(() => {
+      setLoading(false);
+    });
   };
 
   if (mfaType !== RecoveryMfaType) {
     return (
       <div style={{width: 300, height: 350}}>
-        <div
-          style={{marginBottom: 24, textAlign: "center", fontSize: "24px"}}
-        >
+        <div style={{marginBottom: 24, textAlign: "center", fontSize: "24px"}}>
           {i18next.t("mfa:Multi-factor authentication")}
         </div>
-
         {mfaType === SmsMfaType || mfaType === EmailMfaType ? (
           <div>
             <div style={{marginBottom: 24}}>
@@ -113,14 +95,11 @@ export function MfaAuthVerifyForm({
             <MfaVerifyTotpForm mfaProps={mfaProps} onFinish={verify} />
           </div>
         )}
-
         <span style={{float: "right"}}>
           {i18next.t("mfa:Have problems?")}
-          <a
-            onClick={() => {
-              setMfaType("recovery");
-            }}
-          >
+          <a onClick={() => {
+            setMfaType("recovery");
+          }}>
             {i18next.t("mfa:Use a recovery code")}
           </a>
         </span>
@@ -129,39 +108,28 @@ export function MfaAuthVerifyForm({
   } else {
     return (
       <div style={{width: 300, height: 350}}>
-        <div
-          style={{marginBottom: 24, textAlign: "center", fontSize: "24px"}}
-        >
+        <div style={{marginBottom: 24, textAlign: "center", fontSize: "24px"}}>
           {i18next.t("mfa:Multi-factor recover")}
         </div>
         <div style={{marginBottom: 24}}>
           {i18next.t("mfa:Multi-factor recover description")}
         </div>
-        <Input
-          placeholder={i18next.t("mfa:Recovery code")}
+        <Input placeholder={i18next.t("mfa:Recovery code")}
           style={{marginBottom: 24}}
           type={"passcode"}
           size={"large"}
-          onChange={(event) => setRecoveryCode(event.target.value)}
+          onChange={event => setRecoveryCode(event.target.value)}
         />
-        <Button
-          style={{width: "100%", marginBottom: 20}}
-          size={"large"}
-          loading={loading}
-          type={"primary"}
-          onClick={() => {
+        <Button style={{width: "100%", marginBottom: 20}} size={"large"} loading={loading}
+          type={"primary"} onClick={() => {
             recover();
-          }}
-        >
-          {i18next.t("forget:Verify")}
+          }}>{i18next.t("forget:Verify")}
         </Button>
         <span style={{float: "right"}}>
           {i18next.t("mfa:Have problems?")}
-          <a
-            onClick={() => {
-              setMfaType(mfaProps.mfaType);
-            }}
-          >
+          <a onClick={() => {
+            setMfaType(mfaProps.mfaType);
+          }}>
             {i18next.t("mfa:Use SMS verification code")}
           </a>
         </span>

--- a/web/src/auth/mfa/MfaAuthVerifyForm.js
+++ b/web/src/auth/mfa/MfaAuthVerifyForm.js
@@ -86,7 +86,7 @@ export function MfaAuthVerifyForm({
         <div
           style={{marginBottom: 24, textAlign: "center", fontSize: "24px"}}
         >
-          {i18next.t("mfa:Multi-factor authentication")}
+          {i18next.t("mfa:Multi-factor Authentication")}
         </div>
         {mfaType === SmsMfaType || mfaType === EmailMfaType ? (
           <div>

--- a/web/src/auth/mfa/MfaAuthVerifyForm.js
+++ b/web/src/auth/mfa/MfaAuthVerifyForm.js
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { useState } from "react";
+import React, {useState} from "react";
 import i18next from "i18next";
-import { Button, Input } from "antd";
+import {Button, Input} from "antd";
 import * as AuthBackend from "../AuthBackend";
-import { EmailMfaType, RecoveryMfaType, SmsMfaType } from "../MfaSetupPage";
-import { mfaAuth } from "./MfaVerifyForm";
+import {EmailMfaType, RecoveryMfaType, SmsMfaType} from "../MfaSetupPage";
+import {mfaAuth} from "./MfaVerifyForm";
 import MfaVerifySmsForm from "./MfaVerifySmsForm";
 import MfaVerifyTotpForm from "./MfaVerifyTotpForm";
 
@@ -38,9 +38,9 @@ export function MfaAuthVerifyForm({
   const [mfaType, setMfaType] = useState(mfaProps.mfaType);
   const [recoveryCode, setRecoveryCode] = useState("");
 
-  const verify = ({ passcode }) => {
+  const verify = ({passcode}) => {
     setLoading(true);
-    const values = { ...formValues, passcode, mfaType };
+    const values = {...formValues, passcode, mfaType};
     const loginFunction =
       formValues.type === "cas" ? AuthBackend.loginCas : AuthBackend.login;
     loginFunction(values, authParams)
@@ -61,7 +61,7 @@ export function MfaAuthVerifyForm({
 
   const recover = () => {
     setLoading(true);
-    const values = { ...formValues, recoveryCode };
+    const values = {...formValues, recoveryCode};
     const loginFunction =
       formValues.type === "cas" ? AuthBackend.loginCas : AuthBackend.login;
     loginFunction(values, authParams)
@@ -82,18 +82,18 @@ export function MfaAuthVerifyForm({
 
   if (mfaType !== RecoveryMfaType) {
     return (
-      <div style={{ width: 300, height: 350 }}>
+      <div style={{width: 300, height: 350}}>
         <div
-          style={{ marginBottom: 24, textAlign: "center", fontSize: "24px" }}
+          style={{marginBottom: 24, textAlign: "center", fontSize: "24px"}}
         >
           {i18next.t("mfa:Multi-factor authentication")}
         </div>
 
         {mfaType === SmsMfaType || mfaType === EmailMfaType ? (
           <div>
-            <div style={{ marginBottom: 24 }}>
+            <div style={{marginBottom: 24}}>
               {i18next.t(
-                "mfa:You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+                "mfa:You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process"
               )}
             </div>
             <MfaVerifySmsForm
@@ -105,16 +105,16 @@ export function MfaAuthVerifyForm({
           </div>
         ) : (
           <div>
-            <div style={{ marginBottom: 24 }}>
+            <div style={{marginBottom: 24}}>
               {i18next.t(
-                "mfa:You have enabled multi-factor authentication, please enter the authentication code",
+                "mfa:You have enabled multi-factor authentication, please enter the authentication code"
               )}
             </div>
             <MfaVerifyTotpForm mfaProps={mfaProps} onFinish={verify} />
           </div>
         )}
 
-        <span style={{ float: "right" }}>
+        <span style={{float: "right"}}>
           {i18next.t("mfa:Have problems?")}
           <a
             onClick={() => {
@@ -128,24 +128,24 @@ export function MfaAuthVerifyForm({
     );
   } else {
     return (
-      <div style={{ width: 300, height: 350 }}>
+      <div style={{width: 300, height: 350}}>
         <div
-          style={{ marginBottom: 24, textAlign: "center", fontSize: "24px" }}
+          style={{marginBottom: 24, textAlign: "center", fontSize: "24px"}}
         >
           {i18next.t("mfa:Multi-factor recover")}
         </div>
-        <div style={{ marginBottom: 24 }}>
+        <div style={{marginBottom: 24}}>
           {i18next.t("mfa:Multi-factor recover description")}
         </div>
         <Input
           placeholder={i18next.t("mfa:Recovery code")}
-          style={{ marginBottom: 24 }}
+          style={{marginBottom: 24}}
           type={"passcode"}
           size={"large"}
           onChange={(event) => setRecoveryCode(event.target.value)}
         />
         <Button
-          style={{ width: "100%", marginBottom: 20 }}
+          style={{width: "100%", marginBottom: 20}}
           size={"large"}
           loading={loading}
           type={"primary"}
@@ -155,7 +155,7 @@ export function MfaAuthVerifyForm({
         >
           {i18next.t("forget:Verify")}
         </Button>
-        <span style={{ float: "right" }}>
+        <span style={{float: "right"}}>
           {i18next.t("mfa:Have problems?")}
           <a
             onClick={() => {

--- a/web/src/auth/mfa/MfaAuthVerifyForm.js
+++ b/web/src/auth/mfa/MfaAuthVerifyForm.js
@@ -12,85 +12,115 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, {useState} from "react";
+import React, { useState } from "react";
 import i18next from "i18next";
-import {Button, Input} from "antd";
+import { Button, Input } from "antd";
 import * as AuthBackend from "../AuthBackend";
-import {EmailMfaType, RecoveryMfaType, SmsMfaType} from "../MfaSetupPage";
-import {mfaAuth} from "./MfaVerifyForm";
+import { EmailMfaType, RecoveryMfaType, SmsMfaType } from "../MfaSetupPage";
+import { mfaAuth } from "./MfaVerifyForm";
 import MfaVerifySmsForm from "./MfaVerifySmsForm";
 import MfaVerifyTotpForm from "./MfaVerifyTotpForm";
 
 export const NextMfa = "NextMfa";
 export const RequiredMfa = "RequiredMfa";
 
-export function MfaAuthVerifyForm({formValues, authParams, mfaProps, application, onSuccess, onFail}) {
+export function MfaAuthVerifyForm({
+  formValues,
+  authParams,
+  mfaProps,
+  application,
+  onSuccess,
+  onFail,
+}) {
   formValues.password = "";
   formValues.username = "";
   const [loading, setLoading] = useState(false);
   const [mfaType, setMfaType] = useState(mfaProps.mfaType);
   const [recoveryCode, setRecoveryCode] = useState("");
 
-  const verify = ({passcode}) => {
+  const verify = ({ passcode }) => {
     setLoading(true);
-    const values = {...formValues, passcode, mfaType};
-    const loginFunction = formValues.type === "cas" ? AuthBackend.loginCas : AuthBackend.login;
-    loginFunction(values, authParams).then((res) => {
-      if (res.status === "ok") {
-        onSuccess(res);
-      } else {
-        onFail(res.msg);
-      }
-    }).catch((res) => {
-      onFail(res.message);
-    }).finally(() => {
-      setLoading(false);
-    });
+    const values = { ...formValues, passcode, mfaType };
+    const loginFunction =
+      formValues.type === "cas" ? AuthBackend.loginCas : AuthBackend.login;
+    loginFunction(values, authParams)
+      .then((res) => {
+        if (res.status === "ok") {
+          onSuccess(res);
+        } else {
+          onFail(res.msg);
+        }
+      })
+      .catch((res) => {
+        onFail(res.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   };
 
   const recover = () => {
     setLoading(true);
-    const values = {...formValues, recoveryCode};
-    const loginFunction = formValues.type === "cas" ? AuthBackend.loginCas : AuthBackend.login;
-    loginFunction(values, authParams).then((res) => {
-      if (res.status === "ok") {
-        onSuccess(res);
-      } else {
-        onFail(res.msg);
-      }
-    }).catch((res) => {
-      onFail(res.message);
-    }).finally(() => {
-      setLoading(false);
-    });
+    const values = { ...formValues, recoveryCode };
+    const loginFunction =
+      formValues.type === "cas" ? AuthBackend.loginCas : AuthBackend.login;
+    loginFunction(values, authParams)
+      .then((res) => {
+        if (res.status === "ok") {
+          onSuccess(res);
+        } else {
+          onFail(res.msg);
+        }
+      })
+      .catch((res) => {
+        onFail(res.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   };
 
   if (mfaType !== RecoveryMfaType) {
     return (
-      <div style={{width: 300, height: 350}}>
-        <div style={{marginBottom: 24, textAlign: "center", fontSize: "24px"}}>
+      <div style={{ width: 300, height: 350 }}>
+        <div
+          style={{ marginBottom: 24, textAlign: "center", fontSize: "24px" }}
+        >
           {i18next.t("mfa:Multi-factor authentication")}
         </div>
-        <div style={{marginBottom: 24}}>
-          {i18next.t("mfa:You have enabled multi-factor authentication, please enter the authentication code")}
-        </div>
+
         {mfaType === SmsMfaType || mfaType === EmailMfaType ? (
-          <MfaVerifySmsForm
-            mfaProps={mfaProps}
-            method={mfaAuth}
-            onFinish={verify}
-            application={application}
-          />) : (
-          <MfaVerifyTotpForm
-            mfaProps={mfaProps}
-            onFinish={verify}
-          />
+          <div>
+            <div style={{ marginBottom: 24 }}>
+              {i18next.t(
+                "mfa:You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+              )}
+            </div>
+            <MfaVerifySmsForm
+              mfaProps={mfaProps}
+              method={mfaAuth}
+              onFinish={verify}
+              application={application}
+            />
+          </div>
+        ) : (
+          <div>
+            <div style={{ marginBottom: 24 }}>
+              {i18next.t(
+                "mfa:You have enabled multi-factor authentication, please enter the authentication code",
+              )}
+            </div>
+            <MfaVerifyTotpForm mfaProps={mfaProps} onFinish={verify} />
+          </div>
         )}
-        <span style={{float: "right"}}>
+
+        <span style={{ float: "right" }}>
           {i18next.t("mfa:Have problems?")}
-          <a onClick={() => {
-            setMfaType("recovery");
-          }}>
+          <a
+            onClick={() => {
+              setMfaType("recovery");
+            }}
+          >
             {i18next.t("mfa:Use a recovery code")}
           </a>
         </span>
@@ -98,29 +128,40 @@ export function MfaAuthVerifyForm({formValues, authParams, mfaProps, application
     );
   } else {
     return (
-      <div style={{width: 300, height: 350}}>
-        <div style={{marginBottom: 24, textAlign: "center", fontSize: "24px"}}>
+      <div style={{ width: 300, height: 350 }}>
+        <div
+          style={{ marginBottom: 24, textAlign: "center", fontSize: "24px" }}
+        >
           {i18next.t("mfa:Multi-factor recover")}
         </div>
-        <div style={{marginBottom: 24}}>
+        <div style={{ marginBottom: 24 }}>
           {i18next.t("mfa:Multi-factor recover description")}
         </div>
-        <Input placeholder={i18next.t("mfa:Recovery code")}
-          style={{marginBottom: 24}}
+        <Input
+          placeholder={i18next.t("mfa:Recovery code")}
+          style={{ marginBottom: 24 }}
           type={"passcode"}
           size={"large"}
-          onChange={event => setRecoveryCode(event.target.value)}
+          onChange={(event) => setRecoveryCode(event.target.value)}
         />
-        <Button style={{width: "100%", marginBottom: 20}} size={"large"} loading={loading}
-          type={"primary"} onClick={() => {
+        <Button
+          style={{ width: "100%", marginBottom: 20 }}
+          size={"large"}
+          loading={loading}
+          type={"primary"}
+          onClick={() => {
             recover();
-          }}>{i18next.t("forget:Verify")}
+          }}
+        >
+          {i18next.t("forget:Verify")}
         </Button>
-        <span style={{float: "right"}}>
+        <span style={{ float: "right" }}>
           {i18next.t("mfa:Have problems?")}
-          <a onClick={() => {
-            setMfaType(mfaProps.mfaType);
-          }}>
+          <a
+            onClick={() => {
+              setMfaType(mfaProps.mfaType);
+            }}
+          >
             {i18next.t("mfa:Use SMS verification code")}
           </a>
         </span>

--- a/web/src/locales/ar/data.json
+++ b/web/src/locales/ar/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/ar/data.json
+++ b/web/src/locales/ar/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/ar/data.json
+++ b/web/src/locales/ar/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/ar/data.json
+++ b/web/src/locales/ar/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/cs/data.json
+++ b/web/src/locales/cs/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Ověřit kód",
     "Verify Password": "Ověřit heslo",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Váš email je",
     "Your phone is": "Váš telefon je",
     "preferred": "preferované"

--- a/web/src/locales/cs/data.json
+++ b/web/src/locales/cs/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Ověření selhalo",
     "Verify Code": "Ověřit kód",
     "Verify Password": "Ověřit heslo",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Váš email je",
     "Your phone is": "Váš telefon je",

--- a/web/src/locales/cs/data.json
+++ b/web/src/locales/cs/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Ověřit kód",
     "Verify Password": "Ověřit heslo",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Váš email je",
     "Your phone is": "Váš telefon je",
     "preferred": "preferované"

--- a/web/src/locales/de/data.json
+++ b/web/src/locales/de/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/de/data.json
+++ b/web/src/locales/de/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/de/data.json
+++ b/web/src/locales/de/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/de/data.json
+++ b/web/src/locales/de/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/es/data.json
+++ b/web/src/locales/es/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/es/data.json
+++ b/web/src/locales/es/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/es/data.json
+++ b/web/src/locales/es/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/es/data.json
+++ b/web/src/locales/es/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/fa/data.json
+++ b/web/src/locales/fa/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/fa/data.json
+++ b/web/src/locales/fa/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/fa/data.json
+++ b/web/src/locales/fa/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/fa/data.json
+++ b/web/src/locales/fa/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/fi/data.json
+++ b/web/src/locales/fi/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/fi/data.json
+++ b/web/src/locales/fi/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/fi/data.json
+++ b/web/src/locales/fi/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/fi/data.json
+++ b/web/src/locales/fi/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/fr/data.json
+++ b/web/src/locales/fr/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Vérifier le code",
     "Verify Password": "Confirmez le mot de passe",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Votre e-mail est",
     "Your phone is": "Votre téléphone est",
     "preferred": "préféré"

--- a/web/src/locales/fr/data.json
+++ b/web/src/locales/fr/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Échec de l'obtention de l'application",
     "Failed to initiate MFA": "Échec de la configuration de l'authentification multifacteur",
     "Have problems?": "Des problèmes ?",
-    "Multi-factor authentication": "Authentification multifacteur",
+    "Multi-factor Authentication": "Authentification multifacteur",
     "Multi-factor authentication - Tooltip ": "Authentification multifacteur - infobulle ",
     "Multi-factor methods": "Méthodes d'authentification multifacteur",
     "Multi-factor recover": "Restauration de l'authentification multifacteur",

--- a/web/src/locales/fr/data.json
+++ b/web/src/locales/fr/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Échec de la vérification",
     "Verify Code": "Vérifier le code",
     "Verify Password": "Confirmez le mot de passe",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Votre e-mail est",
     "Your phone is": "Votre téléphone est",

--- a/web/src/locales/fr/data.json
+++ b/web/src/locales/fr/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Vérifier le code",
     "Verify Password": "Confirmez le mot de passe",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Votre e-mail est",
     "Your phone is": "Votre téléphone est",
     "preferred": "préféré"

--- a/web/src/locales/he/data.json
+++ b/web/src/locales/he/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/he/data.json
+++ b/web/src/locales/he/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/he/data.json
+++ b/web/src/locales/he/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/he/data.json
+++ b/web/src/locales/he/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/id/data.json
+++ b/web/src/locales/id/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/id/data.json
+++ b/web/src/locales/id/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/id/data.json
+++ b/web/src/locales/id/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/id/data.json
+++ b/web/src/locales/id/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/it/data.json
+++ b/web/src/locales/it/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/it/data.json
+++ b/web/src/locales/it/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/it/data.json
+++ b/web/src/locales/it/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/it/data.json
+++ b/web/src/locales/it/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/ja/data.json
+++ b/web/src/locales/ja/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/ja/data.json
+++ b/web/src/locales/ja/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/ja/data.json
+++ b/web/src/locales/ja/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/ja/data.json
+++ b/web/src/locales/ja/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/kk/data.json
+++ b/web/src/locales/kk/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/kk/data.json
+++ b/web/src/locales/kk/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/kk/data.json
+++ b/web/src/locales/kk/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/kk/data.json
+++ b/web/src/locales/kk/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/ko/data.json
+++ b/web/src/locales/ko/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/ko/data.json
+++ b/web/src/locales/ko/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/ko/data.json
+++ b/web/src/locales/ko/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/ko/data.json
+++ b/web/src/locales/ko/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/ms/data.json
+++ b/web/src/locales/ms/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/ms/data.json
+++ b/web/src/locales/ms/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/ms/data.json
+++ b/web/src/locales/ms/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/ms/data.json
+++ b/web/src/locales/ms/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/nl/data.json
+++ b/web/src/locales/nl/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/nl/data.json
+++ b/web/src/locales/nl/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/nl/data.json
+++ b/web/src/locales/nl/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/nl/data.json
+++ b/web/src/locales/nl/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/pl/data.json
+++ b/web/src/locales/pl/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/pl/data.json
+++ b/web/src/locales/pl/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/pl/data.json
+++ b/web/src/locales/pl/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/pl/data.json
+++ b/web/src/locales/pl/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/pt/data.json
+++ b/web/src/locales/pt/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/pt/data.json
+++ b/web/src/locales/pt/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/pt/data.json
+++ b/web/src/locales/pt/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Tem problemas?",
-    "Multi-factor authentication": "Autenticação de vários fatores",
+    "Multi-factor Authentication": "Autenticação de vários fatores",
     "Multi-factor authentication - Tooltip ": "Autenticação de múltiplos fatores - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/pt/data.json
+++ b/web/src/locales/pt/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/ru/data.json
+++ b/web/src/locales/ru/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Проверка не удалась",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Ваш email",
     "Your phone is": "Ваш телефон",

--- a/web/src/locales/ru/data.json
+++ b/web/src/locales/ru/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Ваш email",
     "Your phone is": "Ваш телефон",
     "preferred": "preferred"

--- a/web/src/locales/ru/data.json
+++ b/web/src/locales/ru/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Ваш email",
     "Your phone is": "Ваш телефон",
     "preferred": "preferred"

--- a/web/src/locales/ru/data.json
+++ b/web/src/locales/ru/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Не удалось загрузить приложение",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Возникли проблемы?",
-    "Multi-factor authentication": "Многофакторная аутентификация",
+    "Multi-factor Authentication": "Многофакторная аутентификация",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/sk/data.json
+++ b/web/src/locales/sk/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Overiť kód",
     "Verify Password": "Overiť heslo",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Váš email je",
     "Your phone is": "Váš telefón je",
     "preferred": "preferované"

--- a/web/src/locales/sk/data.json
+++ b/web/src/locales/sk/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Overiť kód",
     "Verify Password": "Overiť heslo",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Váš email je",
     "Your phone is": "Váš telefón je",
     "preferred": "preferované"

--- a/web/src/locales/sk/data.json
+++ b/web/src/locales/sk/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Overenie zlyhalo",
     "Verify Code": "Overiť kód",
     "Verify Password": "Overiť heslo",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Váš email je",
     "Your phone is": "Váš telefón je",

--- a/web/src/locales/sk/data.json
+++ b/web/src/locales/sk/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Nepodarilo sa získať aplikáciu",
     "Failed to initiate MFA": "Nepodarilo sa inicializovať MFA",
     "Have problems?": "Máte problémy?",
-    "Multi-factor authentication": "Viacfaktorová autentifikácia",
+    "Multi-factor Authentication": "Viacfaktorová autentifikácia",
     "Multi-factor authentication - Tooltip ": "Viacfaktorová autentifikácia - Nápoveda ",
     "Multi-factor methods": "Metódy viacfaktorovej autentifikácie",
     "Multi-factor recover": "Obnova viacfaktorovej autentifikácie",

--- a/web/src/locales/sv/data.json
+++ b/web/src/locales/sv/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/sv/data.json
+++ b/web/src/locales/sv/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/sv/data.json
+++ b/web/src/locales/sv/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/sv/data.json
+++ b/web/src/locales/sv/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/tr/data.json
+++ b/web/src/locales/tr/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Kodu doğrula",
     "Verify Password": "Parolayı Doğrula",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "E-postanız",
     "Your phone is": "Telefon numaranız",
     "preferred": "tercih edilen"

--- a/web/src/locales/tr/data.json
+++ b/web/src/locales/tr/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Doğrulama başarısız",
     "Verify Code": "Kodu doğrula",
     "Verify Password": "Parolayı Doğrula",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "E-postanız",
     "Your phone is": "Telefon numaranız",

--- a/web/src/locales/tr/data.json
+++ b/web/src/locales/tr/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Kodu doğrula",
     "Verify Password": "Parolayı Doğrula",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "E-postanız",
     "Your phone is": "Telefon numaranız",
     "preferred": "tercih edilen"

--- a/web/src/locales/tr/data.json
+++ b/web/src/locales/tr/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/uk/data.json
+++ b/web/src/locales/uk/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Не вдалося отримати заявку",
     "Failed to initiate MFA": "Не вдалося запустити MFA",
     "Have problems?": "Є проблеми?",
-    "Multi-factor authentication": "Багатофакторна аутентифікація",
+    "Multi-factor Authentication": "Багатофакторна аутентифікація",
     "Multi-factor authentication - Tooltip ": "Багатофакторна автентифікація – підказка ",
     "Multi-factor methods": "Багатофакторні методи",
     "Multi-factor recover": "Багатофакторне відновлення",

--- a/web/src/locales/uk/data.json
+++ b/web/src/locales/uk/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Підтвердити код",
     "Verify Password": "Підтвердіть пароль",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Ваша електронна адреса",
     "Your phone is": "Ваш телефон",
     "preferred": "бажаний"

--- a/web/src/locales/uk/data.json
+++ b/web/src/locales/uk/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Не вдалося перевірити",
     "Verify Code": "Підтвердити код",
     "Verify Password": "Підтвердіть пароль",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Ваша електронна адреса",
     "Your phone is": "Ваш телефон",

--- a/web/src/locales/uk/data.json
+++ b/web/src/locales/uk/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Підтвердити код",
     "Verify Password": "Підтвердіть пароль",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Ваша електронна адреса",
     "Your phone is": "Ваш телефон",
     "preferred": "бажаний"

--- a/web/src/locales/vi/data.json
+++ b/web/src/locales/vi/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/vi/data.json
+++ b/web/src/locales/vi/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "Failed to get application",
     "Failed to initiate MFA": "Failed to initiate MFA",
     "Have problems?": "Have problems?",
-    "Multi-factor authentication": "Multi-factor authentication",
+    "Multi-factor Authentication": "Multi-factor Authentication",
     "Multi-factor authentication - Tooltip ": "Multi-factor authentication - Tooltip ",
     "Multi-factor methods": "Multi-factor methods",
     "Multi-factor recover": "Multi-factor recover",

--- a/web/src/locales/vi/data.json
+++ b/web/src/locales/vi/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "Verification failed",
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
-    "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",

--- a/web/src/locales/vi/data.json
+++ b/web/src/locales/vi/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "Verify Code",
     "Verify Password": "Verify Password",
     "You have enabled multi-factor authentication, please enter the authentication code": "You have enabled multi-factor authentication, please enter the authentication code",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process",
     "Your email is": "Your email is",
     "Your phone is": "Your phone is",
     "preferred": "preferred"

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -562,7 +562,7 @@
     "Verification failed": "验证失败",
     "Verify Code": "验证码",
     "Verify Password": "验证密码",
-    "You have enabled multi-factor authentication, please enter the authentication code": "您已经启用多因素认证，请输入认证码",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
     "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "你的电子邮件",
     "Your phone is": "你的手机号",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -563,6 +563,7 @@
     "Verify Code": "验证码",
     "Verify Password": "验证密码",
     "You have enabled multi-factor authentication, please enter the authentication code": "您已经启用多因素认证，请输入认证码",
+    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "您已启用多重身份验证。请点击发送代码并按照提示完成登录过程",
     "Your email is": "你的电子邮件",
     "Your phone is": "你的手机号",
     "preferred": "首选"

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -562,8 +562,8 @@
     "Verification failed": "验证失败",
     "Verify Code": "验证码",
     "Verify Password": "验证密码",
-    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "You have enabled Multi-Factor Authentication, please enter the TOTP code",
-    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
+    "You have enabled Multi-Factor Authentication, please enter the TOTP code": "您已启用多重身份验证，请输入 TOTP 代码",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "您已启用多重身份验证。请点击“发送代码”继续",
     "Your email is": "你的电子邮件",
     "Your phone is": "你的手机号",
     "preferred": "首选"

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -536,7 +536,7 @@
     "Failed to get application": "获取应用失败",
     "Failed to initiate MFA": "初始化 MFA 失败",
     "Have problems?": "遇到问题?",
-    "Multi-factor authentication": "多因素认证",
+    "Multi-factor Authentication": "多因素认证",
     "Multi-factor authentication - Tooltip ": "多因素认证 - Tooltip ",
     "Multi-factor methods": "多因素认证方式",
     "Multi-factor recover": "重置多因素认证",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -563,7 +563,7 @@
     "Verify Code": "验证码",
     "Verify Password": "验证密码",
     "You have enabled multi-factor authentication, please enter the authentication code": "您已经启用多因素认证，请输入认证码",
-    "You have enabled Multi-factor Authentication. Please click Send Code and follow the prompts to finish your login process": "您已启用多重身份验证。请点击发送代码并按照提示完成登录过程",
+    "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue": "You have enabled Multi-Factor Authentication. Please click \"Send Code\" to continue",
     "Your email is": "你的电子邮件",
     "Your phone is": "你的手机号",
     "preferred": "首选"


### PR DESCRIPTION
For Email and SMS based MFA:

Before:

![Screenshot 2024-10-10 at 3 30 52 PM](https://github.com/user-attachments/assets/8e75f680-5de3-466a-89f7-e9df8b837801)


After:

![Screenshot 2024-10-10 at 4 49 00 PM](https://github.com/user-attachments/assets/cc9b2545-edd3-4a7a-bfd3-7e45662b5538)


No change for TOTP based MFA.


