### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/object/product.go
+++ b/object/product.go
@@ -16,6 +16,7 @@ package object
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/casdoor/casdoor/idp"
 
@@ -136,12 +137,7 @@ func (product *Product) GetId() string {
 }
 
 func (product *Product) isValidProvider(provider *Provider) bool {
-	for _, providerName := range product.Providers {
-		if providerName == provider.Name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(product.Providers, provider.Name)
 }
 
 func (product *Product) getProvider(providerName string) (*Provider, error) {

--- a/object/record.go
+++ b/object/record.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/beego/beego/context"
@@ -214,13 +215,7 @@ func getFilteredWebhooks(webhooks []*Webhook, organization string, action string
 			}
 		}
 
-		matched := false
-		for _, event := range webhook.Events {
-			if action == event {
-				matched = true
-				break
-			}
-		}
+		matched := slices.Contains(webhook.Events, action)
 
 		if matched {
 			res = append(res, webhook)

--- a/object/token_oauth.go
+++ b/object/token_oauth.go
@@ -18,6 +18,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -436,12 +437,7 @@ func IsGrantTypeValid(method string, grantTypes []string) bool {
 	if method == "authorization_code" {
 		return true
 	}
-	for _, m := range grantTypes {
-		if m == method {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(grantTypes, method)
 }
 
 // GetAuthorizationCodeToken


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.