### PR TITLE
fix: respect `enableErrorMask` in `AutoSigninFilter`

### DIFF
--- a/object/check.go
+++ b/object/check.go
@@ -21,6 +21,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/casdoor/casdoor/conf"
 	"github.com/casdoor/casdoor/cred"
 	"github.com/casdoor/casdoor/form"
 	"github.com/casdoor/casdoor/i18n"
@@ -341,6 +342,10 @@ func CheckUserPassword(organization string, username string, password string, la
 	}
 
 	if user == nil || user.IsDeleted {
+		enableErrorMask := conf.GetConfigBool("enableErrorMask")
+		if enableErrorMask {
+			return nil, fmt.Errorf(i18n.Translate(lang, "check:password or code is incorrect"))
+		}
 		return nil, fmt.Errorf(i18n.Translate(lang, "general:The user: %s doesn't exist"), util.GetId(organization, username))
 	}
 

--- a/object/check_util.go
+++ b/object/check_util.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/casdoor/casdoor/conf"
 	"github.com/casdoor/casdoor/i18n"
 )
 
@@ -100,6 +101,10 @@ func recordSigninErrorInfo(user *User, lang string, options ...bool) error {
 	if leftChances == 0 && enableCaptcha {
 		return fmt.Errorf(i18n.Translate(lang, "check:password or code is incorrect"))
 	} else if leftChances >= 0 {
+		enableErrorMask := conf.GetConfigBool("enableErrorMask")
+		if enableErrorMask {
+			return fmt.Errorf(i18n.Translate(lang, "check:password or code is incorrect"))
+		}
 		return fmt.Errorf(i18n.Translate(lang, "check:password or code is incorrect, you have %d remaining chances"), leftChances)
 	}
 


### PR DESCRIPTION
**Current behavior:**
When `AutoSigninFilter` is getting used (so, always), and `username` and `password` are passed in query params or some other way, it tries to autologin it. But when it fails, it reveals information if user with data like this exists.

_Request:_
```bash
curl --location --request POST 'https://auth.stage.aliyoop.com/api/I_DONT_EXIST?username=org%2Fusername&password=password'
```

_Response:_
```json
{
  "status": "error",
  "msg": "The user: org/username doesn't exist",
  "data": null,
  "data2": null
}
```

The error is raised [here](https://github.com/casdoor/casdoor/blob/457c6098a49ea6c9bb3fa328807103175effcead/object/check.go#L343-L345).
It leads to having a possibility of enumeration users and knowing if user with username/phone/emails exists.

**PR behavior:**
Now when using `enableErrorMask` param, the error is mapped to `check:password or code is incorrect`, if username is invalid OR password is invalid and `failedSigninLimit` is enabled.
Same as in from [controllers\util.go](https://github.com/casdoor/casdoor/blob/457c6098a49ea6c9bb3fa328807103175effcead/controllers/util.go#L57-L62).