### PR TITLE
feat: fix org's LDAP table wrong link

### DIFF
--- a/web/src/table/LdapTable.js
+++ b/web/src/table/LdapTable.js
@@ -100,7 +100,7 @@ class LdapTable extends React.Component {
         sorter: (a, b) => a.serverName.localeCompare(b.serverName),
         render: (text, record, index) => {
           return (
-            <Link to={`/ldaps/${record.id}`}>
+            <Link to={`/ldap/${record.owner}/${record.id}`}>
               {text}
             </Link>
           );


### PR DESCRIPTION
Error: When trying to visit the LDAP server page from the LDAP Table, the link was incorrect. The link has been fixed to match the edit button.

The Problem:
![Screenshot From 2025-06-24 15-41-20](https://github.com/user-attachments/assets/f68de2d5-68df-4026-9934-a7b684492e88)
