### PR TITLE
build: automate release artifact generation with Linux deployment support

### DIFF
--- a/allInOnePackage.ps1
+++ b/allInOnePackage.ps1
@@ -1,0 +1,53 @@
+
+Remove-Item -Path ./release -Force -Recurse
+New-Item -Path ./release -ItemType Directory
+New-Item -Path ./release/web -ItemType Directory
+New-Item -Path ./release/conf -ItemType Directory
+
+Copy-Item -Path ./conf/app.conf -Destination ./release/conf
+
+
+# 复制配置文件
+Copy-Item -Path ./conf/app.conf -Destination ./release/conf
+
+# 修改配置文件，指明前端编译产物路径
+$confPath = "./release/conf/app.conf"
+$tempFile = "$env:TEMP\temp_config.conf"
+
+# 逐行处理并修改特定键
+Get-Content $confPath | ForEach-Object {
+    if ($_ -match '^\s*staticBaseUrl\s*=') {
+        'staticBaseUrl = "./web/build"'
+    } else {
+        $_
+    }
+} | Set-Content $tempFile -Encoding UTF8
+
+# 替换原文件
+Move-Item $tempFile $confPath -Force
+
+
+# 编译前端
+cd web
+npm run build
+cd ../
+# 将前端产物复制到release/web
+Copy-Item -Path ./web/build -Destination ./release/web -Recurse -Force
+
+# 编译后端
+$env:CGO_ENABLED = "0"
+$env:GOOS = "linux"
+$env:GOARCH = "amd64"
+go build -ldflags="-w -s" -o ./release/casdoor-Linux
+
+# $env:CGO_ENABLED = "0"
+# $env:GOOS = "windows"
+# $env:GOARCH = "amd64"
+# go build -ldflags="-w -s" -o ./release/casdoor-WIN.exe
+
+
+cd release
+
+tar -czvf "casdoor.tar.gz" .
+
+


### PR DESCRIPTION
## Changes
- Added PowerShell script to automate the following release pipeline:
  1. **Clean & prepare directories**
     - Force-clean existing `./release` folder
     - Create structured directories (`/release/web`, `/release/conf`)
  
  2. **Configuration handling**
     - Copy `app.conf` to release folder
     - Modify `staticBaseUrl` to point to local `./web/build` path

  3. **Build artifacts**
     - Compile frontend via `npm run build`
     - Cross-compile backend for Linux (amd64) with:
       - Static linking (`CGO_ENABLED=0`)
       - Stripped debug symbols (`-ldflags="-w -s"`)

  4. **Package artifacts**
     - Generate `casdoor.tar.gz` containing:
       - Compiled Linux binary (`casdoor-Linux`)
       - Frontend build assets (`/web/build`)
       - Configured app config (`/conf/app.conf`)

## Notes
- Currently targets **Linux** only (commented Windows build available)
- Config modification preserves original formatting
- Uses temporary file for atomic config updates

## Verification
Run the script and confirm:
```sh
./release/casdoor-Linux  # Should execute
tar -tzvf casdoor.tar.gz # Should show:
# - casdoor-Linux
# - web/build/
# - conf/app.conf