### PR TITLE
feat: move to a more robust way of checking if element in slice

### DIFF
--- a/util/slice.go
+++ b/util/slice.go
@@ -14,7 +14,7 @@
 
 package util
 
-import "sort"
+import "slices"
 
 func DeleteVal(values []string, val string) []string {
 	newValues := []string{}
@@ -39,17 +39,11 @@ func ReplaceVal(values []string, oldVal string, newVal string) []string {
 }
 
 func ContainsString(values []string, val string) bool {
-	sort.Strings(values)
-	return sort.SearchStrings(values, val) != len(values)
+	return slices.Contains(values, val)
 }
 
 func InSlice(slice []string, elem string) bool {
-	for _, val := range slice {
-		if val == elem {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, elem)
 }
 
 func ReturnAnyNotEmpty(strs ...string) string {


### PR DESCRIPTION
This PR refactors the ContainsString function to use the standard library's slices.Contains. This change improves code readability, safety, and performance by leveraging a robust and idiomatic function designed for this exact purpose.

**Problem**
The previous implementation of ContainsString used a custom pattern with sort.SearchStrings:

```go
func ContainsString(values []string, val string) bool {
    sort.Strings(values)
    return sort.SearchStrings(values, val) != len(values)
}
```

This approach has a subtle but critical bug. While sort.SearchStrings efficiently finds the index where an element would be, its return value does not guarantee the element's existence. The function would return true for a string that is not in the slice, as long as its alphabetical position falls between existing elements.

For example, given the sorted columns slice:

`["balance", "country_code", "email", "id", "last_signin_time", "name", "phone", "type", "updated_time"]`

and searching for "groups", the function would incorrectly return true.

- sort.Strings sorts the slice (it's already sorted here).

- sort.SearchStrings finds the insertion point for "groups", which is index 4 (before "last_signin_time").

The return statement evaluates 4 != len(values) (4 != 9), which is true.

This bug leads to false positives, where the function incorrectly indicates that a string is present