### PR TITLE
feat: skip old password verification for OAuth users without a password

### DIFF
--- a/controllers/user.go
+++ b/controllers/user.go
@@ -524,7 +524,10 @@ func (c *ApiController) SetPassword() {
 			}
 		}
 	} else if code == "" {
-		if user.Ldap == "" {
+		// For OAuth users who don't have a password set, skip old password verification
+		if targetUser.Password == "" && user.Ldap == "" {
+			// OAuth user without password - no need to verify old password
+		} else if user.Ldap == "" {
 			err = object.CheckPassword(targetUser, oldPassword, c.GetAcceptLanguage())
 		} else {
 			err = object.CheckLdapUserPassword(targetUser, oldPassword, c.GetAcceptLanguage())

--- a/object/check.go
+++ b/object/check.go
@@ -392,14 +392,20 @@ func CheckUserPassword(organization string, username string, password string, la
 			return nil, recordSigninErrorInfo(user, lang, enableCaptcha)
 		}
 	} else {
-		err = CheckPassword(user, password, lang, enableCaptcha)
-		if err != nil {
-			return nil, err
-		}
+		// For OAuth users who don't have a password set, skip password verification
+		if user.Password == "" && password == "" {
+			// OAuth user without password - allow access without password verification
+			// This is used in scenarios like MFA setup where OAuth users need to proceed
+		} else {
+			err = CheckPassword(user, password, lang, enableCaptcha)
+			if err != nil {
+				return nil, err
+			}
 
-		err = checkPasswordExpired(user, lang)
-		if err != nil {
-			return nil, err
+			err = checkPasswordExpired(user, lang)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/object/token_oauth.go
+++ b/object/token_oauth.go
@@ -537,6 +537,13 @@ func GetPasswordToken(application *Application, username string, password string
 	if user.Ldap != "" {
 		err = CheckLdapUserPassword(user, password, "en")
 	} else {
+		// For OAuth users who don't have a password set, they cannot use password grant type
+		if user.Password == "" {
+			return nil, &TokenError{
+				Error:            InvalidGrant,
+				ErrorDescription: "OAuth users cannot use password grant type, please use authorization code flow",
+			}, nil
+		}
 		err = CheckPassword(user, password, "en")
 	}
 	if err != nil {


### PR DESCRIPTION
I'm facing a problem that users who registered their account through OAuth can't change their password in the manage page. So I tried to fix the problem.


This pull request introduces improvements to authentication logic for OAuth users and adds a comprehensive Casdoor architecture and development guide for AI agents. The main focus is on handling password verification for OAuth users who do not have a password set, ensuring proper access control and error handling in various authentication scenarios.

**Authentication Logic Improvements**

* Password verification is now skipped for OAuth users who do not have a password set, allowing them to proceed in scenarios like MFA setup and password change without requiring an old password. [[1]](diffhunk://#diff-64a63228546ebdbd9a1ee7a43793f89b24047f3bd080a952d86abdd38ed2b258L527-R530) [[2]](diffhunk://#diff-8cd443ab0f47d0d05db201355fb82a567f9dce59f45203b2e386ab9a56d15a63R394-R398)
* The password grant type in OAuth token generation is now explicitly disallowed for OAuth users without a password, returning a clear error message and enforcing the use of the authorization code flow instead.