### PR TITLE
feat: add webhook for buy-product and add resp data

### DIFF
--- a/object/record.go
+++ b/object/record.go
@@ -43,6 +43,8 @@ type Record struct {
 type Response struct {
 	Status string `json:"status"`
 	Msg    string `json:"msg"`
+
+	Data interface{} `json:"data"`
 }
 
 func maskPassword(recordString string) string {
@@ -74,6 +76,19 @@ func NewRecord(ctx *context.Context) (*casvisorsdk.Record, error) {
 		return nil, err
 	}
 
+	if action != "buy-product" {
+		resp.Data = nil
+	}
+
+	dataResp := ""
+	if resp.Data != nil {
+		dataByte, err := json.Marshal(resp.Data)
+		if err != nil {
+			return nil, err
+		}
+		dataResp = fmt.Sprintf(", data:%s", string(dataByte))
+	}
+
 	language := ctx.Request.Header.Get("Accept-Language")
 	if len(language) > 2 {
 		language = language[0:2]
@@ -91,7 +106,7 @@ func NewRecord(ctx *context.Context) (*casvisorsdk.Record, error) {
 		Language:    languageCode,
 		Object:      object,
 		StatusCode:  200,
-		Response:    fmt.Sprintf("{status:\"%s\", msg:\"%s\"}", resp.Status, resp.Msg),
+		Response:    fmt.Sprintf("{status:\"%s\", msg:\"%s\"%s}", resp.Status, resp.Msg, dataResp),
 		IsTriggered: false,
 	}
 	return &record, nil

--- a/web/src/WebhookEditPage.js
+++ b/web/src/WebhookEditPage.js
@@ -171,6 +171,9 @@ class WebhookEditPage extends React.Component {
       if (obj === "payment") {
         res.push("invoice-payment", "notify-payment");
       }
+      if (obj === "product") {
+        res.push("buy-product");
+      }
     });
     return res;
   }


### PR DESCRIPTION
Replace: https://github.com/casdoor/casdoor/pull/4173

use existing code to send webhook, not only support subscription but support all buy-product request, and add response data to record for receiver to read payment info