### PR TITLE
feat: don't panic when provider not found in Login() API

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -598,7 +598,6 @@ func (c *ApiController) Login() {
 			c.ResponseError(err.Error())
 			return
 		}
-
 		if provider == nil {
 			c.ResponseError(fmt.Sprintf(c.T("auth:The provider: %s does not exist"), authForm.Provider))
 		}

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -599,6 +599,10 @@ func (c *ApiController) Login() {
 			return
 		}
 
+		if provider == nil {
+			c.ResponseError(fmt.Sprintf(c.T("auth:The provider: %s does not exist"), authForm.Provider))
+		}
+
 		providerItem := application.GetProviderItem(provider.Name)
 		if !providerItem.IsProviderVisible() {
 			c.ResponseError(fmt.Sprintf(c.T("auth:The provider: %s is not enabled for the application"), provider.Name))


### PR DESCRIPTION
Add handling for case when provider wasn't found by name (for example renamed, disabled etc).
Prevent nil pointer error and throw valid error with valid json instead of html fatal error output.

![telegram-cloud-photo-size-2-5368354523661330832-y](https://github.com/user-attachments/assets/8b056971-5cb0-4abe-a493-cdf6c252b1f2)

`getProvider` returns nil in case not found provider.
![Знімок екрана 2025-03-13 о 10 44 32 дп](https://github.com/user-attachments/assets/b0dac944-7bc2-4c8a-9852-801d1d8079e9)

