### PR TITLE
feat(jwt): add `azp` claim to ID token

### DIFF
--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -30,6 +30,8 @@ type Claims struct {
 	Nonce     string `json:"nonce,omitempty"`
 	Tag       string `json:"tag"`
 	Scope     string `json:"scope,omitempty"`
+	// the `azp` (Authorized Party) claim. Optional. See https://openid.net/specs/openid-connect-core-1_0.html#IDToken
+	Azp string `json:"azp,omitempty"`
 	jwt.RegisteredClaims
 }
 
@@ -137,6 +139,7 @@ type ClaimsShort struct {
 	TokenType string `json:"tokenType,omitempty"`
 	Nonce     string `json:"nonce,omitempty"`
 	Scope     string `json:"scope,omitempty"`
+	Azp       string `json:"azp,omitempty"`
 	jwt.RegisteredClaims
 }
 
@@ -155,6 +158,7 @@ type ClaimsWithoutThirdIdp struct {
 	Nonce     string `json:"nonce,omitempty"`
 	Tag       string `json:"tag"`
 	Scope     string `json:"scope,omitempty"`
+	Azp       string `json:"azp,omitempty"`
 	jwt.RegisteredClaims
 }
 
@@ -269,6 +273,7 @@ func getShortClaims(claims Claims) ClaimsShort {
 		Nonce:            claims.Nonce,
 		Scope:            claims.Scope,
 		RegisteredClaims: claims.RegisteredClaims,
+		Azp:              claims.Azp,
 	}
 	return res
 }
@@ -281,6 +286,7 @@ func getClaimsWithoutThirdIdp(claims Claims) ClaimsWithoutThirdIdp {
 		Tag:                 claims.Tag,
 		Scope:               claims.Scope,
 		RegisteredClaims:    claims.RegisteredClaims,
+		Azp:                 claims.Azp,
 	}
 	return res
 }
@@ -301,6 +307,7 @@ func getClaimsCustom(claims Claims, tokenField []string) jwt.MapClaims {
 	res["nonce"] = claims.Nonce
 	res["tag"] = claims.Tag
 	res["scope"] = claims.Scope
+	res["azp"] = claims.Azp
 
 	for _, field := range tokenField {
 		userField := userValue.FieldByName(field)
@@ -357,6 +364,7 @@ func generateJwtToken(application *Application, user *User, nonce string, scope 
 		// FIXME: A workaround for custom claim by reusing `tag` in user info
 		Tag:   user.Tag,
 		Scope: scope,
+		Azp:   application.ClientId,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    originBackend,
 			Subject:   user.Id,

--- a/object/token_standard_jwt.go
+++ b/object/token_standard_jwt.go
@@ -32,6 +32,7 @@ type ClaimsStandard struct {
 	Nonce               string      `json:"nonce,omitempty"`
 	Scope               string      `json:"scope,omitempty"`
 	Address             OIDCAddress `json:"address,omitempty"`
+	Azp                 string      `json:"azp,omitempty"`
 
 	jwt.RegisteredClaims
 }
@@ -52,6 +53,7 @@ func getStandardClaims(claims Claims) ClaimsStandard {
 		Nonce:            claims.Nonce,
 		Scope:            claims.Scope,
 		RegisteredClaims: claims.RegisteredClaims,
+		Azp:              claims.Azp,
 	}
 
 	res.Phone = ""


### PR DESCRIPTION
Added the `azp` (Authorized Party) claim to various JWT token structures including Claims, ClaimsShort, ClaimsWithoutThirdIdp, and ClaimsStandard.

Because go-jwt refused to add `azp` to standard claim, see golang-jwt/jwt#366

Fix: https://github.com/casdoor/casdoor/issues/3566