### PR TITLE
fix: add default value for `verificationCodeTimeout`

### DIFF
--- a/object/verification.go
+++ b/object/verification.go
@@ -251,7 +251,7 @@ func CheckVerificationCode(dest string, code string, lang string) (*VerifyResult
 
 	timeoutInMinutes, err := conf.GetConfigInt64("verificationCodeTimeout")
 	if err != nil {
-		return nil, err
+		timeoutInMinutes = 10
 	}
 
 	now := time.Now().Unix()


### PR DESCRIPTION
fix: #3943 