### PR TITLE
Enable using User Properties as custom claims

### DIFF
--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -303,10 +303,25 @@ func getClaimsCustom(claims Claims, tokenField []string) jwt.MapClaims {
 	res["scope"] = claims.Scope
 
 	for _, field := range tokenField {
-		userField := userValue.FieldByName(field)
-		if userField.IsValid() {
-			newfield := util.SnakeToCamel(util.CamelToSnakeCase(field))
-			res[newfield] = userField.Interface()
+		if strings.HasPrefix(field, "Properties") {
+			parts := strings.Split(field, ".")
+			if len(parts) == 2 {
+				base, fieldName := parts[0], parts[1]
+				mField := userValue.FieldByName(base)
+				if mField.IsValid() {
+					finalField := mField.MapIndex(reflect.ValueOf(fieldName))
+					if finalField.IsValid() {
+						newfield := util.SnakeToCamel(util.CamelToSnakeCase(fieldName))
+						res[newfield] = finalField.Interface()
+					}
+				}
+			}
+		} else {
+			userField := userValue.FieldByName(field)
+			if userField.IsValid() {
+				newfield := util.SnakeToCamel(util.CamelToSnakeCase(field))
+				res[newfield] = userField.Interface()
+			}
 		}
 	}
 

--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -311,8 +311,7 @@ func getClaimsCustom(claims Claims, tokenField []string) jwt.MapClaims {
 				if mField.IsValid() {
 					finalField := mField.MapIndex(reflect.ValueOf(fieldName))
 					if finalField.IsValid() {
-						newfield := util.SnakeToCamel(util.CamelToSnakeCase(fieldName))
-						res[newfield] = finalField.Interface()
+						res[fieldName] = finalField.Interface()
 					}
 				}
 			}


### PR DESCRIPTION
Enable adding custom claims that can match fields that are needed by downstream applications. Using a "." notation in the application custom token fields list to enable surfacing them to the top level, without needing to expose all of the Properties for a user.

Example:
If the user has a property named `preferred_username`, the application would add `Properties.preferred_username` to the token fields list.


Application Setting:
![image](https://github.com/user-attachments/assets/8d700531-0cae-425a-a118-11bc94eb8e51)

User Setting:
![image](https://github.com/user-attachments/assets/4e288373-66ba-4780-b955-5abeebbca603)

Generated JWT (notice the `preferred_username` field, which is not a field of the user in http://casdoor.org/docs/user/overview/):

```
{
  "alg": "RS256",
  "kid": "cert-built-in",
  "typ": "JWT"
}.{
  "aud": [
    "0ac0f951d0b93ff0cbab"
  ],
  "exp": 1739829942,
  "iat": 1739225142,
  "iss": "http://localhost:8000",
  "jti": "admin/b5544cbd-a3c0-4e48-88b4-04a6493ef782",
  "nbf": 1739225142,
  "nonce": "",
  "owner": "organization_queimk",
  "preferred_username": "my_username",
  "scope": "profile",
  "sub": "7a3d19df-d0f8-4d86-a376-688c82d48c42",
  "tag": "staff",
  "title": "Awesome Guy",
  "tokenType": "access-token"
}
```

Note: This also will enable not needing the workaround used in the Minio documentation (https://casdoor.org/docs/integration/go/minio/#step-2-configure-casdoor-application Step 4).
Instead of using a tag for the claim name, any field name could be chosen and set in the properties.