### PR TITLE
feat: allow org to configure status of tour and ai assistant

### DIFF
--- a/object/init.go
+++ b/object/init.go
@@ -112,6 +112,7 @@ func initBuiltInOrganization() bool {
 		IsProfilePublic:    false,
 		UseEmailAsUsername: false,
 		EnableTour:         true,
+		EnableAIAssistant:  true,
 	}
 	_, err = AddOrganization(organization)
 	if err != nil {

--- a/object/organization.go
+++ b/object/organization.go
@@ -79,6 +79,7 @@ type Organization struct {
 	IsProfilePublic        bool       `json:"isProfilePublic"`
 	UseEmailAsUsername     bool       `json:"useEmailAsUsername"`
 	EnableTour             bool       `json:"enableTour"`
+	EnableAIAssistant      bool       `json:"enableAIAssistant"`
 	IpRestriction          string     `json:"ipRestriction"`
 	NavItems               []string   `xorm:"varchar(500)" json:"navItems"`
 

--- a/web/src/ManagementPage.js
+++ b/web/src/ManagementPage.js
@@ -193,15 +193,17 @@ function ManagementPage(props) {
             onChange={props.setLogoAndThemeAlgorithm} />
           <LanguageSelect languages={props.account.organization.languages} />
           {
-            Conf.AiAssistantUrl?.trim() && (
+            props.account.organization.enableAIAssistant ? Conf.AiAssistantUrl?.trim() && (
               <Tooltip title="Click to open AI assistant">
                 <div className="select-box" onClick={props.openAiAssistant}>
                   <DeploymentUnitOutlined style={{fontSize: "24px"}} />
                 </div>
               </Tooltip>
-            )
+            ) : null
           }
-          <OpenTour />
+          {
+            props.account.organization.enableTour ? <OpenTour /> : null
+          }
           {Setting.isAdminUser(props.account) && (props.uri.indexOf("/trees") === -1) &&
                         <OrganizationSelect
                           initValue={Setting.getOrganization()}

--- a/web/src/OrganizationEditPage.js
+++ b/web/src/OrganizationEditPage.js
@@ -536,6 +536,16 @@ class OrganizationEditPage extends React.Component {
           </Col>
         </Row>
         <Row style={{marginTop: "20px"}} >
+          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 19 : 2}>
+            {Setting.getLabel(i18next.t("general:Enable AI assistant"), i18next.t("general:Enable AI assistant - Tooltip"))} :
+          </Col>
+          <Col span={1} >
+            <Switch checked={this.state.organization.enableAIAssistant} onChange={checked => {
+              this.updateOrganizationField("enableAIAssistant", checked);
+            }} />
+          </Col>
+        </Row>
+        <Row style={{marginTop: "20px"}} >
           <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
             {Setting.getLabel(i18next.t("general:Navbar items"), i18next.t("general:Navbar items - Tooltip"))} :
           </Col>

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -254,6 +254,8 @@
     "Enable": "Enable",
     "Enable dark logo": "Enable dark logo",
     "Enable dark logo - Tooltip": "Enable dark logo",
+    "Enable AI assistant": "Enable AI assistant",
+    "Enable AI assistant - Tooltip": "Enable AI assistant - Tooltip",
     "Enable tour": "Enable tour",
     "Enable tour - Tooltip": "Display tour for users",
     "Enabled": "Enabled",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -254,6 +254,8 @@
     "Enable": "启用",
     "Enable dark logo": "开启暗黑Logo",
     "Enable dark logo - Tooltip": "开启暗黑Logo",
+    "Enable AI assistant": "启用 AI assistant",
+    "Enable AI assistant - Tooltip": "为用户启用 AI assistant",
     "Enable tour": "启用导引",
     "Enable tour - Tooltip": "为用户显示导引",
     "Enabled": "已开启",


### PR DESCRIPTION
fix: when tour disabled in org, it still shows "open tour" in account menu and doesnt work on click

feat: allow org to disable ai assistant

![image](https://github.com/user-attachments/assets/23fd3624-33f5-4857-a578-1ef8ae30b6e7)
