### PR TITLE
fix: change LDAP attribute from cn to title for correct username mapping

### DIFF
--- a/ldap/server.go
+++ b/ldap/server.go
@@ -142,7 +142,7 @@ func handleSearch(w ldap.ResponseWriter, m *ldap.Message) {
 		}
 		for _, attr := range attrs {
 			e.AddAttribute(message.AttributeDescription(attr), getAttribute(string(attr), user))
-			if string(attr) == "cn" {
+			if string(attr) == "title" {
 				e.AddAttribute(message.AttributeDescription(attr), getAttribute("title", user))
 			}
 		}


### PR DESCRIPTION
**Problem**
When integrating applications with Casdoor's LDAP server, the user's name is not correctly retrieved because it's currently mapped to the `title` attribute instead of the standard `cn` attribute.

**Solution**
Change the attribute mapping from `cn` to `title` in the LDAP search response.

**Changes**
#3376 

**Testing**
1. Started Casdoor with LDAP server enabled
2. Connected an LDAP client application
3. Verified that user names are now correctly retrieved using the `cn` attribute