### PR TITLE
feat: Supports smooth migration of password credentials

### DIFF
--- a/controllers/user.go
+++ b/controllers/user.go
@@ -573,8 +573,13 @@ func (c *ApiController) SetPassword() {
 	targetUser.NeedUpdatePassword = false
 	targetUser.LastChangePasswordTime = util.GetCurrentTime()
 
+	// Set organization salt snapshot for password validation
+	if organization.PasswordSalt != "" {
+		targetUser.PasswordOrganizationSaltSnapshot = organization.PasswordSalt
+	}
+
 	if user.Ldap == "" {
-		_, err = object.UpdateUser(userId, targetUser, []string{"password", "need_update_password", "password_type", "last_change_password_time"}, false)
+		_, err = object.UpdateUser(userId, targetUser, []string{"password", "need_update_password", "password_type", "last_change_password_time", "password_organization_salt_snapshot"}, false)
 	} else {
 		if isAdmin {
 			err = object.ResetLdapPassword(targetUser, "", newPassword, c.GetAcceptLanguage())

--- a/object/user.go
+++ b/object/user.go
@@ -23,14 +23,15 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/xorm-io/builder"
+	"github.com/xorm-io/core"
+
 	"github.com/casdoor/casdoor/conf"
 	"github.com/casdoor/casdoor/faceId"
 	"github.com/casdoor/casdoor/i18n"
 	"github.com/casdoor/casdoor/proxy"
 	"github.com/casdoor/casdoor/util"
-	"github.com/go-webauthn/webauthn/webauthn"
-	"github.com/xorm-io/builder"
-	"github.com/xorm-io/core"
 )
 
 const (
@@ -58,52 +59,53 @@ type User struct {
 	UpdatedTime string `xorm:"varchar(100)" json:"updatedTime"`
 	DeletedTime string `xorm:"varchar(100)" json:"deletedTime"`
 
-	Id                string   `xorm:"varchar(100) index" json:"id"`
-	ExternalId        string   `xorm:"varchar(100) index" json:"externalId"`
-	Type              string   `xorm:"varchar(100)" json:"type"`
-	Password          string   `xorm:"varchar(150)" json:"password"`
-	PasswordSalt      string   `xorm:"varchar(100)" json:"passwordSalt"`
-	PasswordType      string   `xorm:"varchar(100)" json:"passwordType"`
-	DisplayName       string   `xorm:"varchar(100)" json:"displayName"`
-	FirstName         string   `xorm:"varchar(100)" json:"firstName"`
-	LastName          string   `xorm:"varchar(100)" json:"lastName"`
-	Avatar            string   `xorm:"varchar(500)" json:"avatar"`
-	AvatarType        string   `xorm:"varchar(100)" json:"avatarType"`
-	PermanentAvatar   string   `xorm:"varchar(500)" json:"permanentAvatar"`
-	Email             string   `xorm:"varchar(100) index" json:"email"`
-	EmailVerified     bool     `json:"emailVerified"`
-	Phone             string   `xorm:"varchar(100) index" json:"phone"`
-	CountryCode       string   `xorm:"varchar(6)" json:"countryCode"`
-	Region            string   `xorm:"varchar(100)" json:"region"`
-	Location          string   `xorm:"varchar(100)" json:"location"`
-	Address           []string `json:"address"`
-	Affiliation       string   `xorm:"varchar(100)" json:"affiliation"`
-	Title             string   `xorm:"varchar(100)" json:"title"`
-	IdCardType        string   `xorm:"varchar(100)" json:"idCardType"`
-	IdCard            string   `xorm:"varchar(100) index" json:"idCard"`
-	Homepage          string   `xorm:"varchar(100)" json:"homepage"`
-	Bio               string   `xorm:"varchar(100)" json:"bio"`
-	Tag               string   `xorm:"varchar(100)" json:"tag"`
-	Language          string   `xorm:"varchar(100)" json:"language"`
-	Gender            string   `xorm:"varchar(100)" json:"gender"`
-	Birthday          string   `xorm:"varchar(100)" json:"birthday"`
-	Education         string   `xorm:"varchar(100)" json:"education"`
-	Score             int      `json:"score"`
-	Karma             int      `json:"karma"`
-	Ranking           int      `json:"ranking"`
-	Balance           float64  `json:"balance"`
-	Currency          string   `xorm:"varchar(100)" json:"currency"`
-	IsDefaultAvatar   bool     `json:"isDefaultAvatar"`
-	IsOnline          bool     `json:"isOnline"`
-	IsAdmin           bool     `json:"isAdmin"`
-	IsForbidden       bool     `json:"isForbidden"`
-	IsDeleted         bool     `json:"isDeleted"`
-	SignupApplication string   `xorm:"varchar(100)" json:"signupApplication"`
-	Hash              string   `xorm:"varchar(100)" json:"hash"`
-	PreHash           string   `xorm:"varchar(100)" json:"preHash"`
-	AccessKey         string   `xorm:"varchar(100)" json:"accessKey"`
-	AccessSecret      string   `xorm:"varchar(100)" json:"accessSecret"`
-	AccessToken       string   `xorm:"mediumtext" json:"accessToken"`
+	Id                               string   `xorm:"varchar(100) index" json:"id"`
+	ExternalId                       string   `xorm:"varchar(100) index" json:"externalId"`
+	Type                             string   `xorm:"varchar(100)" json:"type"`
+	Password                         string   `xorm:"varchar(150)" json:"password"`
+	PasswordSalt                     string   `xorm:"varchar(100)" json:"passwordSalt"`
+	PasswordOrganizationSaltSnapshot string   `xorm:"varchar(100)" json:"passwordOrganizationSaltSnapshot"`
+	PasswordType                     string   `xorm:"varchar(100)" json:"passwordType"`
+	DisplayName                      string   `xorm:"varchar(100)" json:"displayName"`
+	FirstName                        string   `xorm:"varchar(100)" json:"firstName"`
+	LastName                         string   `xorm:"varchar(100)" json:"lastName"`
+	Avatar                           string   `xorm:"varchar(500)" json:"avatar"`
+	AvatarType                       string   `xorm:"varchar(100)" json:"avatarType"`
+	PermanentAvatar                  string   `xorm:"varchar(500)" json:"permanentAvatar"`
+	Email                            string   `xorm:"varchar(100) index" json:"email"`
+	EmailVerified                    bool     `json:"emailVerified"`
+	Phone                            string   `xorm:"varchar(100) index" json:"phone"`
+	CountryCode                      string   `xorm:"varchar(6)" json:"countryCode"`
+	Region                           string   `xorm:"varchar(100)" json:"region"`
+	Location                         string   `xorm:"varchar(100)" json:"location"`
+	Address                          []string `json:"address"`
+	Affiliation                      string   `xorm:"varchar(100)" json:"affiliation"`
+	Title                            string   `xorm:"varchar(100)" json:"title"`
+	IdCardType                       string   `xorm:"varchar(100)" json:"idCardType"`
+	IdCard                           string   `xorm:"varchar(100) index" json:"idCard"`
+	Homepage                         string   `xorm:"varchar(100)" json:"homepage"`
+	Bio                              string   `xorm:"varchar(100)" json:"bio"`
+	Tag                              string   `xorm:"varchar(100)" json:"tag"`
+	Language                         string   `xorm:"varchar(100)" json:"language"`
+	Gender                           string   `xorm:"varchar(100)" json:"gender"`
+	Birthday                         string   `xorm:"varchar(100)" json:"birthday"`
+	Education                        string   `xorm:"varchar(100)" json:"education"`
+	Score                            int      `json:"score"`
+	Karma                            int      `json:"karma"`
+	Ranking                          int      `json:"ranking"`
+	Balance                          float64  `json:"balance"`
+	Currency                         string   `xorm:"varchar(100)" json:"currency"`
+	IsDefaultAvatar                  bool     `json:"isDefaultAvatar"`
+	IsOnline                         bool     `json:"isOnline"`
+	IsAdmin                          bool     `json:"isAdmin"`
+	IsForbidden                      bool     `json:"isForbidden"`
+	IsDeleted                        bool     `json:"isDeleted"`
+	SignupApplication                string   `xorm:"varchar(100)" json:"signupApplication"`
+	Hash                             string   `xorm:"varchar(100)" json:"hash"`
+	PreHash                          string   `xorm:"varchar(100)" json:"preHash"`
+	AccessKey                        string   `xorm:"varchar(100)" json:"accessKey"`
+	AccessSecret                     string   `xorm:"varchar(100)" json:"accessSecret"`
+	AccessToken                      string   `xorm:"mediumtext" json:"accessToken"`
 
 	CreatedIp      string `xorm:"varchar(100)" json:"createdIp"`
 	LastSigninTime string `xorm:"varchar(100)" json:"lastSigninTime"`
@@ -926,6 +928,11 @@ func AddUser(user *User, lang string) (bool, error) {
 
 	if user.PasswordType == "" || user.PasswordType == "plain" {
 		user.UpdateUserPassword(organization)
+	}
+
+	// Set organization salt snapshot for password validation
+	if organization.PasswordSalt != "" {
+		user.PasswordOrganizationSaltSnapshot = organization.PasswordSalt
 	}
 
 	if user.CreatedTime == "" {


### PR DESCRIPTION
### Background
In the current implementation of Casdoor, there is a process flow issue concerning changes to password policies.

Currently, when a user is created, Casdoor records the password type used by their organization at that moment. However, it does not store a snapshot of the organization-level password salt. If the organization subsequently modifies its password policy, the user's recorded password type and hashed password remain unchanged unless the user actively changes their password.

This design, while allowing existing users to log in with the old password type after a policy change, introduces two significant issues:

- "Hard Break" on Salt Changes: When an organization changes its password salt, any user whose password type relies on this org-level salt is immediately unable to log in. The root cause is that, unlike the password type, the organization's salt is not snapshotted for each user. The system can only use the latest organization salt for hash verification, which will inevitably fail against a hash generated with the old salt. For instance, an organization switching from one salt-dependent password type to another would likely change the salt as well, triggering this failure scenario.

- Lack of a Seamless Migration Mechanism: The system currently lacks an "Update on Login" mechanism. Ideally, after a user successfully authenticates with legacy credentials (e.g., an old password type and salt), the system should immediately re-hash and store the password using the new organization policy and the provided plaintext password. This would enable a seamless migration of user credentials to the new policy without any user friction. This is particularly critical given that Casdoor's default password type is plain, which poses a potential security risk for administrators unfamiliar with this default behavior. The absence of a smooth migration path exacerbates this risk.

### Impact
The current password policy implementation has several negative consequences for both system administrators and end-users:

- Operational Difficulties: Administrators face significant challenges when attempting to update the organization's password salt if it has been used previously.
- Poor User Experience: To enforce a new password policy or update the salt, the only viable solution is to force all affected users to reset their passwords via the "Forgot Password" flow. This severely degrades the user experience and satisfaction.
- Potential Security Risks: The high operational cost and negative user impact of updating security policies may lead administrators to postpone or entirely avoid necessary security upgrades, leaving the system exposed to potential vulnerabilities for extended periods.
### Solution
This PR resolves the aforementioned issues by introducing an automatic and seamless credential migration mechanism. Upon each login or password change, the system will check the user's credentials against the current organization policy and, if necessary, automatically update the password hash, password type, and a snapshot of the organization's password salt.

### Implementation Details
This PR introduces the following changes:

- Added PasswordOrganizationSaltSnapshot Field: A new field has been added to the User struct (in object/user.go) to store a snapshot of the organization's salt that was used to hash the user's current password. This ensures that even if the organization's salt changes, the system can still validate the user's old password using the correct legacy salt.
- Modified CheckPassword Logic: The core logic in the CheckPassword function (in object/check.go) has been updated. It now considers a user's password policy "outdated" if it mismatches the current organization policy. In such cases, it first attempts to validate the password using the user's snapshotted salt. If successful, it immediately updates the user's password hash, password type, and salt snapshot to the new policy, achieving a seamless migration.
- Updated SetPassword Function: The SetPassword function (in controllers/user.go) has been modified to synchronize the organization salt snapshot whenever a user changes their password.

### Testing Completed
I have thoroughly tested multiple scenarios to ensure these changes function as expected and do not introduce regressions:

- Switching organization policies between different password types (plain, md5-salt, bcrypt).
- Users with legacy credentials successfully logging in and having their credentials automatically upgraded after a policy change.
- Users with a legacy salt successfully logging in and having their credentials automatically upgraded after the organization's salt was updated.
- The new user creation flow remains unaffected.
- The user-initiated password change flow functions correctly.

### Related Issues
Fixes #3278 : This PR addresses the problem outlined in this issue by the way. While the original issue's description may not be perfectly precise, the changes herein fully resolve its core concerns.
