### PR TITLE
feat: fix bug due to null characters in descriptor when creating a payment intent

### DIFF
--- a/pp/airwallex.go
+++ b/pp/airwallex.go
@@ -203,7 +203,7 @@ func (c *AirwallexClient) CreateIntent(r *PayReq) (*AirWallexIntentResp, error) 
 		"amount":            r.Price,
 		"merchant_order_id": orderId,
 		"request_id":        orderId,
-		"descriptor":        string([]rune(description)[:32]), // display to the customer.
+		"descriptor":        strings.ReplaceAll(string([]rune(description)[:32]), "\x00", ""),
 		"metadata":          map[string]interface{}{"description": description},
 		"order":             map[string]interface{}{"products": []map[string]interface{}{{"name": r.ProductDisplayName, "quantity": 1, "desc": r.ProductDescription, "image_url": r.ProductImage}}},
 		"customer":          map[string]interface{}{"merchant_customer_id": r.PayerId, "email": r.PayerEmail, "first_name": r.PayerName, "last_name": r.PayerName},


### PR DESCRIPTION
Description:

- If the string is shorter than 32 characters, it will be padded with \u0000.
- The descriptor field must not contain null characters.

I'm sorry for not noticing this exception earlier. 😔