### PR TITLE
feat: can pass empty user id on user update

### DIFF
--- a/object/user.go
+++ b/object/user.go
@@ -678,6 +678,10 @@ func UpdateUser(id string, user *User, columns []string, isAdmin bool) (bool, er
 		user.Password = oldUser.Password
 	}
 
+	if user.Id != oldUser.Id && user.Id == "" {
+		user.Id = oldUser.Id
+	}
+
 	if user.Avatar != oldUser.Avatar && user.Avatar != "" && user.PermanentAvatar != "*" {
 		user.PermanentAvatar, err = getPermanentAvatarUrl(user.Owner, user.Name, user.Avatar, false)
 		if err != nil {


### PR DESCRIPTION
When i update user i only know his login. So I don't want to make additional `GET user` request to find out this user's ID.