### PR TITLE
feat: increase frontend build memory to 4096 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=$BUILDPLATFORM node:18.19.0 AS FRONT
 WORKDIR /web
 COPY ./web .
-RUN yarn install --frozen-lockfile --network-timeout 1000000 && yarn run build
+RUN yarn install --frozen-lockfile --network-timeout 1000000 && NODE_OPTIONS="--max-old-space-size=4096" yarn run build
 
 
 FROM --platform=$BUILDPLATFORM golang:1.20.12 AS BACK


### PR DESCRIPTION
297.8 FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
