### PR TITLE
fix: allow API users to specify default groups for oauth users

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -749,6 +749,7 @@ func (c *ApiController) Login() {
 						IsDeleted:         false,
 						SignupApplication: application.Name,
 						Properties:        properties,
+						Groups:            authForm.Groups,
 					}
 
 					var affected bool

--- a/form/auth.go
+++ b/form/auth.go
@@ -20,22 +20,23 @@ type AuthForm struct {
 	Type         string `json:"type"`
 	SigninMethod string `json:"signinMethod"`
 
-	Organization   string `json:"organization"`
-	Username       string `json:"username"`
-	Password       string `json:"password"`
-	Name           string `json:"name"`
-	FirstName      string `json:"firstName"`
-	LastName       string `json:"lastName"`
-	Gender         string `json:"gender"`
-	Bio            string `json:"bio"`
-	Tag            string `json:"tag"`
-	Education      string `json:"education"`
-	Email          string `json:"email"`
-	Phone          string `json:"phone"`
-	Affiliation    string `json:"affiliation"`
-	IdCard         string `json:"idCard"`
-	Region         string `json:"region"`
-	InvitationCode string `json:"invitationCode"`
+	Organization   string   `json:"organization"`
+	Username       string   `json:"username"`
+	Password       string   `json:"password"`
+	Name           string   `json:"name"`
+	FirstName      string   `json:"firstName"`
+	LastName       string   `json:"lastName"`
+	Gender         string   `json:"gender"`
+	Bio            string   `json:"bio"`
+	Tag            string   `json:"tag"`
+	Education      string   `json:"education"`
+	Email          string   `json:"email"`
+	Phone          string   `json:"phone"`
+	Affiliation    string   `json:"affiliation"`
+	IdCard         string   `json:"idCard"`
+	Region         string   `json:"region"`
+	InvitationCode string   `json:"invitationCode"`
+	Groups         []string `json:"groups"`
 
 	Application string `json:"application"`
 	ClientId    string `json:"clientId"`


### PR DESCRIPTION
## Summary
When a API user (client system) wants to create a user in Casdoor, we can simply use [this](https://door.casdoor.com/swagger/#/User%20API/ApiController.AddUser]) API to create the user with necessary groups.

However if we allow 3rd party OAuth login for API users we don't have a way to set the default groups for these user.

In this pull request I propose to allow any API user to set the default groups when using OAuth login.

## Example Usage

```
  public async LoginWithOAuth(provider: string, oauthCode: string, redirectUri: string) {
    const res = await this.openIDClientService.startAuthFlow();
    const fetchUrl = res.ajaxUrl;

    const response = await fetch(fetchUrl, {
      method: "POST",
      headers: {
        "Content-Type": "application/json",
      },
      body: JSON.stringify({
        type: "code",
        application: this.appConfig.casdoor.appName,
        provider,
        code: oauthCode,
        samlRequest: null,
        state: this.appConfig.casdoor.appName,
        redirectUri,
        method: "signup",
        groups: this.dynamicConfig.defaultGroups, // <-- Here I can add default groups for OAuth users
      })
    });
    return response
  }
```