### PR TITLE
feat: skip node_modules folder when generating i18n

### DIFF
--- a/i18n/generate.go
+++ b/i18n/generate.go
@@ -84,6 +84,10 @@ func getAllFilePathsInFolder(folder string, fileSuffix string) []string {
 				return err
 			}
 
+			if strings.HasSuffix(path, "node_modules") {
+				return filepath.SkipDir
+			}
+
 			if !strings.HasSuffix(info.Name(), fileSuffix) {
 				return nil
 			}


### PR DESCRIPTION
fix: skip node_modules folder in i18n generate func