### PR TITLE
feat: separate getLocalPrimaryKey() and getTargetTablePrimaryKey() in DB syncer

### DIFF
--- a/object/syncer.go
+++ b/object/syncer.go
@@ -273,9 +273,14 @@ func (syncer *Syncer) getKeyColumn() *TableColumn {
 	return column
 }
 
-func (syncer *Syncer) getKey() string {
+func (syncer *Syncer) getLocalPrimaryKey() string {
 	column := syncer.getKeyColumn()
 	return util.CamelToSnakeCase(column.CasdoorName)
+}
+
+func (syncer *Syncer) getTargetTablePrimaryKey() string {
+	column := syncer.getKeyColumn()
+	return column.Name
 }
 
 func RunSyncer(syncer *Syncer) error {

--- a/object/syncer_sync.go
+++ b/object/syncer_sync.go
@@ -65,7 +65,7 @@ func (syncer *Syncer) syncUsers() error {
 		}
 	}
 
-	key := syncer.getKey()
+	key := syncer.getLocalPrimaryKey()
 
 	myUsers := map[string]*User{}
 	for _, m := range users {

--- a/object/syncer_user.go
+++ b/object/syncer_user.go
@@ -75,7 +75,7 @@ func (syncer *Syncer) getCasdoorColumns() []string {
 }
 
 func (syncer *Syncer) updateUser(user *OriginalUser) (bool, error) {
-	key := syncer.getKey()
+	key := syncer.getTargetTablePrimaryKey()
 	m := syncer.getMapFromOriginalUser(user)
 	pkValue := m[key]
 	delete(m, key)


### PR DESCRIPTION
fix: https://github.com/casdoor/casdoor/issues/4147


https://github.com/user-attachments/assets/ac5ad6d8-1c16-42ea-b229-6b5fc2e7ef29

