### PR TITLE
Fix link to LDAP server in LdapTable.js

### DIFF
--- a/web/src/table/LdapTable.js
+++ b/web/src/table/LdapTable.js
@@ -100,7 +100,7 @@ class LdapTable extends React.Component {
         sorter: (a, b) => a.serverName.localeCompare(b.serverName),
         render: (text, record, index) => {
           return (
-            <Link to={`/ldaps/${record.id}`}>
+            <Link to={`/ldap/${record.id}`}>
               {text}
             </Link>
           );


### PR DESCRIPTION
Clicking on the name of the ldap server erroneously has `ldaps` in the path instead of `ldap` (which the working Edit button has).

![image](https://github.com/user-attachments/assets/7c1cda83-5161-4b51-a870-347404d5f185)
