### PR TITLE
feat: can pass empty user id on user update

### DIFF
--- a/controllers/user.go
+++ b/controllers/user.go
@@ -309,6 +309,10 @@ func (c *ApiController) UpdateUser() {
 		user.Name = strings.ToLower(user.Name)
 	}
 
+	if user.Id != oldUser.Id && user.Id == "" {
+		user.Id = oldUser.Id
+	}
+
 	isAdmin := c.IsAdmin()
 	if pass, err := object.CheckPermissionForUpdateUser(oldUser, &user, isAdmin, c.GetAcceptLanguage()); !pass {
 		c.ResponseError(err)

--- a/object/user.go
+++ b/object/user.go
@@ -679,10 +679,6 @@ func UpdateUser(id string, user *User, columns []string, isAdmin bool) (bool, er
 		user.Password = oldUser.Password
 	}
 
-	if user.Id != oldUser.Id && user.Id == "" {
-		user.Id = oldUser.Id
-	}
-
 	if user.Avatar != oldUser.Avatar && user.Avatar != "" && user.PermanentAvatar != "*" {
 		user.PermanentAvatar, err = getPermanentAvatarUrl(user.Owner, user.Name, user.Avatar, false)
 		if err != nil {


### PR DESCRIPTION
@hsluoyz Hello! Have to say that my previous PR (#3443) didn't fix my problem, because error went from `CheckPermissionForUpdateUser` which is obviously before `UpdateUser`. I was in a bit of a hurry, my bad

For now I moved this check in controller just to be before premission check method.

Or maybe I should ignore empty ID in `object/user_util.go:288`?