### PR TITLE
feat: fix memory usage in sysinfo page

### DIFF
--- a/util/system.go
+++ b/util/system.go
@@ -60,7 +60,7 @@ func getMemoryUsage() (uint64, uint64, error) {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
 
-	return m.Alloc, virtualMem.Total, nil
+	return m.Sys, virtualMem.Total, nil
 }
 
 func GetSystemInfo() (*SystemInfo, error) {


### PR DESCRIPTION
fix: #3844 

maybe use MemStat.Sys instead of MemStat.Alloc can be more accurate

**Description of MemStat.Sys**
> Sys is the sum of the XSys fields below. Sys measures the virtual address space reserved by the Go runtime for the heap, stacks, and other internal data structures. It's likely that not all of the virtual address space is backed by physical memory at any given moment, though in general it all was at some point

**Description of MemStat.Alloc**
> Alloc is bytes of allocated heap objects.
