### PR TITLE
feat: fix issue that resource provider.PathPrefix is not used in GetDirectResources() API

### DIFF
--- a/object/resource_direct.go
+++ b/object/resource_direct.go
@@ -28,7 +28,8 @@ func GetDirectResources(owner string, user string, provider *Provider, prefix st
 	}
 
 	res := []*Resource{}
-	objects, err := storageProvider.List(prefix)
+	fullPathPrefix := util.UrlJoin(provider.PathPrefix, prefix)
+	objects, err := storageProvider.List(fullPathPrefix)
 	for _, obj := range objects {
 		resource := &Resource{
 			Owner:       owner,


### PR DESCRIPTION
I found that cloud storage (such as alicloud oss) considers the incoming fullFilePath and storage provider.PathPrefix to be concatenated as a path when uploading resources, as follows:
<img width="498" height="26" alt="image" src="https://github.com/user-attachments/assets/83e83d84-acba-45c3-92bf-fd5dde6f7d40" />
However, when querying (GetResources), it does not consider concatenating provider.PathPrefix, but only the incoming fullFilePath. This has led to the issue of “casibase being unable to retrieve any files when calling getresou