### PR TITLE
feat: show the popover on the top when window's width too small and close popover when password options is empty

### DIFF
--- a/web/src/auth/ForgetPage.js
+++ b/web/src/auth/ForgetPage.js
@@ -415,7 +415,7 @@ class ForgetPage extends React.Component {
                   }}
                   onFocus={() => {
                     this.setState({
-                      passwordPopoverOpen: true,
+                      passwordPopoverOpen: application.organizationObj.passwordOptions?.length > 0,
                       passwordPopover: PasswordChecker.renderPasswordPopover(application.organizationObj.passwordOptions, this.form.current?.getFieldValue("newPassword") ?? ""),
                     });
                   }}

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -635,7 +635,7 @@ class SignupPage extends React.Component {
             }}
             onFocus={() => {
               this.setState({
-                passwordPopoverOpen: true,
+                passwordPopoverOpen: application.organizationObj.passwordOptions?.length > 0,
                 passwordPopover: PasswordChecker.renderPasswordPopover(application.organizationObj.passwordOptions, this.form.current?.getFieldValue("password") ?? ""),
               });
             }}

--- a/web/src/common/modal/PasswordModal.js
+++ b/web/src/common/modal/PasswordModal.js
@@ -138,12 +138,12 @@ export const PasswordModal = (props) => {
                 placeholder={i18next.t("user:input password")}
                 onChange={(e) => {
                   handleNewPassword(e.target.value);
-                  setPasswordPopoverOpen(true);
+                  setPasswordPopoverOpen(passwordOptions?.length > 0);
                   setPasswordPopover(PasswordChecker.renderPasswordPopover(passwordOptions, e.target.value));
 
                 }}
                 onFocus={() => {
-                  setPasswordPopoverOpen(true);
+                  setPasswordPopoverOpen(passwordOptions?.length > 0);
                   setPasswordPopover(PasswordChecker.renderPasswordPopover(passwordOptions, newPassword));
                 }}
                 onBlur={() => {


### PR DESCRIPTION
fix: show the popover on the top when window's width too small and close popover when password options is empty

before, when the window's width too small, it will hide the password
![3ff5996a942de362f3668ea72482bf55](https://github.com/user-attachments/assets/b58a3268-aba8-4ec2-8be6-05ea2b8ae64c)

now, it will display on the top of the input
![baa1da490fd003cc2cd4828488e6b7f0](https://github.com/user-attachments/assets/f787dce2-6fba-419f-aa54-5117b41b8d5e)
