### PR TITLE
feat: allow Custom OAuth provider to not fill in email and avatarUrl in configuring user_mapping

### DIFF
--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -174,7 +174,11 @@ class ProviderEditPage extends React.Component {
       }
     }
 
-    provider.userMapping[key] = value;
+    if (value === "") {
+      delete provider.userMapping[key];
+    } else {
+      provider.userMapping[key] = value;
+    }
 
     this.setState({
       provider: provider,


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/4021