### PR TITLE
feat: prevent two captcha providers are added to one single application

### DIFF
--- a/web/src/table/ProviderTable.js
+++ b/web/src/table/ProviderTable.js
@@ -88,16 +88,10 @@ class ProviderTable extends React.Component {
                 }
               }} >
               {
-                Setting.getDeduplicatedArray(this.props.providers, table, "name").filter(provider => {
-                  if (provider.category === "Captcha") {
-                    const hasCaptchaProvider = table.some(tableItem => {
-                      const existingProvider = Setting.getArrayItem(this.props.providers, "name", tableItem.name);
-                      return existingProvider && existingProvider.category === "Captcha";
-                    });
-                    return !hasCaptchaProvider;
-                  }
-                  return true;
-                }).map((provider, index) => <Option key={index} value={provider.name}>{provider.name}</Option>)
+                Setting.getDeduplicatedArray(this.props.providers, table, "name").filter(provider => provider.category !== "Captcha" || !table.some(tableItem => {
+                  const existingProvider = Setting.getArrayItem(this.props.providers, "name", tableItem.name);
+                  return existingProvider && existingProvider.category === "Captcha";
+                })).map((provider, index) => <Option key={index} value={provider.name}>{provider.name}</Option>)
               }
             </Select>
           );

--- a/web/src/table/ProviderTable.js
+++ b/web/src/table/ProviderTable.js
@@ -88,7 +88,16 @@ class ProviderTable extends React.Component {
                 }
               }} >
               {
-                Setting.getDeduplicatedArray(this.props.providers, table, "name").map((provider, index) => <Option key={index} value={provider.name}>{provider.name}</Option>)
+                Setting.getDeduplicatedArray(this.props.providers, table, "name").filter(provider => {
+                  if (provider.category === "Captcha") {
+                    const hasCaptchaProvider = table.some(tableItem => {
+                      const existingProvider = Setting.getArrayItem(this.props.providers, "name", tableItem.name);
+                      return existingProvider && existingProvider.category === "Captcha";
+                    });
+                    return !hasCaptchaProvider;
+                  }
+                  return true;
+                }).map((provider, index) => <Option key={index} value={provider.name}>{provider.name}</Option>)
               }
             </Select>
           );


### PR DESCRIPTION
fix: #3989 
- Ensure that one application contains only one Captcha provider and filter out captcha provider options when one already exists in the application
- Only affects Captcha category providers, other provider types remain unaffected