### PR TITLE
fix: Skip redundant MFA verification for same type during email/SMS login (#3423)

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -331,6 +331,9 @@ func (c *ApiController) Login() {
 		return
 	}
 
+	useVerificationCode := false
+	verificationCodeType := ""
+
 	if authForm.Username != "" {
 		if authForm.Type == ResponseTypeLogin {
 			if c.GetSessionUsername() != "" {
@@ -391,8 +394,8 @@ func (c *ApiController) Login() {
 				c.ResponseError(fmt.Sprintf(c.T("auth:The application: %s does not exist"), authForm.Application))
 				return
 			}
-
-			verificationCodeType := object.GetVerifyType(authForm.Username)
+			useVerificationCode = true
+			verificationCodeType = object.GetVerifyType(authForm.Username)
 			if verificationCodeType == object.VerifyTypeEmail && !application.IsCodeSigninViaEmailEnabled() {
 				c.ResponseError(c.T("auth:The login method: login with email is not enabled for the application"))
 				return
@@ -522,7 +525,7 @@ func (c *ApiController) Login() {
 				return
 			}
 
-			if user.IsMfaEnabled() {
+			if user.IsMfaEnabled() && (!useVerificationCode || verificationCodeType != user.PreferredMfaType) {
 				c.setMfaUserSession(user.GetId())
 				c.ResponseOk(object.NextMfa, user.GetPreferredMfaProps(true))
 				return


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/3423

This PR fixes an issue where users are required to verify twice when logging in with email or SMS verification and the MFA method is of the same type (e.g., email MFA for email login).
﻿  
* The login process now skips MFA verification if the MFA method matches the login method (e.g., email login skips email MFA, SMS login skips SMS MFA).
* If the MFA method is different from the login method (e.g., email login with SMS MFA), the MFA step will still be required.
  
Why this fix is needed:
﻿
Requiring users to verify twice with the same method adds unnecessary friction to the login process without improving security. This change simplifies the user experience while maintaining security for cases where the MFA method is different.
﻿
This should address the issue described in #3423.