### PR TITLE
feat: According to the document, supplement the missing default API

### DIFF
--- a/authz/authz.go
+++ b/authz/authz.go
@@ -95,6 +95,8 @@ p, *, *, GET, /api/get-plan, *, *
 p, *, *, GET, /api/get-subscription, *, *
 p, *, *, GET, /api/get-provider, *, *
 p, *, *, GET, /api/get-organization-names, *, *
+p, *, *, post, /api/enforce, *, *
+p, *, *, post, /api/batch-enforce, *, *
 p, *, *, GET, /api/get-all-objects, *, *
 p, *, *, GET, /api/get-all-actions, *, *
 p, *, *, GET, /api/get-all-roles, *, *


### PR DESCRIPTION
According to the document: https://casdoor.org/docs/permission/exposed-casbin-apis/
supplement the missing default API permissions.