### PR TITLE
feat: added configurable session and cookie timeout settings

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -34,3 +34,5 @@ logConfig = {"filename": "logs/casdoor.log", "maxdays":99999, "perm":"0770"}
 initDataNewOnly = false
 initDataFile = "./init_data.json"
 frontendBaseDir = "../cc_0"
+session_default_timeout = 2592000
+cookie_default_timeout = 2592000

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -110,3 +110,19 @@ func GetConfigBatchSize() int {
 	}
 	return res
 }
+
+func GetSessionDefaultTimeout() int64 {
+	timeout, err := GetConfigInt64("session_default_timeout")
+	if err != nil || timeout <= 0 {
+		timeout = 2592000
+	}
+	return timeout
+}
+
+func GetCookieDefaultTimeout() int64 {
+	timeout, err := GetConfigInt64("cookie_default_timeout")
+	if err != nil || timeout <= 0 {
+		timeout = 2592000
+	}
+	return timeout
+}

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -125,3 +125,58 @@ func TestGetConfigLogs(t *testing.T) {
 		assert.Equal(t, scenery.expected, quota)
 	}
 }
+func TestGetSessionDefaultTimeout(t *testing.T) {
+	scenarios := []struct {
+		description string
+		envValue    string
+		configValue string
+		expected    int64
+	}{
+		{"Valid timeout from config", "", "3600", 3600},
+		{"Valid timeout from environment", "7200", "", 7200},
+		{"Invalid timeout falls back to default", "", "-100", 2592000},
+		{"Missing timeout falls back to default", "", "", 2592000},
+	}
+
+	for _, scenery := range scenarios {
+		t.Run(scenery.description, func(t *testing.T) {
+			if scenery.envValue != "" {
+				os.Setenv("session_default_timeout", scenery.envValue)
+			} else {
+				os.Unsetenv("session_default_timeout")
+			}
+
+			beego.AppConfig.Set("session_default_timeout", scenery.configValue)
+			actual := GetSessionDefaultTimeout()
+			assert.Equal(t, scenery.expected, actual)
+		})
+	}
+}
+func TestGetCookieDefaultTimeout(t *testing.T) {
+	scenarios := []struct {
+		description string
+		envValue    string
+		configValue string
+		expected    int64
+	}{
+		{"Valid timeout from config", "", "3600", 3600},
+		{"Valid timeout from environment", "7200", "", 7200},
+		{"Invalid timeout falls back to default", "", "-100", 2592000},
+		{"Missing timeout falls back to default", "", "", 2592000},
+	}
+
+	for _, scenery := range scenarios {
+		t.Run(scenery.description, func(t *testing.T) {
+			if scenery.envValue != "" {
+				os.Setenv("cookie_default_timeout", scenery.envValue)
+			} else {
+				os.Unsetenv("cookie_default_timeout")
+			}
+
+			beego.AppConfig.Set("cookie_default_timeout", scenery.configValue)
+
+			actual := GetCookieDefaultTimeout()
+			assert.Equal(t, scenery.expected, actual)
+		})
+	}
+}

--- a/controllers/token.go
+++ b/controllers/token.go
@@ -156,7 +156,7 @@ func (c *ApiController) DeleteToken() {
 
 	c.Data["json"] = wrapActionResponse(object.DeleteToken(&token))
 	c.ServeJSON()
-} 
+}
 
 // GetOAuthToken
 // @Title GetOAuthToken

--- a/controllers/token.go
+++ b/controllers/token.go
@@ -82,6 +82,12 @@ func (c *ApiController) GetToken() {
 		return
 	}
 
+	// Set token expiration based on session timeout (per-application or global)
+	if token != nil {
+		// Assuming app.SessionTimeout is available for the current application
+		token.ExpiresIn = object.GetSessionTimeoutForToken(token.Application)
+	}
+
 	c.ResponseOk(token)
 }
 
@@ -103,6 +109,10 @@ func (c *ApiController) UpdateToken() {
 		return
 	}
 
+	// Set the expiration time based on application's session timeout
+	token.ExpiresIn = object.GetSessionTimeoutForToken(token.Application)
+
+	// Update the token
 	c.Data["json"] = wrapActionResponse(object.UpdateToken(id, &token))
 	c.ServeJSON()
 }
@@ -121,6 +131,9 @@ func (c *ApiController) AddToken() {
 		c.ResponseError(err.Error())
 		return
 	}
+
+	// Set the expiration time based on application's session timeout
+	token.ExpiresIn = object.GetSessionTimeoutForToken(token.Application)
 
 	c.Data["json"] = wrapActionResponse(object.AddToken(&token))
 	c.ServeJSON()
@@ -143,7 +156,7 @@ func (c *ApiController) DeleteToken() {
 
 	c.Data["json"] = wrapActionResponse(object.DeleteToken(&token))
 	c.ServeJSON()
-}
+} 
 
 // GetOAuthToken
 // @Title GetOAuthToken

--- a/main.go
+++ b/main.go
@@ -71,9 +71,9 @@ func main() {
 		beego.BConfig.WebConfig.Session.SessionProvider = "redis"
 		beego.BConfig.WebConfig.Session.SessionProviderConfig = conf.GetConfigString("redisEndpoint")
 	}
-	
-	sessionTimeout := beego.AppConfig.DefaultInt("session.default_timeout", 720) 
-	cookieLifetime := beego.AppConfig.DefaultInt("cookie.default_lifetime", 43200) 
+
+	sessionTimeout := beego.AppConfig.DefaultInt("session.default_timeout", 720)
+	cookieLifetime := beego.AppConfig.DefaultInt("cookie.default_lifetime", 43200)
 
 	beego.BConfig.WebConfig.Session.SessionGCMaxLifetime = int64(sessionTimeout * 60)
 	beego.BConfig.WebConfig.Session.SessionCookieLifeTime = cookieLifetime

--- a/main.go
+++ b/main.go
@@ -71,8 +71,13 @@ func main() {
 		beego.BConfig.WebConfig.Session.SessionProvider = "redis"
 		beego.BConfig.WebConfig.Session.SessionProviderConfig = conf.GetConfigString("redisEndpoint")
 	}
-	beego.BConfig.WebConfig.Session.SessionCookieLifeTime = 3600 * 24 * 30
-	beego.BConfig.WebConfig.Session.SessionGCMaxLifetime = 3600 * 24 * 30
+	
+	sessionTimeout := beego.AppConfig.DefaultInt("session.default_timeout", 720) 
+	cookieLifetime := beego.AppConfig.DefaultInt("cookie.default_lifetime", 43200) 
+
+	beego.BConfig.WebConfig.Session.SessionGCMaxLifetime = int64(sessionTimeout * 60)
+	beego.BConfig.WebConfig.Session.SessionCookieLifeTime = cookieLifetime
+
 	// beego.BConfig.WebConfig.Session.SessionCookieSameSite = http.SameSiteNoneMode
 
 	err := logs.SetLogger(logs.AdapterFile, conf.GetConfigString("logConfig"))

--- a/web/cypress.config.js
+++ b/web/cypress.config.js
@@ -3,8 +3,10 @@ const { defineConfig } = require("cypress");
 module.exports = defineConfig({
   e2e: {
     "retries": {
-      "runMode": 2,
+      "runMode": 3,
       "openMode": 0
     }
   },
 });
+Cypress.config('defaultCommandTimeout', 10000);
+Cypress.config('pageLoadTimeout', 30000); 

--- a/web/cypress.config.js
+++ b/web/cypress.config.js
@@ -1,12 +1,11 @@
-const { defineConfig } = require("cypress");
+const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
   e2e: {
-    "retries": {
-      "runMode": 3,
-      "openMode": 0
-    }
+    baseUrl: 'http://localhost:7001',
+    retries: {
+      runMode: 2,
+      openMode: 0,
+    },
   },
 });
-Cypress.config('defaultCommandTimeout', 10000);
-Cypress.config('pageLoadTimeout', 30000); 


### PR DESCRIPTION
This pull request introduces configurable session and cookie timeout settings per application. 
 Changes:
- Added global session timeout defaults in `conf/app.conf`.
- Introduced per-application timeout settings in `object/application.go`.
- Updated the session management logic to respect application-specific and global settings.
- Modified the UI to allow configuring these settings.

 Issue Addressed:
https://github.com/casdoor/casdoor/issues/3363

 Testing:
- Tested locally and verified the settings apply as expected.

Please review and suggest further changes if needed.
