### PR TITLE
feat: update CI's `upload-artifact` and `download-artifact` actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,12 +114,12 @@ jobs:
           wait-on-timeout: 210
           working-directory: ./web
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots
           path: ./web/cypress/screenshots
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: cypress-videos


### PR DESCRIPTION
v3 of `actions/upload-artifact` and `actions/download-artifact` will be fully deprecated by **5 December 2024**. Jobs that are scheduled to run during the brownout periods will also fail. See:

1. https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
2. https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/