### PR TITLE
feat: validate token before get from DB, use GetTokenByValueOrId instead of GetTokenByValue

### DIFF
--- a/controllers/token.go
+++ b/controllers/token.go
@@ -321,8 +321,54 @@ func (c *ApiController) IntrospectToken() {
 		return
 	}
 
+	resData := &object.IntrospectionResponse{Active: false}
+
+	if application.TokenFormat == "JWT-Standard" {
+		jwtToken, err := object.ParseStandardJwtTokenByApplication(tokenValue, application)
+		if err != nil || jwtToken.Valid() != nil {
+			// and token revoked case. but we not implement
+			// TODO: 2022-03-03 add token revoked check, when we implemented the Token Revocation(rfc7009) Specs.
+			// refs: https://tools.ietf.org/html/rfc7009
+			c.Data["json"] = resData
+			c.ServeJSON()
+			return
+		}
+
+		resData = &object.IntrospectionResponse{
+			Scope: jwtToken.Scope,
+			Exp:   jwtToken.ExpiresAt.Unix(),
+			Iat:   jwtToken.IssuedAt.Unix(),
+			Nbf:   jwtToken.NotBefore.Unix(),
+			Sub:   jwtToken.Subject,
+			Aud:   jwtToken.Audience,
+			Iss:   jwtToken.Issuer,
+			Jti:   jwtToken.ID,
+		}
+	} else {
+		jwtToken, err := object.ParseJwtTokenByApplication(tokenValue, application)
+		if err != nil || jwtToken.Valid() != nil {
+			// and token revoked case. but we not implement
+			// TODO: 2022-03-03 add token revoked check, when we implemented the Token Revocation(rfc7009) Specs.
+			// refs: https://tools.ietf.org/html/rfc7009
+			c.Data["json"] = resData
+			c.ServeJSON()
+			return
+		}
+
+		resData = &object.IntrospectionResponse{
+			Scope: jwtToken.Scope,
+			Exp:   jwtToken.ExpiresAt.Unix(),
+			Iat:   jwtToken.IssuedAt.Unix(),
+			Nbf:   jwtToken.NotBefore.Unix(),
+			Sub:   jwtToken.Subject,
+			Aud:   jwtToken.Audience,
+			Iss:   jwtToken.Issuer,
+			Jti:   jwtToken.ID,
+		}
+	}
+
 	tokenTypeHint := c.Input().Get("token_type_hint")
-	token, err := object.GetTokenByTokenValue(tokenValue, tokenTypeHint)
+	token, err := object.GetTokenByValueOrId(tokenValue, tokenTypeHint, resData.Jti)
 	if err != nil {
 		c.ResponseTokenError(err.Error())
 		return
@@ -333,58 +379,11 @@ func (c *ApiController) IntrospectToken() {
 		return
 	}
 
-	if application.TokenFormat == "JWT-Standard" {
-		jwtToken, err := object.ParseStandardJwtTokenByApplication(tokenValue, application)
-		if err != nil || jwtToken.Valid() != nil {
-			// and token revoked case. but we not implement
-			// TODO: 2022-03-03 add token revoked check, when we implemented the Token Revocation(rfc7009) Specs.
-			// refs: https://tools.ietf.org/html/rfc7009
-			c.Data["json"] = &object.IntrospectionResponse{Active: false}
-			c.ServeJSON()
-			return
-		}
+	resData.Active = true
+	resData.ClientId = clientId
+	resData.Username = token.User
+	resData.TokenType = token.TokenType
 
-		c.Data["json"] = &object.IntrospectionResponse{
-			Active:    true,
-			Scope:     jwtToken.Scope,
-			ClientId:  clientId,
-			Username:  token.User,
-			TokenType: token.TokenType,
-			Exp:       jwtToken.ExpiresAt.Unix(),
-			Iat:       jwtToken.IssuedAt.Unix(),
-			Nbf:       jwtToken.NotBefore.Unix(),
-			Sub:       jwtToken.Subject,
-			Aud:       jwtToken.Audience,
-			Iss:       jwtToken.Issuer,
-			Jti:       jwtToken.ID,
-		}
-		c.ServeJSON()
-		return
-	}
-
-	jwtToken, err := object.ParseJwtTokenByApplication(tokenValue, application)
-	if err != nil || jwtToken.Valid() != nil {
-		// and token revoked case. but we not implement
-		// TODO: 2022-03-03 add token revoked check, when we implemented the Token Revocation(rfc7009) Specs.
-		// refs: https://tools.ietf.org/html/rfc7009
-		c.Data["json"] = &object.IntrospectionResponse{Active: false}
-		c.ServeJSON()
-		return
-	}
-
-	c.Data["json"] = &object.IntrospectionResponse{
-		Active:    true,
-		Scope:     jwtToken.Scope,
-		ClientId:  clientId,
-		Username:  token.User,
-		TokenType: token.TokenType,
-		Exp:       jwtToken.ExpiresAt.Unix(),
-		Iat:       jwtToken.IssuedAt.Unix(),
-		Nbf:       jwtToken.NotBefore.Unix(),
-		Sub:       jwtToken.Subject,
-		Aud:       jwtToken.Audience,
-		Iss:       jwtToken.Issuer,
-		Jti:       jwtToken.ID,
-	}
+	c.Data["json"] = resData
 	c.ServeJSON()
 }

--- a/object/token.go
+++ b/object/token.go
@@ -116,6 +116,11 @@ func GetTokenByAccessToken(accessToken string) (*Token, error) {
 	return &token, nil
 }
 
+func GetTokenByAccessTokenOrId(accessToken, tokenId string) (*Token, error) {
+	token := Token{AccessTokenHash: getTokenHash(accessToken)}
+	return GetTokenByTokenOrId(token, tokenId)
+}
+
 func GetTokenByRefreshToken(refreshToken string) (*Token, error) {
 	token := Token{RefreshTokenHash: getTokenHash(refreshToken)}
 	existed, err := ormer.Engine.Get(&token)
@@ -137,10 +142,29 @@ func GetTokenByRefreshToken(refreshToken string) (*Token, error) {
 	return &token, nil
 }
 
-func GetTokenByTokenValue(tokenValue, tokenTypeHint string) (*Token, error) {
+func GetTokenByRefreshTokenOrId(refreshToken, tokenId string) (*Token, error) {
+	token := Token{RefreshTokenHash: getTokenHash(refreshToken)}
+	return GetTokenByTokenOrId(token, tokenId)
+}
+
+func GetTokenByTokenOrId(token Token, tokenId string) (*Token, error) {
+	existed, err := ormer.Engine.Get(&token)
+	if err != nil {
+		return nil, err
+	}
+
+	if !existed {
+		owner, name := util.GetOwnerAndNameFromId(tokenId)
+		return getToken(owner, name)
+	}
+
+	return &token, nil
+}
+
+func GetTokenByValueOrId(tokenValue, tokenTypeHint, tokenId string) (*Token, error) {
 	switch tokenTypeHint {
 	case "access_token":
-		token, err := GetTokenByAccessToken(tokenValue)
+		token, err := GetTokenByAccessTokenOrId(tokenValue, tokenId)
 		if err != nil {
 			return nil, err
 		}
@@ -148,7 +172,7 @@ func GetTokenByTokenValue(tokenValue, tokenTypeHint string) (*Token, error) {
 			return token, nil
 		}
 	case "refresh_token":
-		token, err := GetTokenByRefreshToken(tokenValue)
+		token, err := GetTokenByRefreshTokenOrId(tokenValue, tokenId)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Optimize token validation and retrieval
- Validate the token before retrieving it from the database to reduce unnecessary database calls.
- Replace `GetTokenByValue` with `GetTokenByValueOrId` for token retrieval, as querying by token value (text) is inefficient for indexing and querying.