### PR TITLE
feat: use only one salt arg in CredManager.IsPasswordCorrect()

### DIFF
--- a/cred/argon2id.go
+++ b/cred/argon2id.go
@@ -31,7 +31,7 @@ func (cm *Argon2idCredManager) GetHashedPassword(password string, salt string) s
 	return hash
 }
 
-func (cm *Argon2idCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, userSalt string, organizationSalt string) bool {
+func (cm *Argon2idCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, salt string) bool {
 	match, _ := argon2id.ComparePasswordAndHash(plainPwd, hashedPwd)
 	return match
 }

--- a/cred/bcrypt.go
+++ b/cred/bcrypt.go
@@ -17,7 +17,7 @@ func (cm *BcryptCredManager) GetHashedPassword(password string, salt string) str
 	return string(bytes)
 }
 
-func (cm *BcryptCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, userSalt string, organizationSalt string) bool {
+func (cm *BcryptCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, salt string) bool {
 	err := bcrypt.CompareHashAndPassword([]byte(hashedPwd), []byte(plainPwd))
 	return err == nil
 }

--- a/cred/manager.go
+++ b/cred/manager.go
@@ -16,7 +16,7 @@ package cred
 
 type CredManager interface {
 	GetHashedPassword(password string, salt string) string
-	IsPasswordCorrect(password string, passwordHash string, userSalt string, organizationSalt string) bool
+	IsPasswordCorrect(password string, passwordHash string, salt string) bool
 }
 
 func GetCredManager(passwordType string) CredManager {

--- a/cred/md5-user-salt.go
+++ b/cred/md5-user-salt.go
@@ -41,9 +41,6 @@ func (cm *Md5UserSaltCredManager) GetHashedPassword(password string, salt string
 	return getMd5HexDigest(getMd5HexDigest(password) + salt)
 }
 
-func (cm *Md5UserSaltCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, userSalt string, organizationSalt string) bool {
-	if hashedPwd == cm.GetHashedPassword(plainPwd, organizationSalt) {
-		return true
-	}
-	return hashedPwd == cm.GetHashedPassword(plainPwd, userSalt)
+func (cm *Md5UserSaltCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, salt string) bool {
+	return hashedPwd == cm.GetHashedPassword(plainPwd, salt)
 }

--- a/cred/pbkdf2-salt.go
+++ b/cred/pbkdf2-salt.go
@@ -35,9 +35,6 @@ func (cm *Pbkdf2SaltCredManager) GetHashedPassword(password string, salt string)
 	return base64.StdEncoding.EncodeToString(res)
 }
 
-func (cm *Pbkdf2SaltCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, userSalt string, organizationSalt string) bool {
-	if hashedPwd == cm.GetHashedPassword(plainPwd, organizationSalt) {
-		return true
-	}
-	return hashedPwd == cm.GetHashedPassword(plainPwd, userSalt)
+func (cm *Pbkdf2SaltCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, salt string) bool {
+	return hashedPwd == cm.GetHashedPassword(plainPwd, salt)
 }

--- a/cred/pbkdf2_django.go
+++ b/cred/pbkdf2_django.go
@@ -42,7 +42,7 @@ func (m *Pbkdf2DjangoCredManager) GetHashedPassword(password string, salt string
 	return "pbkdf2_sha256$" + strconv.Itoa(iterations) + "$" + salt + "$" + hashBase64
 }
 
-func (m *Pbkdf2DjangoCredManager) IsPasswordCorrect(password string, passwordHash string, userSalt string, organizationSalt string) bool {
+func (m *Pbkdf2DjangoCredManager) IsPasswordCorrect(password string, passwordHash string, _salt string) bool {
 	parts := strings.Split(passwordHash, "$")
 	if len(parts) != 4 {
 		return false

--- a/cred/plain.go
+++ b/cred/plain.go
@@ -25,6 +25,6 @@ func (cm *PlainCredManager) GetHashedPassword(password string, salt string) stri
 	return password
 }
 
-func (cm *PlainCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, userSalt string, organizationSalt string) bool {
+func (cm *PlainCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, salt string) bool {
 	return hashedPwd == plainPwd
 }

--- a/cred/sha256-salt.go
+++ b/cred/sha256-salt.go
@@ -41,9 +41,6 @@ func (cm *Sha256SaltCredManager) GetHashedPassword(password string, salt string)
 	return getSha256HexDigest(getSha256HexDigest(password) + salt)
 }
 
-func (cm *Sha256SaltCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, userSalt string, organizationSalt string) bool {
-	if hashedPwd == cm.GetHashedPassword(plainPwd, organizationSalt) {
-		return true
-	}
-	return hashedPwd == cm.GetHashedPassword(plainPwd, userSalt)
+func (cm *Sha256SaltCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, salt string) bool {
+	return hashedPwd == cm.GetHashedPassword(plainPwd, salt)
 }

--- a/cred/sha512-salt.go
+++ b/cred/sha512-salt.go
@@ -41,9 +41,6 @@ func (cm *Sha512SaltCredManager) GetHashedPassword(password string, salt string)
 	return getSha512HexDigest(getSha512HexDigest(password) + salt)
 }
 
-func (cm *Sha512SaltCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, userSalt string, organizationSalt string) bool {
-	if hashedPwd == cm.GetHashedPassword(plainPwd, organizationSalt) {
-		return true
-	}
-	return hashedPwd == cm.GetHashedPassword(plainPwd, userSalt)
+func (cm *Sha512SaltCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, salt string) bool {
+	return hashedPwd == cm.GetHashedPassword(plainPwd, salt)
 }

--- a/object/check.go
+++ b/object/check.go
@@ -252,12 +252,12 @@ func CheckPassword(user *User, password string, lang string, options ...bool) er
 	credManager := cred.GetCredManager(passwordType)
 	if credManager != nil {
 		if organization.MasterPassword != "" {
-			if password == organization.MasterPassword || credManager.IsPasswordCorrect(password, organization.MasterPassword, "", organization.PasswordSalt) {
+			if password == organization.MasterPassword || credManager.IsPasswordCorrect(password, organization.MasterPassword, organization.PasswordSalt) {
 				return resetUserSigninErrorTimes(user)
 			}
 		}
 
-		if credManager.IsPasswordCorrect(password, user.Password, user.PasswordSalt, organization.PasswordSalt) {
+		if credManager.IsPasswordCorrect(password, user.Password, organization.PasswordSalt) || credManager.IsPasswordCorrect(password, user.Password, user.PasswordSalt) {
 			return resetUserSigninErrorTimes(user)
 		}
 


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/3929