### PR TITLE
feat: fix apps page grid style

### DIFF
--- a/web/src/basic/GridCards.js
+++ b/web/src/basic/GridCards.js
@@ -35,8 +35,8 @@ const GridCards = (props) => {
         {items.map(item => <SingleCard key={item.link} logo={item.logo} link={item.link} title={item.name} desc={item.description} isSingle={items.length === 1} />)}
       </Card>
     ) : (
-      <div style={{margin: "0 15px"}}>
-        <Row>
+      <div style={{width: "100%", padding: "0 100px"}}>
+        <Row style={{justifyContent: "center"}}>
           {items.map(item => <SingleCard logo={item.logo} link={item.link} title={item.name} desc={item.description} time={item.createdTime} isSingle={items.length === 1} key={item.name} />)}
         </Row>
       </div>


### PR DESCRIPTION
When there is only one application on the /apps page, the card width is too narrow to display the title and other content.

Before:

![image](https://github.com/user-attachments/assets/03133382-4948-4c23-ac30-e966a2c85044)

![image](https://github.com/user-attachments/assets/0cdb0dea-8cc8-4f99-8673-f1c83ee7ad4f)

After:

![image](https://github.com/user-attachments/assets/f43fe67a-8dd0-45a8-bbc0-31f8f941216b)

![image](https://github.com/user-attachments/assets/1eb7b566-c531-4ef7-8a74-ad20ac9d296f)
