### PR TITLE
feat: can specify content type and http body field mapping for Custom HTTP Email provider

### DIFF
--- a/email/custom_http.go
+++ b/email/custom_http.go
@@ -34,7 +34,6 @@ type HttpEmailProvider struct {
 }
 
 func NewHttpEmailProvider(endpoint string, method string, httpHeaders map[string]string, bodyMapping map[string]string, contentType string) *HttpEmailProvider {
-
 	if contentType == "" {
 		contentType = "application/x-www-form-urlencoded"
 	}

--- a/email/custom_http.go
+++ b/email/custom_http.go
@@ -15,6 +15,8 @@
 package email
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -27,13 +29,22 @@ type HttpEmailProvider struct {
 	endpoint    string
 	method      string
 	httpHeaders map[string]string
+	bodyMapping map[string]string
+	contentType string
 }
 
-func NewHttpEmailProvider(endpoint string, method string, httpHeaders map[string]string) *HttpEmailProvider {
+func NewHttpEmailProvider(endpoint string, method string, httpHeaders map[string]string, bodyMapping map[string]string, contentType string) *HttpEmailProvider {
+
+	if contentType == "" {
+		contentType = "application/x-www-form-urlencoded"
+	}
+
 	client := &HttpEmailProvider{
 		endpoint:    endpoint,
 		method:      method,
 		httpHeaders: httpHeaders,
+		bodyMapping: bodyMapping,
+		contentType: contentType,
 	}
 	return client
 }
@@ -41,18 +52,52 @@ func NewHttpEmailProvider(endpoint string, method string, httpHeaders map[string
 func (c *HttpEmailProvider) Send(fromAddress string, fromName string, toAddress string, subject string, content string) error {
 	var req *http.Request
 	var err error
+
+	fromNameField := "fromName"
+	toAddressField := "toAddress"
+	subjectField := "subject"
+	contentField := "content"
+
+	for k, v := range c.bodyMapping {
+		switch k {
+		case "fromName":
+			fromNameField = v
+		case "toAddress":
+			toAddressField = v
+		case "subject":
+			subjectField = v
+		case "content":
+			contentField = v
+		}
+	}
+
 	if c.method == "POST" || c.method == "PUT" || c.method == "DELETE" {
-		formValues := url.Values{}
-		formValues.Set("fromName", fromName)
-		formValues.Set("toAddress", toAddress)
-		formValues.Set("subject", subject)
-		formValues.Set("content", content)
-		req, err = http.NewRequest(c.method, c.endpoint, strings.NewReader(formValues.Encode()))
+		bodyMap := make(map[string]string)
+		bodyMap[fromNameField] = fromName
+		bodyMap[toAddressField] = toAddress
+		bodyMap[subjectField] = subject
+		bodyMap[contentField] = content
+
+		var fromValueBytes []byte
+		if c.contentType == "application/json" {
+			fromValueBytes, err = json.Marshal(bodyMap)
+			if err != nil {
+				return err
+			}
+			req, err = http.NewRequest(c.method, c.endpoint, bytes.NewBuffer(fromValueBytes))
+		} else {
+			formValues := url.Values{}
+			for k, v := range bodyMap {
+				formValues.Add(k, v)
+			}
+			req, err = http.NewRequest(c.method, c.endpoint, strings.NewReader(formValues.Encode()))
+		}
+
 		if err != nil {
 			return err
 		}
 
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Content-Type", c.contentType)
 	} else if c.method == "GET" {
 		req, err = http.NewRequest(c.method, c.endpoint, nil)
 		if err != nil {
@@ -60,10 +105,10 @@ func (c *HttpEmailProvider) Send(fromAddress string, fromName string, toAddress 
 		}
 
 		q := req.URL.Query()
-		q.Add("fromName", fromName)
-		q.Add("toAddress", toAddress)
-		q.Add("subject", subject)
-		q.Add("content", content)
+		q.Add(fromNameField, fromName)
+		q.Add(toAddressField, toAddress)
+		q.Add(subjectField, subject)
+		q.Add(contentField, content)
 		req.URL.RawQuery = q.Encode()
 	} else {
 		return fmt.Errorf("HttpEmailProvider's Send() error, unsupported method: %s", c.method)

--- a/email/provider.go
+++ b/email/provider.go
@@ -18,11 +18,11 @@ type EmailProvider interface {
 	Send(fromAddress string, fromName, toAddress string, subject string, content string) error
 }
 
-func GetEmailProvider(typ string, clientId string, clientSecret string, host string, port int, disableSsl bool, endpoint string, method string, httpHeaders map[string]string) EmailProvider {
+func GetEmailProvider(typ string, clientId string, clientSecret string, host string, port int, disableSsl bool, endpoint string, method string, httpHeaders map[string]string, bodyMapping map[string]string, contentType string) EmailProvider {
 	if typ == "Azure ACS" {
 		return NewAzureACSEmailProvider(clientSecret, host)
 	} else if typ == "Custom HTTP Email" {
-		return NewHttpEmailProvider(endpoint, method, httpHeaders)
+		return NewHttpEmailProvider(endpoint, method, httpHeaders, bodyMapping, contentType)
 	} else if typ == "SendGrid" {
 		return NewSendgridEmailProvider(clientSecret, host, endpoint)
 	} else {

--- a/object/email.go
+++ b/object/email.go
@@ -31,7 +31,7 @@ func TestSmtpServer(provider *Provider) error {
 }
 
 func SendEmail(provider *Provider, title string, content string, dest string, sender string) error {
-	emailProvider := email.GetEmailProvider(provider.Type, provider.ClientId, provider.ClientSecret, provider.Host, provider.Port, provider.DisableSsl, provider.Endpoint, provider.Method, provider.HttpHeaders)
+	emailProvider := email.GetEmailProvider(provider.Type, provider.ClientId, provider.ClientSecret, provider.Host, provider.Port, provider.DisableSsl, provider.Endpoint, provider.Method, provider.HttpHeaders, provider.UserMapping, provider.IssuerUrl)
 
 	fromAddress := provider.ClientId2
 	if fromAddress == "" {

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -1144,60 +1144,66 @@ class ProviderEditPage extends React.Component {
                   </Col>
                 </Row>
               )}
-              <Row style={{marginTop: "20px"}} >
-                <Col style={{marginTop: "5px"}} span={2}>
-                  {Setting.getLabel(i18next.t("general:Method"), i18next.t("provider:Method - Tooltip"))} :
-                </Col>
-                <Col span={22} >
-                  <Select virtual={false} style={{width: "100%"}} value={this.state.provider.method} onChange={value => {
-                    this.updateProviderField("method", value);
-                  }}>
-                    {
-                      [
-                        {id: "GET", name: "GET"},
-                        {id: "POST", name: "POST"},
-                        {id: "PUT", name: "PUT"},
-                        {id: "DELETE", name: "DELETE"},
-                      ].map((method, index) => <Option key={index} value={method.id}>{method.name}</Option>)
-                    }
-                  </Select>
-                </Col>
-              </Row>
               {
-                this.state.provider.method !== "GET" ? (<Row style={{marginTop: "20px"}} >
-                  <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                    {Setting.getLabel(i18next.t("webhook:Content type"), i18next.t("webhook:Content type - Tooltip"))} :
-                  </Col>
-                  <Col span={22} >
-                    <Select virtual={false} style={{width: "100%"}} value={this.state.provider.issuerUrl === "" ? "application/x-www-form-urlencoded" : this.state.provider.issuerUrl} onChange={value => {
-                      this.updateProviderField("issuerUrl", value);
-                    }}>
-                      {
-                        [
-                          {id: "application/json", name: "application/json"},
-                          {id: "application/x-www-form-urlencoded", name: "application/x-www-form-urlencoded"},
-                        ].map((method, index) => <Option key={index} value={method.id}>{method.name}</Option>)
-                      }
-                    </Select>
-                  </Col>
-                </Row>) : null
+                !["Custom HTTP Email"].includes(this.state.provider.type) ? null : (
+                  <React.Fragment>
+                    <Row style={{marginTop: "20px"}} >
+                      <Col style={{marginTop: "5px"}} span={2}>
+                        {Setting.getLabel(i18next.t("general:Method"), i18next.t("provider:Method - Tooltip"))} :
+                      </Col>
+                      <Col span={22} >
+                        <Select virtual={false} style={{width: "100%"}} value={this.state.provider.method} onChange={value => {
+                          this.updateProviderField("method", value);
+                        }}>
+                          {
+                            [
+                              {id: "GET", name: "GET"},
+                              {id: "POST", name: "POST"},
+                              {id: "PUT", name: "PUT"},
+                              {id: "DELETE", name: "DELETE"},
+                            ].map((method, index) => <Option key={index} value={method.id}>{method.name}</Option>)
+                          }
+                        </Select>
+                      </Col>
+                    </Row>
+                    {
+                      this.state.provider.method !== "GET" ? (<Row style={{marginTop: "20px"}} >
+                        <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                          {Setting.getLabel(i18next.t("webhook:Content type"), i18next.t("webhook:Content type - Tooltip"))} :
+                        </Col>
+                        <Col span={22} >
+                          <Select virtual={false} style={{width: "100%"}} value={this.state.provider.issuerUrl === "" ? "application/x-www-form-urlencoded" : this.state.provider.issuerUrl} onChange={value => {
+                            this.updateProviderField("issuerUrl", value);
+                          }}>
+                            {
+                              [
+                                {id: "application/json", name: "application/json"},
+                                {id: "application/x-www-form-urlencoded", name: "application/x-www-form-urlencoded"},
+                              ].map((method, index) => <Option key={index} value={method.id}>{method.name}</Option>)
+                            }
+                          </Select>
+                        </Col>
+                      </Row>) : null
+                    }
+                    <Row style={{marginTop: "20px"}} >
+                      <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                        {Setting.getLabel(i18next.t("provider:HTTP header"), i18next.t("provider:HTTP header - Tooltip"))} :
+                      </Col>
+                      <Col span={22} >
+                        <HttpHeaderTable httpHeaders={this.state.provider.httpHeaders} onUpdateTable={(value) => {this.updateProviderField("httpHeaders", value);}} />
+                      </Col>
+                    </Row>
+                    {this.state.provider.method !== "GET" ? <Row style={{marginTop: "20px"}}>
+                      <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                        {Setting.getLabel(i18next.t("provider:HTTP body mapping"), i18next.t("provider:HTTP body mapping - Tooltip"))} :
+                      </Col>
+                      <Col span={22}>
+                        {this.renderEmailMappingInput()}
+                      </Col>
+                    </Row> : null}
+                  </React.Fragment>
+                )
               }
-              <Row style={{marginTop: "20px"}} >
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:HTTP header"), i18next.t("provider:HTTP header - Tooltip"))} :
-                </Col>
-                <Col span={22} >
-                  <HttpHeaderTable httpHeaders={this.state.provider.httpHeaders} onUpdateTable={(value) => {this.updateProviderField("httpHeaders", value);}} />
-                </Col>
-              </Row>
-              <Row style={{marginTop: "20px"}} >
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:HTTP body mapping"), i18next.t("provider:HTTP body mapping - Tooltip"))} :
-                </Col>
-                <Col span={22} >
-                  {this.renderEmailMappingInput()}
-                </Col>
-              </Row>
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
                   {Setting.getLabel(i18next.t("provider:Email title"), i18next.t("provider:Email title - Tooltip"))} :


### PR DESCRIPTION
Improve: https://github.com/casdoor/casdoor/issues/3684

second part pr for this issue, this time add support for specify content type and http body field mapping

![image](https://github.com/user-attachments/assets/0e0a565d-652a-42e9-9bc0-3db1a1fff155)
