### PR TITLE
fix: user id generation on create user with oauth

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -771,10 +771,7 @@ func (c *ApiController) Login() {
 						return
 					}
 
-					userId := userInfo.Id
-					if userId == "" {
-						userId = util.GenerateId()
-					}
+					userId := util.GenerateId()
 
 					user = &object.User{
 						Owner:             application.Organization,


### PR DESCRIPTION
Usually casdoor generate uuid for any new user registered at system.

For oauth casdoor user external id from oauth provider which mostly aren't valid UUID.
Also it not good practice to use external id as internal primary id. For example in case that two different providers have same id for two users in their system (let's say like user Bob have id 123456 in Facebook and user John has is 123456 in X).

For example compare users on screenshot: first is registered through casdoor, another three are user received from Google oauth
![Знімок екрана 2025-03-13 о 10 36 19 дп](https://github.com/user-attachments/assets/405873e2-7cb6-464a-8aee-d303f21a1a55)

This fix make random uuid generation for any new user.
