### PR TITLE
feat: set name from email when resetting email

### DIFF
--- a/controllers/verification.go
+++ b/controllers/verification.go
@@ -435,9 +435,15 @@ func (c *ApiController) ResetEmailOrPhone() {
 
 	switch destType {
 	case object.VerifyTypeEmail:
+		id := user.GetId()
 		user.Email = dest
 		user.EmailVerified = true
-		_, err = object.UpdateUser(user.GetId(), user, []string{"email", "email_verified"}, false)
+		columns := []string{"email", "email_verified"}
+		if organization.UseEmailAsUsername {
+			user.Name = user.Email
+			columns = append(columns, "name")
+		}
+		_, err = object.UpdateUser(id, user, columns, false)
 	case object.VerifyTypePhone:
 		user.Phone = dest
 		_, err = object.SetUserField(user, "phone", user.Phone)
@@ -448,6 +454,9 @@ func (c *ApiController) ResetEmailOrPhone() {
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
+	}
+	if organization.UseEmailAsUsername {
+		c.SetSessionUsername(user.GetId())
 	}
 
 	err = object.DisableVerificationCode(checkDest)


### PR DESCRIPTION
When the UseEmailAsUsername option is enabled, automatically derive and set the user's name from their email address during the email reset process. This ensures consistency between the email and name fields in scenarios where email is used as the username.
