### PR TITLE
feat: fix issue that introspectionResponse uses `Bearer` instead of raw tokenType

### DIFF
--- a/controllers/token.go
+++ b/controllers/token.go
@@ -402,6 +402,7 @@ func (c *ApiController) IntrospectToken() {
 			return
 		}
 	}
+	introspectionResponse.TokenType = token.TokenType
 
 	c.Data["json"] = introspectionResponse
 	c.ServeJSON()


### PR DESCRIPTION
fix: #3398 

my fault, according to [RFC7662 SECTION 2.2](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2) token type in introspectionResponse should be `Bearer` or `MAC` which defined in [RFC6749 SECTION 7.1](https://datatracker.ietf.org/doc/html/rfc6749#section-7.1)

@hadestructhor plz help me to test 