### PR TITLE
feat: fix missing redirect_uri in DingTalk registration

### DIFF
--- a/web/src/auth/AuthCallback.js
+++ b/web/src/auth/AuthCallback.js
@@ -194,7 +194,12 @@ class AuthCallback extends React.Component {
               Setting.goToLink(`${oAuthParams.redirectUri}${concatChar}${responseType}=${token}&state=${oAuthParams.state}&token_type=bearer`);
             } else if (responseType === "link") {
               const from = innerParams.get("from");
-              Setting.goToLinkSoftOrJumpSelf(this, from);
+              const redirectUri = innerParams.get("redirectUri");
+              if (redirectUri === null) {
+                Setting.goToLinkSoftOrJumpSelf(this, `${from}`);
+              } else {
+                Setting.goToLinkSoftOrJumpSelf(this, `${from}?redirectUri=${redirectUri}`);
+              }
             } else if (responseType === "saml") {
               if (res.data2.method === "POST") {
                 this.setState({

--- a/web/src/auth/AuthCallback.js
+++ b/web/src/auth/AuthCallback.js
@@ -196,7 +196,7 @@ class AuthCallback extends React.Component {
               const from = innerParams.get("from");
               const redirectUri = innerParams.get("redirectUri");
               if (redirectUri === null) {
-                Setting.goToLinkSoftOrJumpSelf(this, `${from}`);
+                Setting.goToLinkSoftOrJumpSelf(this, from);
               } else {
                 Setting.goToLinkSoftOrJumpSelf(this, `${from}?redirectUri=${redirectUri}`);
               }

--- a/web/src/auth/PromptPage.js
+++ b/web/src/auth/PromptPage.js
@@ -194,8 +194,11 @@ class PromptPage extends React.Component {
     const redirectUri = params.get("redirectUri");
     const code = params.get("code");
     const state = params.get("state");
-    if (redirectUri === null || code === null || state === null) {
+    if (redirectUri === null) {
       return "";
+    }
+    if (code === null || state === null) {
+      return redirectUri;
     }
     return `${redirectUri}?code=${code}&state=${state}`;
   }

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -195,8 +195,12 @@ class SignupPage extends React.Component {
     if (authConfig.appName === application.name) {
       return "/result";
     } else {
+      const oAuthParams = Util.getOAuthGetParameters();
       if (Setting.hasPromptPage(application)) {
-        return `/prompt/${application.name}`;
+        if (!oAuthParams.redirectUri) {
+          return `/prompt/${application.name}`;
+        }
+        return `/prompt/${application.name}?redirectUri=${oAuthParams.redirectUri}`;
       } else {
         return `/result/${application.name}`;
       }


### PR DESCRIPTION
When binding DingTalk on the registration page, the app redirects to the /apps route afterward, instead of redirecting to the user's original intended page.