### PR TITLE
feat: add Casbin CLI API to Casdoor

### DIFF
--- a/controllers/casbin_api.go
+++ b/controllers/casbin_api.go
@@ -17,7 +17,12 @@ package controllers
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
+	fileadapter "github.com/casbin/casbin/v2/persist/file-adapter"
 	"github.com/casdoor/casdoor/object"
 	"github.com/casdoor/casdoor/util"
 )
@@ -326,4 +331,69 @@ func (c *ApiController) GetAllRoles() {
 	}
 
 	c.ResponseOk(roles)
+}
+
+// CasbinCli
+// @Title CasbinCli
+// @Tag Enforcer API
+// @Description Call casbin-go-cli
+// @Param   enforcerId    query   string  false   "enforcer id"
+// @Success 200 {object} controllers.Response The Response object
+// @router /casbin-cli [get]
+func (c *ApiController) CasbinCli() {
+	enforcerId := c.Input().Get("enforcerId")
+	command := c.Input().Get("command")
+	args := c.Input().Get("args")
+
+	cliPath, err := filepath.Abs("casbin-go-cli")
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	tmpDir := "./tmp"
+	modelPath := filepath.Join(tmpDir, "tmpModel.conf")
+	policyPath := filepath.Join(tmpDir, "tmpPolicy.csv")
+
+	if _, err := os.Stat(tmpDir); os.IsNotExist(err) {
+		err = os.Mkdir(tmpDir, os.ModePerm)
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
+	}
+
+	inputArgs := []string{command, "-m", modelPath, "-p", policyPath}
+	if args != "" {
+		inputArgs = append(inputArgs, strings.Split(args, " ")...)
+	}
+
+	enforcer, err := object.GetInitializedEnforcer(enforcerId)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	if enforcer == nil {
+		c.ResponseError(fmt.Sprintf(c.T("enforcer:The enforcer: \"%s\" doesn't exist"), enforcerId))
+		return
+	}
+
+	util.WriteStringToPath(enforcer.GetModel().ToText(), modelPath)
+
+	adapter := fileadapter.NewAdapter(policyPath)
+	enforcer.SetAdapter(adapter)
+	err = enforcer.SavePolicy()
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	casbinCli := exec.Command(cliPath, inputArgs...)
+	output, err := casbinCli.CombinedOutput()
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.ResponseOk(string(output))
 }

--- a/routers/router.go
+++ b/routers/router.go
@@ -173,6 +173,7 @@ func initAPI() {
 	beego.Router("/api/get-all-objects", &controllers.ApiController{}, "GET:GetAllObjects")
 	beego.Router("/api/get-all-actions", &controllers.ApiController{}, "GET:GetAllActions")
 	beego.Router("/api/get-all-roles", &controllers.ApiController{}, "GET:GetAllRoles")
+	beego.Router("/api/casbin-cli", &controllers.ApiController{}, "GET:CasbinCli")
 
 	beego.Router("/api/get-sessions", &controllers.ApiController{}, "GET:GetSessions")
 	beego.Router("/api/get-session", &controllers.ApiController{}, "GET:GetSingleSession")


### PR DESCRIPTION
Part of: https://github.com/casdoor/casdoor/issues/3206

The casbin-go-cli command should be placed in the casdoor directory.

![1731602635332](https://github.com/user-attachments/assets/e709e89d-d37a-42e3-bbdc-6fc8ec3fac06)

The request example is:

![image](https://github.com/user-attachments/assets/83fefeb8-94fc-4390-adb1-8356b0cf09f1)

The result is "Allowed\n"
