### PR TITLE
revert-4067-fix-provider-captcha

### DIFF
--- a/controllers/verification.go
+++ b/controllers/verification.go
@@ -147,11 +147,6 @@ func (c *ApiController) SendVerificationCode() {
 	}
 
 	if provider != nil {
-		if vform.CaptchaType != provider.Type {
-			c.ResponseError(c.T("verification:Turing test failed."))
-			return
-		}
-
 		if provider.Type != "Default" {
 			vform.ClientSecret = provider.ClientSecret
 		}


### PR DESCRIPTION
fix: allow CaptchaType="none" without provider type match in verification.go