### PR TITLE
feat: improve TikTok username generation logic

### DIFF
--- a/idp/douyin.go
+++ b/idp/douyin.go
@@ -190,7 +190,7 @@ func (idp *DouyinIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error)
 
 	userInfo := UserInfo{
 		Id:          douyinUserInfo.Data.OpenId,
-		Username:    douyinUserInfo.Data.Nickname,
+		Username:    douyinUserInfo.Data.OpenId,
 		DisplayName: douyinUserInfo.Data.Nickname,
 		AvatarUrl:   douyinUserInfo.Data.Avatar,
 	}

--- a/idp/douyin.go
+++ b/idp/douyin.go
@@ -21,10 +21,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 )
 
@@ -190,18 +188,9 @@ func (idp *DouyinIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error)
 		return nil, err
 	}
 
-	username := douyinUserInfo.Data.Nickname
-	if username == "" {
-		uid, err := uuid.NewRandom()
-		if err != nil {
-			return nil, err
-		}
-		uidStr := strings.Split(uid.String(), "-")
-		username = fmt.Sprintf("douyinuser-%s", uidStr[0])
-	}
 	userInfo := UserInfo{
 		Id:          douyinUserInfo.Data.OpenId,
-		Username:    username,
+		Username:    douyinUserInfo.Data.OpenId,
 		DisplayName: douyinUserInfo.Data.Nickname,
 		AvatarUrl:   douyinUserInfo.Data.Avatar,
 	}

--- a/idp/douyin.go
+++ b/idp/douyin.go
@@ -21,8 +21,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 )
 
@@ -188,9 +190,18 @@ func (idp *DouyinIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error)
 		return nil, err
 	}
 
+	username := douyinUserInfo.Data.Nickname
+	if username == "" {
+		uid, err := uuid.NewRandom()
+		if err != nil {
+			return nil, err
+		}
+		uidStr := strings.Split(uid.String(), "-")
+		username = fmt.Sprintf("douyinuser-%s", uidStr[0])
+	}
 	userInfo := UserInfo{
 		Id:          douyinUserInfo.Data.OpenId,
-		Username:    douyinUserInfo.Data.OpenId,
+		Username:    username,
 		DisplayName: douyinUserInfo.Data.Nickname,
 		AvatarUrl:   douyinUserInfo.Data.Avatar,
 	}


### PR DESCRIPTION
Use nickname when available, fallback to generated username (douyinuser-xxx) when nickname is empty.
Even if a username is duplicated, the conflict is already handled in `controllers/auth.go`.

![图片](https://github.com/user-attachments/assets/9fca8dee-9fab-4785-a4bd-bc98dcea0519)

fixes #3912 