### PR TITLE
Fix Tumblr error=invalid_scope&error_description=An+unsupported+scope…

### DIFF
--- a/web/src/auth/Provider.js
+++ b/web/src/auth/Provider.js
@@ -278,7 +278,7 @@ const authInfo = {
     endpoint: "https://www.tiktok.com/auth/authorize/",
   },
   Tumblr: {
-    scope: "email",
+    scope: "basic",
     endpoint: "https://www.tumblr.com/oauth2/authorize",
   },
   Twitch: {


### PR DESCRIPTION
…+was+requested

Email scope not supported in Tumblr API V2
https://www.tumblr.com/docs/en/api/v2

"API clients have access to Authorization Code, Client Credentials, and Refresh Token grants. Available scopes include basic, write, and offline_access. Note that you must specify a valid OAuth2 redirect URL for OAuth2 to be available to your application. You can find this field by editing one of your applications."