### PR TITLE
feat: fix bug that fails to login when PasswordObfuscator is enabled

### DIFF
--- a/web/src/auth/Obfuscator.js
+++ b/web/src/auth/Obfuscator.js
@@ -14,6 +14,7 @@
 
 import CryptoJS from "crypto-js";
 import i18next from "i18next";
+import {Buffer} from "buffer";
 
 export function getRandomKeyForObfuscator(obfuscatorType) {
   if (obfuscatorType === "DES") {


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/3300

The bug was introduced by PR: https://github.com/casdoor/casdoor/pull/3260

1. In User Management -> Organizations, set the Password Obfuscator to a non-Plain type.
2. In Authentication -> Applications, set the Organization to the one configured in step 1.
3. Use http://host/login/oauth/authorize?client_id=2.application&... for authentication and log in using a password.


![image](https://github.com/user-attachments/assets/eea65217-c458-4336-876c-bc646cfbb6bf)
![image](https://github.com/user-attachments/assets/cb8cacba-45b5-47a7-b005-64564cce4316)
