### PR TITLE
feat: fix issue that LDAP user address was not syncing

### DIFF
--- a/object/ldap_conn.go
+++ b/object/ldap_conn.go
@@ -260,15 +260,15 @@ func AutoAdjustLdapUser(users []LdapUser) []LdapUser {
 	res := make([]LdapUser, len(users))
 	for i, user := range users {
 		res[i] = LdapUser{
-			UidNumber:         user.UidNumber,
-			Uid:               user.Uid,
-			Cn:                user.Cn,
-			GroupId:           user.GidNumber,
-			Uuid:              user.GetLdapUuid(),
-			DisplayName:       user.DisplayName,
-			Email:             util.ReturnAnyNotEmpty(user.Email, user.EmailAddress, user.Mail),
-			Mobile:            util.ReturnAnyNotEmpty(user.Mobile, user.MobileTelephoneNumber, user.TelephoneNumber),
-			RegisteredAddress: util.ReturnAnyNotEmpty(user.PostalAddress, user.RegisteredAddress),
+			UidNumber:   user.UidNumber,
+			Uid:         user.Uid,
+			Cn:          user.Cn,
+			GroupId:     user.GidNumber,
+			Uuid:        user.GetLdapUuid(),
+			DisplayName: user.DisplayName,
+			Email:       util.ReturnAnyNotEmpty(user.Email, user.EmailAddress, user.Mail),
+			Mobile:      util.ReturnAnyNotEmpty(user.Mobile, user.MobileTelephoneNumber, user.TelephoneNumber),
+			Address:     util.ReturnAnyNotEmpty(user.Address, user.PostalAddress, user.RegisteredAddress),
 		}
 	}
 	return res


### PR DESCRIPTION
There was an issue where LDAP fields like `RegisteredAddress` and `PostalAddress` were not syncing to Casdoor.

Picture of Error (address expected):
![Screenshot From 2025-06-25 16-02-43](https://github.com/user-attachments/assets/f463d0ad-b6df-414e-a589-ce8fe6f6a9c7)

After Fix:
![Screenshot From 2025-06-25 16-30-16](https://github.com/user-attachments/assets/fcce0a7b-ec34-47f7-9f3a-1f90e8a387ba)
![Screenshot From 2025-06-25 16-32-58](https://github.com/user-attachments/assets/579917ff-b750-4424-ae45-b366790993b7)

Fix of: https://github.com/casdoor/casdoor/pull/3904