### PR TITLE
fix: stop using `AutoSigninFilter` on unknown paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,12 +54,12 @@ func main() {
 	beego.SetStaticPath("/files", "files")
 	// https://studygolang.com/articles/2303
 	beego.InsertFilter("*", beego.BeforeRouter, routers.StaticFilter)
-	beego.InsertFilter("*", beego.BeforeRouter, routers.AutoSigninFilter)
 	beego.InsertFilter("*", beego.BeforeRouter, routers.CorsFilter)
-	beego.InsertFilter("*", beego.BeforeRouter, routers.TimeoutFilter)
-	beego.InsertFilter("*", beego.BeforeRouter, routers.ApiFilter)
-	beego.InsertFilter("*", beego.BeforeRouter, routers.PrometheusFilter)
-	beego.InsertFilter("*", beego.BeforeRouter, routers.RecordMessage)
+	beego.InsertFilter("*", beego.BeforeExec, routers.AutoSigninFilter)
+	beego.InsertFilter("*", beego.BeforeExec, routers.TimeoutFilter)
+	beego.InsertFilter("*", beego.BeforeExec, routers.ApiFilter)
+	beego.InsertFilter("*", beego.BeforeExec, routers.PrometheusFilter)
+	beego.InsertFilter("*", beego.BeforeExec, routers.RecordMessage)
 	beego.InsertFilter("*", beego.AfterExec, routers.AfterRecordMessage, false)
 
 	beego.BConfig.WebConfig.Session.SessionOn = true


### PR DESCRIPTION
**Current behavior:**
When having requests like:
```bash
curl --location --request POST 'https://baseUrl/api/I_DONT_EXIST?username=org%2Fusername&password=password'
```

The response is:
```json
{
  "status": "error",
  "msg": "The user: org/username doesn't exist",
  "data": null,
  "data2": null
}
```

And when user exists and user lock out is enabled:
```json
{
    "status": "error",
    "msg": "password or code is incorrect, you have 4 remaining chances",
    "data": null,
    "data2": null
}
```

**Expected behavior:**
Error 404 endpoint (path) is not found.

**PR behavior:**
I haven't tested this myself, but judging by the [docs](https://doc.meoying.com/en-US/beego/developing/web/filter/#quick-start):

> web.BeforeStatic: Before finding the static file.
> web.BeforeRouter: Before finding router.
> web.BeforeExec: After finding router and before executing the matched Controller.
> web.AfterExec: After executing Controller.
> web.FinishRouter: After finishing router.

This should help and at least do not try to auto sign in on unknown paths.