### PR TITLE
fix: cannot use casdoor as idp because casdoor idp use domain field as its host

### DIFF
--- a/idp/provider.go
+++ b/idp/provider.go
@@ -41,6 +41,7 @@ type ProviderInfo struct {
 	ClientSecret  string
 	ClientId2     string
 	ClientSecret2 string
+	Domain        string
 	AppId         string
 	HostUrl       string
 	RedirectUrl   string
@@ -108,7 +109,7 @@ func GetIdProvider(idpInfo *ProviderInfo, redirectUrl string) (IdProvider, error
 			return nil, fmt.Errorf("Infoflow provider subType: %s is not supported", idpInfo.SubType)
 		}
 	case "Casdoor":
-		return NewCasdoorIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl, idpInfo.HostUrl), nil
+		return NewCasdoorIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl, idpInfo.Domain), nil
 	case "Okta":
 		return NewOktaIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl, idpInfo.HostUrl), nil
 	case "Douyin":

--- a/object/provider.go
+++ b/object/provider.go
@@ -408,6 +408,7 @@ func FromProviderToIdpInfo(ctx *context.Context, provider *Provider) *idp.Provid
 		ClientSecret:  provider.ClientSecret,
 		ClientId2:     provider.ClientId2,
 		ClientSecret2: provider.ClientSecret2,
+		Domain:        provider.Domain,
 		AppId:         provider.AppId,
 		HostUrl:       provider.Host,
 		TokenURL:      provider.CustomTokenUrl,


### PR DESCRIPTION
fix: #3449 