### PR TITLE
feat: allow db port to be specified in docker env

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -76,6 +76,7 @@ func GetConfigDataSourceName() string {
 
 func ReplaceDataSourceNameByDocker(dataSourceName string) string {
 	runningInDocker := os.Getenv("RUNNING_IN_DOCKER")
+	specifiedDbPort := os.Getenv("DB_PORT")
 	if runningInDocker == "true" {
 		// https://stackoverflow.com/questions/48546124/what-is-linux-equivalent-of-host-docker-internal
 		if runtime.GOOS == "linux" {
@@ -83,6 +84,9 @@ func ReplaceDataSourceNameByDocker(dataSourceName string) string {
 		} else {
 			dataSourceName = strings.ReplaceAll(dataSourceName, "localhost", "host.docker.internal")
 		}
+	}
+	if specifiedDbPort != "" {
+		dataSourceName = strings.ReplaceAll(dataSourceName, "3306", specifiedDbPort)
 	}
 	return dataSourceName
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - db
     environment:
       RUNNING_IN_DOCKER: "true"
+      DB_PORT: "3306"
     volumes:
       - ./conf:/conf/
   db:


### PR DESCRIPTION
Add a new environment for changing exposing db port in multi-app envioronment.

3306端口占用容易冲突，补充一个环境变量DB_PORT让用户在Docker镜像不变更的情况下，能够简化部署。