### PR TITLE
fix: improve spacing between captcha input and image

### DIFF
--- a/web/src/common/modal/CaptchaModal.js
+++ b/web/src/common/modal/CaptchaModal.js
@@ -83,7 +83,7 @@ export const CaptchaModal = (props) => {
   const renderDefaultCaptcha = () => {
     if (noModal) {
       return (
-        <Row style={{textAlign: "center"}}>
+        <Row style={{textAlign: "center"}} gutter={10}>
           <Col
             style={{flex: noModal ? "70%" : "100%"}}>
             <Input


### PR DESCRIPTION
Added 10px gutter spacing to Row component in CaptchaModal when rendered inline to prevent captcha input field and image from appearing too close together.
fixes: #4072
<img width="1624" height="983" alt="图片" src="https://github.com/user-attachments/assets/48336c57-c505-402f-9f24-fadb5c6232fc" />
