### PR TITLE
feat: improve InitFromFile() code order to fix GetOrganizationApplicationCount always returns 0 bug

### DIFF
--- a/object/init_data.go
+++ b/object/init_data.go
@@ -70,11 +70,11 @@ func InitFromFile() {
 		for _, provider := range initData.Providers {
 			initDefinedProvider(provider)
 		}
-		for _, user := range initData.Users {
-			initDefinedUser(user)
-		}
 		for _, application := range initData.Applications {
 			initDefinedApplication(application)
+		}
+		for _, user := range initData.Users {
+			initDefinedUser(user)
 		}
 		for _, cert := range initData.Certs {
 			initDefinedCert(cert)


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/3718

This change modifies the initialization sequence in InitFromFile() to create 
applications before users, ensuring proper dependency resolution during system 
initialization.