### PR TITLE
feat: set created time if not presented in AddUser() API

### DIFF
--- a/object/user.go
+++ b/object/user.go
@@ -816,6 +816,10 @@ func AddUser(user *User) (bool, error) {
 		user.UpdateUserPassword(organization)
 	}
 
+	if user.CreatedTime == "" {
+		user.CreatedTime = util.GetCurrentTime()
+	}
+
 	err = user.UpdateUserHash()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
If I am creating user with API like
```curl
curl --request POST \
  --url https://casdoor.example/api/add-user \
  --header 'Accept: application/json' \
  --header 'Authorization: Basic <...>' \
  --header 'Content-Type: application/json' \
  --data '{
            "phone": "79217210133",
	    "name": "79217210133",
	    "owner": "b2cOrg",
              "properties": {
                "is_synced": "false"
	      }
	  }'
```

Property `created_time` is not set