### PR TITLE
feat: standardize Resource APIs by handling path prefix internally and returning clean paths

### DIFF
--- a/controllers/resource.go
+++ b/controllers/resource.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -186,6 +187,11 @@ func (c *ApiController) DeleteResource() {
 		return
 	}
 	_, resource.Name = refineFullFilePath(resource.Name)
+
+	tag := c.Input().Get("tag")
+	if tag == "Direct" {
+		resource.Name = path.Join(provider.PathPrefix, resource.Name)
+	}
 
 	err = object.DeleteFile(provider, resource.Name, c.GetAcceptLanguage())
 	if err != nil {

--- a/object/resource_direct.go
+++ b/object/resource_direct.go
@@ -31,9 +31,11 @@ func GetDirectResources(owner string, user string, provider *Provider, prefix st
 	fullPathPrefix := util.UrlJoin(provider.PathPrefix, prefix)
 	objects, err := storageProvider.List(fullPathPrefix)
 	for _, obj := range objects {
+		name := strings.TrimPrefix(obj.Path, "/")
+		name = strings.TrimPrefix(name, provider.PathPrefix+"/")
 		resource := &Resource{
 			Owner:       owner,
-			Name:        strings.TrimPrefix(obj.Path, "/"),
+			Name:        name,
 			CreatedTime: obj.LastModified.Local().Format(time.RFC3339),
 			User:        user,
 			Provider:    "",


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/4045