### PR TITLE
feat: show Domain field for Qiniu storage provider

### DIFF
--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -908,7 +908,7 @@ class ProviderEditPage extends React.Component {
                 </Col>
               </Row>
             )}
-            {["Custom HTTP SMS", "Qiniu Cloud Kodo", "Synology", "Casdoor"].includes(this.state.provider.type) ? null : (
+            {["Custom HTTP SMS", "Synology", "Casdoor"].includes(this.state.provider.type) ? null : (
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={2}>
                   {Setting.getLabel(i18next.t("provider:Domain"), i18next.t("provider:Domain - Tooltip"))} :


### PR DESCRIPTION
allow Qiniu Provider to edit the Domain property in the edit page. I don't know why it's excluded in the first place, but being able to edit it will fix #3310.


Fix: https://github.com/casdoor/casdoor/issues/3310