### PR TITLE
feat: fix issue with refresh token when application is shared 

### DIFF
--- a/object/token_oauth.go
+++ b/object/token_oauth.go
@@ -328,10 +328,17 @@ func RefreshToken(grantType string, refreshToken string, scope string, clientId 
 	}
 
 	// generate a new token
-	user, err := getUser(application.Organization, token.User)
+	organization := application.Organization
+	// If application is a shared applicaiton, organization of the user can be different from the organization of the application. In this case, we need to get the organization of the user from the token.
+	if application.IsShared {
+		organization = token.Organization
+	}
+
+	user, err := getUser(organization, token.User)
 	if err != nil {
 		return nil, err
 	}
+
 	if user == nil {
 		return "", fmt.Errorf("The user: %s doesn't exist", util.GetId(application.Organization, token.User))
 	}


### PR DESCRIPTION
If application is a shared applicaiton, organization of the user can be different from the organization of the application. In this case, we need to get the organization of the user from the token rather than finding the user in the organization of the application.

Fixes: https://github.com/casdoor/casdoor/issues/3290


Tested the changes in local and changes seems to works. Please take a look.

![Screenshot 2024-10-16 at 4 52 53 PM](https://github.com/user-attachments/assets/854e98fc-bdc7-4d35-84bb-30f8296fef7c)
