### PR TITLE
[WIP] Switch to custom Discord implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go v1.45.5
 	github.com/beego/beego v1.12.12
 	github.com/beevik/etree v1.1.0
+	github.com/bwmarrin/discordgo v0.27.1 // indirect
 	github.com/casbin/casbin/v2 v2.77.2
 	github.com/casdoor/go-sms-sender v0.25.0
 	github.com/casdoor/gomail/v2 v2.1.0

--- a/idp/discord.go
+++ b/idp/discord.go
@@ -1,0 +1,169 @@
+// Copyright 2021 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package idp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"golang.org/x/oauth2"
+)
+
+type DiscordIdProvider struct {
+	Client *http.Client
+	Config *oauth2.Config
+}
+
+func NewDiscordIdProvider(clientId string, clientSecret string, redirectUrl string) *DiscordIdProvider {
+	idp := &DiscordIdProvider{}
+
+	config := idp.getConfig(clientId, clientSecret, redirectUrl)
+	idp.Config = config
+
+	return idp
+}
+
+func (idp *DiscordIdProvider) SetHttpClient(client *http.Client) {
+	idp.Client = client
+}
+
+func (idp *DiscordIdProvider) getConfig(clientId string, clientSecret string, redirectUrl string) *oauth2.Config {
+	endpoint := oauth2.Endpoint{
+		TokenURL:  "https://discord.com/api/oauth2/token",
+		AuthURL:   "https://discord.com/api/oauth2/authorize",
+		AuthStyle: oauth2.AuthStyleInParams,
+	}
+
+	config := &oauth2.Config{
+		Scopes: []string{"openid guilds"},
+
+		Endpoint:     endpoint,
+		ClientID:     clientId,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectUrl,
+	}
+
+	return config
+}
+
+type DiscordAccessToken struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+}
+
+func (idp *DiscordIdProvider) GetToken(code string) (*oauth2.Token, error) {
+	params := url.Values{}
+	params.Add("grant_type", "authorization_code")
+	params.Add("client_id", idp.Config.ClientID)
+	params.Add("client_secret", idp.Config.ClientSecret)
+	params.Add("code", code)
+	params.Add("redirect_uri", idp.Config.RedirectURL)
+
+	accessTokenUrl := fmt.Sprintf("%s?%s", idp.Config.Endpoint.TokenURL, params.Encode())
+	bs, _ := json.Marshal(params.Encode())
+	req, _ := http.NewRequest("POST", accessTokenUrl, strings.NewReader(string(bs)))
+	//req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	rbs, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenResp := DiscordAccessToken{}
+	if err = json.Unmarshal(rbs, &tokenResp); err != nil {
+		return nil, err
+	}
+
+	token := &oauth2.Token{
+		AccessToken:  tokenResp.AccessToken,
+		TokenType:    tokenResp.TokenType,
+		RefreshToken: tokenResp.RefreshToken,
+		Expiry:       time.Unix(time.Now().Unix()+int64(tokenResp.ExpiresIn), 0),
+	}
+
+	return token, nil
+}
+
+func (idp *DiscordIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error) {
+	session, err := discordgo.New("Bearer " + token.AccessToken)
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	user, err := session.User("@me")
+	if err != nil {
+		return nil, err
+	}
+
+	userInfo := UserInfo{
+		Id:          user.ID,
+		Username:    user.Username,
+		DisplayName: user.Username,
+		Email:       user.Email,
+		AvatarUrl:   user.AvatarURL("128"),
+		Extra:       map[string]string{},
+	}
+
+	guilds, err := session.UserGuilds(100, "", "")
+	if err != nil {
+		return nil, err
+	}
+	for guildId := range guilds {
+		guild, err := session.Guild(strconv.Itoa(guildId))
+		if err != nil {
+			continue
+		}
+		userInfo.Extra[guild.ID] = guild.Name
+	}
+
+	return &userInfo, nil
+}
+
+func (idp *DiscordIdProvider) GetUrlResp(url string) (string, error) {
+	resp, err := idp.Client.Get(url)
+	if err != nil {
+		return "", err
+	}
+
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			return
+		}
+	}(resp.Body)
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/idp/goth.go
+++ b/idp/goth.go
@@ -35,7 +35,6 @@ import (
 	"github.com/markbates/goth/providers/dailymotion"
 	"github.com/markbates/goth/providers/deezer"
 	"github.com/markbates/goth/providers/digitalocean"
-	"github.com/markbates/goth/providers/discord"
 	"github.com/markbates/goth/providers/dropbox"
 	"github.com/markbates/goth/providers/eveonline"
 	"github.com/markbates/goth/providers/facebook"
@@ -171,11 +170,6 @@ func NewGothIdProvider(providerType string, clientId string, clientSecret string
 		idp = GothIdProvider{
 			Provider: digitalocean.New(clientId, clientSecret, redirectUrl),
 			Session:  &digitalocean.Session{},
-		}
-	case "Discord":
-		idp = GothIdProvider{
-			Provider: discord.New(clientId, clientSecret, redirectUrl),
-			Session:  &discord.Session{},
 		}
 	case "Dropbox":
 		idp = GothIdProvider{

--- a/idp/provider.go
+++ b/idp/provider.go
@@ -75,6 +75,8 @@ func GetIdProvider(idpInfo *ProviderInfo, redirectUrl string) (IdProvider, error
 		return NewWeiBoIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl), nil
 	case "Gitee":
 		return NewGiteeIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl), nil
+	case "Discord":
+		return NewDiscordIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl), nil
 	case "LinkedIn":
 		return NewLinkedInIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl), nil
 	case "WeCom":
@@ -146,7 +148,6 @@ var gothList = []string{
 	"Dailymotion",
 	"Deezer",
 	"DigitalOcean",
-	"Discord",
 	"Dropbox",
 	"EveOnline",
 	"Fitbit",


### PR DESCRIPTION
This is my initial attempt at switching Casdoor to use a custom Discord Oauth2 implementation. Reason being that I would like to use the user's `ExtraData` field to filter user access by the Discord Servers (`guilds`) they are being joined to.

The code is implemented as a copy and edit of `idp/gitee.go`.

What I am currently stuck at is actually informing the rest of the system about the change. I saw `controller/auth.go` and `object/provider.go`...mind giving me a pointer?

I introduced the `discordgo` library as a dependency, since it has predefined data structures and functions - no need to reinvent the wheel ;). This might also come in handy down the line (i.e.: Casdoor living as a bot on a server to automate access grants and restricts based off of server roles).

The implementation is not complete yet (the current `ExtraData` layout is very basic...for now).

Thanks a lot and kind regards,
Ingwie!