### PR TITLE
feat: Add "Send Invitation Email" action to User Invitation flow

### DIFF
--- a/email/azure_acs.go
+++ b/email/azure_acs.go
@@ -116,9 +116,41 @@ func newEmail(fromAddress string, toAddress string, subject string, content stri
 	}
 }
 
+func newEmailMulti(fromAddress string, toAddress []string, subject string, content string) *Email {
+	var to []EmailAddress
+	for _, addr := range toAddress {
+		to = append(to, EmailAddress{
+			DisplayName: addr,
+			Address:     addr,
+		})
+	}
+	return &Email{
+		Recipients: Recipients{
+			To: to,
+		},
+		SenderAddress: fromAddress,
+		Content: Content{
+			Subject: subject,
+			HTML:    content,
+		},
+		Importance:  importanceNormal,
+		Attachments: []Attachment{},
+	}
+}
+
 func (a *AzureACSEmailProvider) Send(fromAddress string, fromName string, toAddress string, subject string, content string) error {
 	email := newEmail(fromAddress, toAddress, subject, content)
 
+	return a.send(email)
+}
+
+func (a *AzureACSEmailProvider) SendMulti(fromAddress string, fromName string, toAddress []string, subject string, content string) error {
+	email := newEmailMulti(fromAddress, toAddress, subject, content)
+
+	return a.send(email)
+}
+
+func (a *AzureACSEmailProvider) send(email *Email) error {
 	postBody, err := json.Marshal(email)
 	if err != nil {
 		return err

--- a/email/custom_http.go
+++ b/email/custom_http.go
@@ -130,3 +130,90 @@ func (c *HttpEmailProvider) Send(fromAddress string, fromName string, toAddress 
 
 	return err
 }
+
+func (c *HttpEmailProvider) SendMulti(fromAddress string, fromName string, toAddress []string, subject string, content string) error {
+	var req *http.Request
+	var err error
+
+	fromNameField := "fromName"
+	toAddressesField := "toAddresses"
+	subjectField := "subject"
+	contentField := "content"
+
+	for k, v := range c.bodyMapping {
+		switch k {
+		case "fromName":
+			fromNameField = v
+		case "toAddresses":
+			toAddressesField = v
+		case "subject":
+			subjectField = v
+		case "content":
+			contentField = v
+		}
+	}
+
+	if c.method == "POST" || c.method == "PUT" || c.method == "DELETE" {
+		bodyMap := make(map[string]string)
+		bodyMap[fromNameField] = fromName
+		bodyMap[subjectField] = subject
+		bodyMap[contentField] = content
+
+		var fromValueBytes []byte
+		if c.contentType == "application/json" {
+			fromValueBytes, err = json.Marshal(bodyMap)
+			if err != nil {
+				return err
+			}
+			req, err = http.NewRequest(c.method, c.endpoint, bytes.NewBuffer(fromValueBytes))
+		} else {
+			formValues := url.Values{}
+			for k, v := range bodyMap {
+				formValues.Add(k, v)
+			}
+			for _, addr := range toAddress {
+				formValues.Add(toAddressesField, addr)
+			}
+			req, err = http.NewRequest(c.method, c.endpoint, strings.NewReader(formValues.Encode()))
+		}
+
+		if err != nil {
+			return err
+		}
+
+		req.Header.Set("Content-Type", c.contentType)
+	} else if c.method == "GET" {
+		req, err = http.NewRequest(c.method, c.endpoint, nil)
+		if err != nil {
+			return err
+		}
+
+		q := req.URL.Query()
+		q.Add(fromNameField, fromName)
+		for _, address := range toAddress {
+			q.Add(toAddressesField, address)
+		}
+		q.Add(subjectField, subject)
+		q.Add(contentField, content)
+		req.URL.RawQuery = q.Encode()
+	} else {
+		return fmt.Errorf("HttpEmailProvider's Send() error, unsupported method: %s", c.method)
+	}
+
+	for k, v := range c.httpHeaders {
+		req.Header.Set(k, v)
+	}
+
+	httpClient := proxy.DefaultHttpClient
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HttpEmailProvider's Send() error, custom HTTP Email request failed with status: %s", resp.Status)
+	}
+
+	return err
+}

--- a/email/provider.go
+++ b/email/provider.go
@@ -16,6 +16,7 @@ package email
 
 type EmailProvider interface {
 	Send(fromAddress string, fromName, toAddress string, subject string, content string) error
+	SendMulti(fromAddress string, fromName string, toAddress []string, subject string, content string) error
 }
 
 func GetEmailProvider(typ string, clientId string, clientSecret string, host string, port int, disableSsl bool, endpoint string, method string, httpHeaders map[string]string, bodyMapping map[string]string, contentType string) EmailProvider {

--- a/email/smtp.go
+++ b/email/smtp.go
@@ -55,3 +55,19 @@ func (s *SmtpEmailProvider) Send(fromAddress string, fromName string, toAddress 
 	message.SkipUsernameCheck = true
 	return s.Dialer.DialAndSend(message)
 }
+
+func (s *SmtpEmailProvider) SendMulti(fromAddress string, fromName string, toAddresses []string, subject string, content string) error {
+	message := gomail.NewMessage()
+
+	message.SetAddressHeader("From", fromAddress, fromName)
+	var addresses []string
+	for _, address := range toAddresses {
+		addresses = append(addresses, message.FormatAddress(address, ""))
+	}
+	message.SetHeader("To", addresses...)
+	message.SetHeader("Subject", subject)
+	message.SetBody("text/html", content)
+
+	message.SkipUsernameCheck = true
+	return s.Dialer.DialAndSend(message)
+}

--- a/object/email.go
+++ b/object/email.go
@@ -45,3 +45,19 @@ func SendEmail(provider *Provider, title string, content string, dest string, se
 
 	return emailProvider.Send(fromAddress, fromName, dest, title, content)
 }
+
+func SendEmailMulti(provider *Provider, title string, content string, dest []string, sender string) error {
+	emailProvider := email.GetEmailProvider(provider.Type, provider.ClientId, provider.ClientSecret, provider.Host, provider.Port, provider.DisableSsl, provider.Endpoint, provider.Method, provider.HttpHeaders, provider.UserMapping, provider.IssuerUrl)
+
+	fromAddress := provider.ClientId2
+	if fromAddress == "" {
+		fromAddress = provider.ClientId
+	}
+
+	fromName := provider.ClientSecret2
+	if fromName == "" {
+		fromName = sender
+	}
+
+	return emailProvider.SendMulti(fromAddress, fromName, dest, title, content)
+}

--- a/object/invitation.go
+++ b/object/invitation.go
@@ -235,3 +235,8 @@ func (invitation *Invitation) IsInvitationCodeValid(application *Application, in
 	}
 	return true, ""
 }
+
+func (invitation *Invitation) GetInvitationLink(host string, application string) string {
+	frontEnd, _ := getOriginFromHost(host)
+	return fmt.Sprintf("%s/signup/%s?invitationCode=%s", frontEnd, application, invitation.Code)
+}

--- a/routers/router.go
+++ b/routers/router.go
@@ -102,6 +102,7 @@ func initAPI() {
 	beego.Router("/api/add-invitation", &controllers.ApiController{}, "POST:AddInvitation")
 	beego.Router("/api/delete-invitation", &controllers.ApiController{}, "POST:DeleteInvitation")
 	beego.Router("/api/verify-invitation", &controllers.ApiController{}, "GET:VerifyInvitation")
+	beego.Router("/api/send-invitation", &controllers.ApiController{}, "POST:SendInvitation")
 
 	beego.Router("/api/get-applications", &controllers.ApiController{}, "GET:GetApplications")
 	beego.Router("/api/get-application", &controllers.ApiController{}, "GET:GetApplication")

--- a/web/src/InvitationEditPage.js
+++ b/web/src/InvitationEditPage.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from "react";
-import {Button, Card, Col, Input, InputNumber, Row, Select} from "antd";
+import {Button, Card, Col, Input, InputNumber, Modal, Row, Select, Table} from "antd";
 import {CopyOutlined} from "@ant-design/icons";
 import * as InvitationBackend from "./backend/InvitationBackend";
 import * as OrganizationBackend from "./backend/OrganizationBackend";
@@ -22,6 +22,8 @@ import * as Setting from "./Setting";
 import i18next from "i18next";
 import copy from "copy-to-clipboard";
 import * as GroupBackend from "./backend/GroupBackend";
+import {isValidEmail} from "./Setting";
+import {sendInvitation} from "./backend/InvitationBackend";
 
 const {Option} = Select;
 
@@ -37,6 +39,7 @@ class InvitationEditPage extends React.Component {
       applications: [],
       groups: [],
       mode: props.location.mode !== undefined ? props.location.mode : "edit",
+      sendLoading: false,
     };
   }
 
@@ -123,6 +126,35 @@ class InvitationEditPage extends React.Component {
     Setting.showMessage("success", i18next.t("general:Copied to clipboard successfully"));
   }
 
+  renderSendEmailModal() {
+    const emailColumns = [
+      {title: "email", dataIndex: "email"},
+    ];
+    const emails = this.state.emails?.split("\n")?.filter(email => isValidEmail(email));
+    const emailData = emails?.map((email) => {return {email: email};});
+
+    return <Modal title={i18next.t("general:Send")}
+      style={{height: "800px"}}
+      open={this.state.showSendModal}
+      closable
+      footer={[
+        <Button key={1} loading={this.state.sendLoading} type="primary"
+          onClick={() => {
+            this.setState({sendLoading: true});
+            sendInvitation(this.state.invitation, emails).then(() => {
+              this.setState({sendLoading: false});
+              Setting.showMessage("success", "Successfully sent");
+            }).catch(err => Setting.showMessage("success", err.message));
+          }}>{i18next.t("general:Send")}</Button>,
+      ]}
+      onCancel={() => {this.setState({showSendModal: false});}}>
+      <div >
+        <p>You will send invitation email to:</p>
+        <Table showHeader={false} columns={emailColumns} dataSource={emailData} size={"small"}></Table>
+      </div>
+    </Modal>;
+  }
+
   renderInvitation() {
     const isCreatedByPlan = this.state.invitation.tag === "auto_created_invitation_for_plan";
     return (
@@ -197,6 +229,17 @@ class InvitationEditPage extends React.Component {
             <Button style={{marginBottom: "10px"}} type="primary" shape="round" icon={<CopyOutlined />} onClick={_ => this.copySignupLink()}>
               {i18next.t("application:Copy signup page URL")}
             </Button>
+          </Col>
+        </Row>
+        <Row style={{marginTop: "20px"}} >
+          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+            {i18next.t("general:Send")}
+          </Col>
+          <Col span={22} >
+            <Input.TextArea autoSize={{minRows: 3, maxRows: 10}} value={this.state.emails} onChange={(value) => {
+              this.setState({emails: value.target.value});
+            }}></Input.TextArea>
+            <Button type="primary" style={{marginTop: "20px"}} onClick={() => this.setState({showSendModal: true})}>{i18next.t("general:Send")}</Button>
           </Col>
         </Row>
         <Row style={{marginTop: "20px"}} >
@@ -338,6 +381,7 @@ class InvitationEditPage extends React.Component {
   render() {
     return (
       <div>
+        {this.state.showSendModal ? this.renderSendEmailModal() : null}
         {
           this.state.invitation !== null ? this.renderInvitation() : null
         }

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -597,6 +597,7 @@ class ProviderEditPage extends React.Component {
                 this.updateProviderField("disableSsl", false);
                 this.updateProviderField("title", "Casdoor Verification Code");
                 this.updateProviderField("content", Setting.getDefaultHtmlEmailContent());
+                this.updateProviderField("metadata", Setting.getDefaultInvitationHtmlEmailContent());
                 this.updateProviderField("receiver", this.props.account.email);
               } else if (value === "SMS") {
                 this.updateProviderField("type", "Twilio SMS");
@@ -1266,6 +1267,42 @@ class ProviderEditPage extends React.Component {
                     <Col span={Setting.isMobile() ? 22 : 11}>
                       <div style={{margin: "10px"}}>
                         <div dangerouslySetInnerHTML={{__html: this.state.provider.content.replace("%s", "123456").replace("%{user.friendlyName}", Setting.getFriendlyUserName(this.props.account))}} />
+                      </div>
+                    </Col>
+                  </Row>
+                </Col>
+              </Row>
+              <Row style={{marginTop: "20px"}} >
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {Setting.getLabel(i18next.t("provider:Email invitation content"), i18next.t("provider:Email invitation content - Tooltip"))} :
+                </Col>
+                <Col span={22} >
+                  <Row style={{marginTop: "20px"}} >
+                    <Button style={{marginLeft: "10px", marginBottom: "5px"}} onClick={() => this.updateProviderField("metadata", "You have invited to join Casdoor. Here is your invitation code: %s, please enter in 5 minutes. Or click %link to signup")} >
+                      {i18next.t("provider:Reset to Default Text")}
+                    </Button>
+                    <Button style={{marginLeft: "10px", marginBottom: "5px"}} type="primary" onClick={() => this.updateProviderField("metadata", Setting.getDefaultInvitationHtmlEmailContent())} >
+                      {i18next.t("provider:Reset to Default HTML")}
+                    </Button>
+                  </Row>
+                  <Row>
+                    <Col span={Setting.isMobile() ? 22 : 11}>
+                      <div style={{height: "300px", margin: "10px"}}>
+                        <Editor
+                          value={this.state.provider.metadata}
+                          fillHeight
+                          dark
+                          lang="html"
+                          onChange={value => {
+                            this.updateProviderField("metadata", value);
+                          }}
+                        />
+                      </div>
+                    </Col>
+                    <Col span={1} />
+                    <Col span={Setting.isMobile() ? 22 : 11}>
+                      <div style={{margin: "10px"}}>
+                        <div dangerouslySetInnerHTML={{__html: this.state.provider.metadata.replace("%code", "123456")}} />
                       </div>
                     </Col>
                   </Row>

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -1648,6 +1648,48 @@ export function getDefaultHtmlEmailContent() {
 </html>`;
 }
 
+export function getDefaultInvitationHtmlEmailContent() {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Verification Code Email</title>
+<style>
+    body { font-family: Arial, sans-serif; }
+    .email-container { width: 600px; margin: 0 auto; }
+    .header { text-align: center; }
+    .code { font-size: 24px; margin: 20px 0; text-align: center; }
+    .footer { font-size: 12px; text-align: center; margin-top: 50px; }
+    .footer a { color: #000; text-decoration: none; }
+</style>
+</head>
+<body>
+<div class="email-container">
+  <div class="header">
+        <h3>Casbin Organization</h3>
+        <img src="${StaticBaseUrl}/img/casdoor-logo_1185x256.png" alt="Casdoor Logo" width="300">
+    </div>
+    <p>You have been invited into casdoor</p>
+    <div class="code">
+        %code
+    </div>
+    <reset-link>
+      <div class="link">
+         Or click this <a href="%link">link</a> to signup
+      </div>
+    </reset-link>
+    <p>Thanks</p>
+    <p>Casbin Team</p>
+    <hr>
+    <div class="footer">
+        <p>Casdoor is a brand operated by Casbin organization. For more info please refer to <a href="https://casdoor.org">https://casdoor.org</a></p>
+    </div>
+</div>
+</body>
+</html>`;
+}
+
 export function getCurrencyText(product) {
   if (product?.currency === "USD") {
     return i18next.t("currency:USD");

--- a/web/src/backend/InvitationBackend.js
+++ b/web/src/backend/InvitationBackend.js
@@ -89,3 +89,14 @@ export function verifyInvitation(owner, name) {
     },
   }).then(res => res.json());
 }
+
+export function sendInvitation(invitation, destinations) {
+  return fetch(`${Setting.ServerUrl}/api/send-invitation?id=${invitation.owner}/${encodeURIComponent(invitation.name)}`, {
+    method: "POST",
+    credentials: "include",
+    body: JSON.stringify(destinations),
+    headers: {
+      "Accept-Language": Setting.getAcceptLanguage(),
+    },
+  }).then(res => res.json());
+}


### PR DESCRIPTION
feat: #3942 

- Add "Send Invitation Email" action to User Invitation flow and reuse metadata field to support invitation email template
- add `SendMulti` to all email provider to send multiple email easily