### PR TITLE
feat: Webauthn support multi origins

### DIFF
--- a/controllers/webauthn.go
+++ b/controllers/webauthn.go
@@ -39,7 +39,7 @@ func (c *ApiController) WebAuthnSignupBegin() {
 		return
 	}
 
-	webauthnObj, err := object.GetWebAuthnObjectByUser(user)
+	webauthnObj, err := object.GetWebAuthnObjectByUser(user, c.Ctx.Request.Host)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
@@ -75,7 +75,7 @@ func (c *ApiController) WebAuthnSignupFinish() {
 		return
 	}
 
-	webauthnObj, err := object.GetWebAuthnObjectByUser(user)
+	webauthnObj, err := object.GetWebAuthnObjectByUser(user, c.Ctx.Request.Host)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
@@ -130,7 +130,7 @@ func (c *ApiController) WebAuthnSigninBegin() {
 		return
 	}
 
-	webauthnObj, err := object.GetWebAuthnObjectByUser(user)
+	webauthnObj, err := object.GetWebAuthnObjectByUser(user, c.Ctx.Request.Host)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
@@ -183,7 +183,7 @@ func (c *ApiController) WebAuthnSigninFinish() {
 		return
 	}
 
-	webauthnObj, err := object.GetWebAuthnObjectByApplication(application)
+	webauthnObj, err := object.GetWebAuthnObjectByApplication(application, c.Ctx.Request.Host)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return

--- a/object/user_webauthn.go
+++ b/object/user_webauthn.go
@@ -48,6 +48,34 @@ func GetWebAuthnObject(host string) (*webauthn.WebAuthn, error) {
 	return webAuthn, nil
 }
 
+func GetWebAuthnObjectByApplication(application *Application) (*webauthn.WebAuthn, error) {
+	localUrl, err := url.Parse(application.HomepageUrl)
+	if err != nil {
+		return nil, fmt.Errorf("error when parsing origin:" + err.Error())
+	}
+
+	rpOrigins := []string{application.HomepageUrl}
+
+	webAuthn, err := webauthn.New(&webauthn.Config{
+		RPDisplayName: application.Name,
+		RPID:          strings.Split(localUrl.Host, ":")[0],
+		RPOrigins:     rpOrigins,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return webAuthn, nil
+}
+
+func GetWebAuthnObjectByUser(user *User) (*webauthn.WebAuthn, error) {
+	application, err := GetApplicationByUser(user)
+	if err != nil {
+		return nil, err
+	}
+	return GetWebAuthnObjectByApplication(application)
+}
+
 // WebAuthnID
 // implementation of webauthn.User interface
 func (user *User) WebAuthnID() []byte {

--- a/object/user_webauthn.go
+++ b/object/user_webauthn.go
@@ -20,33 +20,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/casdoor/casdoor/conf"
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
 )
-
-func GetWebAuthnObject(host string) (*webauthn.WebAuthn, error) {
-	var err error
-
-	_, originBackend := getOriginFromHost(host)
-
-	localUrl, err := url.Parse(originBackend)
-	if err != nil {
-		return nil, fmt.Errorf("error when parsing origin:" + err.Error())
-	}
-
-	webAuthn, err := webauthn.New(&webauthn.Config{
-		RPDisplayName: conf.GetConfigString("appname"),      // Display Name for your site
-		RPID:          strings.Split(localUrl.Host, ":")[0], // Generally the domain name for your site, it's ok because splits cannot return empty array
-		RPOrigin:      originBackend,                        // The origin URL for WebAuthn requests
-		// RPIcon:     "https://duo.com/logo.png",           // Optional icon URL for your site
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return webAuthn, nil
-}
 
 func GetWebAuthnObjectByApplication(application *Application) (*webauthn.WebAuthn, error) {
 	localUrl, err := url.Parse(application.HomepageUrl)

--- a/object/user_webauthn.go
+++ b/object/user_webauthn.go
@@ -45,7 +45,6 @@ func GetWebAuthnObjectByApplication(application *Application, host string) (*web
 	}
 
 	return webAuthn, nil
-
 }
 
 func GetWebAuthnObjectByUser(user *User, host string) (*webauthn.WebAuthn, error) {


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/3594

This issue was created because I have many applications that call `webauthn` api in `casdoor`. I discovered that I can use the application's `homepage_url` instead of configuring it from the env