### PR TITLE
fix: fix several bugs in samlRequest

### DIFF
--- a/object/saml_idp.go
+++ b/object/saml_idp.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/beevik/etree"
@@ -276,29 +277,38 @@ func GetSamlMeta(application *Application, host string, enablePostBinding bool) 
 func GetSamlResponse(application *Application, user *User, samlRequest string, host string) (string, string, string, error) {
 	// request type
 	method := "GET"
-
+	samlRequest = strings.ReplaceAll(samlRequest, " ", "+")
 	// base64 decode
 	defated, err := base64.StdEncoding.DecodeString(samlRequest)
 	if err != nil {
 		return "", "", "", fmt.Errorf("err: Failed to decode SAML request, %s", err.Error())
 	}
 
-	// decompress
-	var buffer bytes.Buffer
-	rdr := flate.NewReader(bytes.NewReader(defated))
+	var requestByte []byte
 
-	for {
-		_, err = io.CopyN(&buffer, rdr, 1024)
-		if err != nil {
-			if err == io.EOF {
-				break
+	if strings.Contains(string(defated), "xmlns:") {
+		requestByte = defated
+	} else {
+		// decompress
+		var buffer bytes.Buffer
+		rdr := flate.NewReader(bytes.NewReader(defated))
+
+		for {
+
+			_, err = io.CopyN(&buffer, rdr, 1024)
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return "", "", "", err
 			}
-			return "", "", "", err
 		}
+
+		requestByte = buffer.Bytes()
 	}
 
 	var authnRequest saml.AuthNRequest
-	err = xml.Unmarshal(buffer.Bytes(), &authnRequest)
+	err = xml.Unmarshal(requestByte, &authnRequest)
 	if err != nil {
 		return "", "", "", fmt.Errorf("err: Failed to unmarshal AuthnRequest, please check the SAML request, %s", err.Error())
 	}

--- a/web/src/auth/Util.js
+++ b/web/src/auth/Util.js
@@ -113,6 +113,9 @@ export function getCasLoginParameters(owner, name) {
 
 export function getOAuthGetParameters(params) {
   const queries = (params !== undefined) ? params : new URLSearchParams(window.location.search);
+  const lowercaseQueries = {};
+  queries.forEach((val, key) => {lowercaseQueries[key.toLowerCase()] = val;});
+
   const clientId = getRefinedValue(queries.get("client_id"));
   const responseType = getRefinedValue(queries.get("response_type"));
 
@@ -138,9 +141,9 @@ export function getOAuthGetParameters(params) {
   const nonce = getRefinedValue(queries.get("nonce"));
   const challengeMethod = getRefinedValue(queries.get("code_challenge_method"));
   const codeChallenge = getRefinedValue(queries.get("code_challenge"));
-  const samlRequest = getRefinedValue(queries.get("SAMLRequest"));
-  const relayState = getRefinedValue(queries.get("RelayState"));
-  const noRedirect = getRefinedValue(queries.get("noRedirect"));
+  const samlRequest = getRefinedValue(lowercaseQueries["samlRequest".toLowerCase()]);
+  const relayState = getRefinedValue(lowercaseQueries["RelayState".toLowerCase()]);
+  const noRedirect = getRefinedValue(lowercaseQueries["noRedirect".toLowerCase()]);
 
   if (clientId === "" && samlRequest === "") {
     // login


### PR DESCRIPTION
fix: unable to get samlRequest from query, in some case samlRequest will not be compressed, samlRequest lost `+` during post

`if strings.Contains(string(defated), "xmlns:")` is used to check whether samlRequest is compressed