### PR TITLE
feat: fix the error effect of form post response type

### DIFF
--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -1816,3 +1816,24 @@ export function renderLoginPanel(application, getInnerComponent, componentThis) 
     </div>
   );
 }
+
+export function createFormAndSubmit(url, params) {
+  const form = document.createElement("form");
+  form.method = "post";
+  form.action = url;
+
+  for (const k in params) {
+    if (!params[k]) {
+      continue;
+    }
+    const input = document.createElement("input");
+    input.type = "hidden";
+    input.name = k;
+    input.value = params[k];
+    form.appendChild(input);
+  }
+
+  document.body.appendChild(form);
+  form.submit();
+  setTimeout(() => {form.remove();}, 500);
+}


### PR DESCRIPTION
fix: the error effect of form post response type

Q: why change `responseType === "token"` to `responseTypes.includes("token")`? 

A: sometimes the responseType could be `token id_token`, so we need to support this.

Q: why `token` and `id_token` is same?
A: in casdoor, they are same.


demo:

- effect on fragment mode

https://github.com/user-attachments/assets/5840a860-06a8-4d13-9ed7-3cece43772fe

- effect on post_form mode

https://github.com/user-attachments/assets/c3de0fd3-6997-41e1-b7b1-b7ab12e9a8a8



