### PR TITLE
fix: enforce `email` and `phone` data on `signup`

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -139,7 +139,7 @@ func (c *ApiController) Signup() {
 		invitationName = invitation.Name
 	}
 
-	if application.IsSignupItemVisible("Email") && application.GetSignupItemRule("Email") != "No verification" && authForm.Email != "" {
+	if application.IsSignupItemVisible("Email") && application.GetSignupItemRule("Email") != "No verification" {
 		var checkResult *object.VerifyResult
 		checkResult, err = object.CheckVerificationCode(authForm.Email, authForm.EmailCode, c.GetAcceptLanguage())
 		if err != nil {
@@ -153,7 +153,7 @@ func (c *ApiController) Signup() {
 	}
 
 	var checkPhone string
-	if application.IsSignupItemVisible("Phone") && application.GetSignupItemRule("Phone") != "No verification" && authForm.Phone != "" {
+	if application.IsSignupItemVisible("Phone") && application.GetSignupItemRule("Phone") != "No verification" {
 		checkPhone, _ = util.GetE164Number(authForm.Phone, authForm.CountryCode)
 
 		var checkResult *object.VerifyResult


### PR DESCRIPTION
**Current behavior:**
When email is setup like following:
```json
{
   "name":"Email",
   "visible":true,
   "required":true,
   "prompted":false,
   "type":"",
   "customCss":"",
   "label":"",
   "placeholder":"",
   "options":null,
   "regex":"",
   "rule":"Normal"
}
```

And the following request is sent:
```bash
curl --location 'baseUrl/api/signup' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--header 'Accept: */*' \
--data-urlencode 'username=my_org/username' \
--data-urlencode 'password=CoolPassword420'
```

The response is:
```
{
  "status": "error",
  "msg": "The user: org/username doesn't exist",
  "data": null,
  "data2": null
}
```

**Expected behavior:**
Error is raised since email data is not provided.

**Description:**
This PR enforces `phone` and `email` data check, even if data is not passed.