### PR TITLE
Handle individual User Properties for custom claims

### DIFF
--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -303,10 +303,25 @@ func getClaimsCustom(claims Claims, tokenField []string) jwt.MapClaims {
 	res["scope"] = claims.Scope
 
 	for _, field := range tokenField {
-		userField := userValue.FieldByName(field)
-		if userField.IsValid() {
-			newfield := util.SnakeToCamel(util.CamelToSnakeCase(field))
-			res[newfield] = userField.Interface()
+		if strings.HasPrefix(field, "Properties") {
+			parts := strings.Split(field, ".")
+			if len(parts) == 2 {
+				base, fieldName := parts[0], parts[1]
+				mField := userValue.FieldByName(base)
+				if mField.IsValid() {
+					finalField := mField.MapIndex(reflect.ValueOf(fieldName))
+					if finalField.IsValid() {
+						newfield := util.SnakeToCamel(util.CamelToSnakeCase(fieldName))
+						res[newfield] = finalField.Interface()
+					}
+				}
+			}
+		} else {
+			userField := userValue.FieldByName(field)
+			if userField.IsValid() {
+				newfield := util.SnakeToCamel(util.CamelToSnakeCase(field))
+				res[newfield] = userField.Interface()
+			}
 		}
 	}
 


### PR DESCRIPTION
Using a "." notation in the application custom token fields list to enable surfacing them to the top level, without needing to expose all of the Properties for a user.

Example:
If the user has a property named `preferred_username`, the application would add `Properties.preferred_username` to the token fields list.

This also addresses the logstanding comment for
`// FIXME: A workaround for custom claim by reusing `tag` in user info`