### PR TITLE
feat(introspection): return correct active status for expired or revoked tokens

### DIFF
--- a/controllers/token.go
+++ b/controllers/token.go
@@ -334,7 +334,7 @@ func (c *ApiController) IntrospectToken() {
 			c.ResponseTokenError(err.Error())
 			return
 		}
-		if token == nil || token.ExpiresIn == 0 {
+		if token == nil || token.ExpiresIn <= 0 {
 			respondWithInactiveToken()
 			return
 		}
@@ -398,7 +398,7 @@ func (c *ApiController) IntrospectToken() {
 			c.ResponseTokenError(err.Error())
 			return
 		}
-		if token == nil || token.ExpiresIn == 0 {
+		if token == nil || token.ExpiresIn <= 0 {
 			respondWithInactiveToken()
 			return
 		}


### PR DESCRIPTION
fix: #3711

Adding also missing validation at the end on the function for `tokenTypeHint` empty.