### PR TITLE
feat: remove toLower conversion in getPolicies()

### DIFF
--- a/object/permission_enforcer.go
+++ b/object/permission_enforcer.go
@@ -125,10 +125,10 @@ func getPolicies(permission *Permission) [][]string {
 			for _, action := range permission.Actions {
 				if domainExist {
 					for _, domain := range permission.Domains {
-						policies = append(policies, []string{userOrRole, domain, resource, strings.ToLower(action), strings.ToLower(permission.Effect), permissionId})
+						policies = append(policies, []string{userOrRole, domain, resource, action, strings.ToLower(permission.Effect), permissionId})
 					}
 				} else {
-					policies = append(policies, []string{userOrRole, resource, strings.ToLower(action), strings.ToLower(permission.Effect), "", permissionId})
+					policies = append(policies, []string{userOrRole, resource, action, strings.ToLower(permission.Effect), "", permissionId})
 				}
 			}
 		}


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/4019

if user uses custom resource type and configure the action by "POST" and try to call https://casdoor.org/docs/permission/exposed-casbin-apis#enforce with action "POST", it will fail because the database stores it as "post" not "POST"