### PR TITLE
feat: fix SAML's redirectUrl and POST ProtocolBinding

### DIFF
--- a/object/saml_idp.go
+++ b/object/saml_idp.go
@@ -338,6 +338,9 @@ func GetSamlResponse(application *Application, user *User, samlRequest string, h
 	} else if authnRequest.AssertionConsumerServiceURL == "" {
 		return "", "", "", fmt.Errorf("err: SAML request don't has attribute 'AssertionConsumerServiceURL' in <samlp:AuthnRequest>")
 	}
+	if authnRequest.ProtocolBinding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" {
+		method = "POST"
+	}
 
 	_, originBackend := getOriginFromHost(host)
 

--- a/web/src/auth/AuthCallback.js
+++ b/web/src/auth/AuthCallback.js
@@ -204,7 +204,7 @@ class AuthCallback extends React.Component {
               }
               const SAMLResponse = res.data;
               const redirectUri = res.data2.redirectUrl;
-              Setting.goToLink(`${redirectUri}?SAMLResponse=${encodeURIComponent(SAMLResponse)}&RelayState=${oAuthParams.relayState}`);
+              Setting.goToLink(`${redirectUri}${redirectUri.includes("?") ? "&" : "?"}SAMLResponse=${encodeURIComponent(SAMLResponse)}&RelayState=${oAuthParams.relayState}`);
             }
           }
         } else {

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -505,7 +505,7 @@ class LoginPage extends React.Component {
               } else {
                 const SAMLResponse = res.data;
                 const redirectUri = res.data2.redirectUrl;
-                Setting.goToLink(`${redirectUri}?SAMLResponse=${encodeURIComponent(SAMLResponse)}&RelayState=${oAuthParams.relayState}`);
+                Setting.goToLink(`${redirectUri}${redirectUri.includes("?") ? "&" : "?"}SAMLResponse=${encodeURIComponent(SAMLResponse)}&RelayState=${oAuthParams.relayState}`);
               }
             }
           };


### PR DESCRIPTION
fix:saml redirectUrl may already contains ?, uses & in that case. change response method to POST ProtocolBinding == urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST.
