### PR TITLE
feat: add username and loginHint to redirect URL in HandleSamlRedirect of SAML IdP

### DIFF
--- a/controllers/saml.go
+++ b/controllers/saml.go
@@ -59,8 +59,10 @@ func (c *ApiController) HandleSamlRedirect() {
 
 	relayState := c.Input().Get("RelayState")
 	samlRequest := c.Input().Get("SAMLRequest")
+	username := c.Input().Get("username")
+	loginHint := c.Input().Get("login_hint")
 
-	targetURL := object.GetSamlRedirectAddress(owner, application, relayState, samlRequest, host)
+	targetURL := object.GetSamlRedirectAddress(owner, application, relayState, samlRequest, host, username, loginHint)
 
 	c.Redirect(targetURL, http.StatusSeeOther)
 }

--- a/object/saml_idp.go
+++ b/object/saml_idp.go
@@ -26,9 +26,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 	"time"
-	"net/url"
 
 	"github.com/beevik/etree"
 	"github.com/golang-jwt/jwt/v5"

--- a/object/saml_idp.go
+++ b/object/saml_idp.go
@@ -28,6 +28,7 @@ import (
 	"io"
 	"strings"
 	"time"
+	"net/url"
 
 	"github.com/beevik/etree"
 	"github.com/golang-jwt/jwt/v5"
@@ -549,13 +550,12 @@ func NewSamlResponse11(application *Application, user *User, requestID string, h
 
 func GetSamlRedirectAddress(owner string, application string, relayState string, samlRequest string, host string, username string, loginHint string) string {
 	originF, _ := getOriginFromHost(host)
-	baseURL := fmt.Sprintf("%s/login/saml/authorize/%s/%s", originF, owner, application)
-	params := fmt.Sprintf("relayState=%s&samlRequest=%s", relayState, samlRequest)
+	baseURL := fmt.Sprintf("%s/login/saml/authorize/%s/%s?relayState=%s&samlRequest=%s", originF, owner, application, relayState, samlRequest)
 	if username != "" {
-		params += fmt.Sprintf("&username=%s", username)
+		baseURL += fmt.Sprintf("&username=%s", url.QueryEscape(username))
 	}
 	if loginHint != "" {
-		params += fmt.Sprintf("&login_hint=%s", loginHint)
+		baseURL += fmt.Sprintf("&login_hint=%s", url.QueryEscape(loginHint))
 	}
-	return fmt.Sprintf("%s?%s", baseURL, params)
+	return baseURL
 }

--- a/object/saml_idp.go
+++ b/object/saml_idp.go
@@ -547,7 +547,15 @@ func NewSamlResponse11(application *Application, user *User, requestID string, h
 	return samlResponse, nil
 }
 
-func GetSamlRedirectAddress(owner string, application string, relayState string, samlRequest string, host string) string {
+func GetSamlRedirectAddress(owner string, application string, relayState string, samlRequest string, host string, username string, loginHint string) string {
 	originF, _ := getOriginFromHost(host)
-	return fmt.Sprintf("%s/login/saml/authorize/%s/%s?relayState=%s&samlRequest=%s", originF, owner, application, relayState, samlRequest)
+	baseURL := fmt.Sprintf("%s/login/saml/authorize/%s/%s", originF, owner, application)
+	params := fmt.Sprintf("relayState=%s&samlRequest=%s", relayState, samlRequest)
+	if username != "" {
+		params += fmt.Sprintf("&username=%s", username)
+	}
+	if loginHint != "" {
+		params += fmt.Sprintf("&login_hint=%s", loginHint)
+	}
+	return fmt.Sprintf("%s?%s", baseURL, params)
 }


### PR DESCRIPTION
As shown in this figure (Microsoft as SP for SAML login), the username parameter is not passed to the login page after redirection, resulting in the failure of the auto-fill username function. 
#4159
The purpose of this PR is to fix this issue.
<img width="1474" height="832" alt="image" src="https://github.com/user-attachments/assets/83fcaaa0-ff58-464f-a5b1-9149d40446ef" />
<img width="1672" height="842" alt="image" src="https://github.com/user-attachments/assets/dd61d5e7-0ba5-4fe3-8c70-adae9b8deeaa" />
