### PR TITLE
feat: fix missing subject in Sendgrid Email provider

### DIFF
--- a/email/sendgrid.go
+++ b/email/sendgrid.go
@@ -54,6 +54,8 @@ func (s *SendgridEmailProvider) Send(fromAddress string, fromName string, toAddr
 		personalization.AddTos(to)
 	}
 
+	personalization.Subject = subject
+
 	message.AddPersonalizations(personalization)
 
 	client := s.initSendgridClient()


### PR DESCRIPTION
Sendgrid provider is failing with: 
<img width="1370" height="117" alt="Screenshot 2025-10-01 at 3 34 01 PM" src="https://github.com/user-attachments/assets/8a2de86d-141f-451c-9e81-8e934c806147" />

This PR sets the Subject so it can be sent.