### PR TITLE
feat: add grouping policies for user group updates

### DIFF
--- a/object/permission.go
+++ b/object/permission.go
@@ -328,19 +328,12 @@ func DeletePermission(permission *Permission) (bool, error) {
 
 func getPermissionsByUser(userId string) ([]*Permission, error) {
 	permissions := []*Permission{}
-	err := ormer.Engine.Where("users like ? OR JSON_CONTAINS(users, '\"*\"', '$')", "%"+userId+"\"%").Find(&permissions)
+	err := ormer.Engine.Where("users like ? OR users like ?", `%"`+userId+`"%`, `%"*"%`).Find(&permissions)
 	if err != nil {
 		return permissions, err
 	}
 
-	res := []*Permission{}
-	for _, permission := range permissions {
-		if util.InSlice(permission.Users, userId) || util.InSlice(permission.Users, "*") {
-			res = append(res, permission)
-		}
-	}
-
-	return res, nil
+	return permissions, err
 }
 
 func GetPermissionsByRole(roleId string) ([]*Permission, error) {


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/4017
**Summary**  
At present, group memberships can **only** be changed from the **user UI**, not from the groups UI.  
This feels inconsistent with how roles are managed (roles are edited from the roles UI, not the user page).  

I propose that group memberships be managed **from the groups UI instead**, to match the roles workflow and avoid duplicating logic in the user UI.  

---

**Reasoning**  
- **Current approach:**  
  - When a user’s group membership changes, the update is made from the **user UI**.  
  - This means that, on **every user update**, I need to:  
    1. Iterate over **every permission** that has the desired groups (two separate filters).  
    2. Update those grouping policies for the user.  
  - This is costly because most grouping policies **never change** unless the group’s composition (membership or inheritane) changes.

- **Roles workflow (better pattern):**  
  - Roles are updated from the **roles UI**.  
  - Grouping policies for roles are only recalculated **when a role membership changes**, not every time a user is updated.  

- **Benefit of moving to groups UI:**  
  - We only recompute and apply group membership policies when **group membership changes**, not on unrelated user updates.  
  - This matches the roles pattern, avoids unnecessary work, and keeps logic consistent across the system.  

Also, the current implementation adds `group` grouping policies to **all** enforcers affecting the user, not just `user-enforcer`.  

---

**Next Steps / Open Questions**  

Possible approaches:  

1. **Full inheritance fix**  
   - Implement group inheritance so that each child group automatically has the roles/permissions of its parent.  
   - Add these inheritance grouping policies in all relevant enforcers, not just `user-enforcer`.  

2. **Minimal fix**  
   - Only fix this for `user-enforcer`.  
   - Require clients to make 2 ACL calls:  
     - One to their custom enforcer  
     - One to `user-enforcer`  

3. **Alternative approach**  
   - Open to other ideas from maintainers.  

---

**Example Inheritance Policy**  

| Rule type | sub                   | obj                        | act | Action |
|-----------|-----------------------|----------------------------|-----|--------|
| g         | org/user_2            | group:org/group-1          |     |        |
| g         | org/user_1            | group:org/group-sub-1      |     |        |
| g         | group:org/group-sub-1 | group:org/group-1          |     |        |

In this example:  
- `group-sub-1.parent = group-1`  
- This means `user_1` inherits permissions for `group-1` as well as `group-sub-1`.  

---

**Question for Maintainers**  
Before I proceed, I’d like feedback on:  
- Whether we should move group membership management to the groups UI  
- Which inheritance handling approach makes the most sense for Casdoor’s long-term direction  
