### PR TITLE
feat: accept if the certificate is of type PEM as well

### DIFF
--- a/object/saml_sp.go
+++ b/object/saml_sp.go
@@ -159,11 +159,11 @@ func buildSpCertificateStore(provider *Provider, samlResponse string) (certStore
 		// this was a PEM file
 		// block.Bytes are DER encoded so the following code block should happily accept it
 		certData = block.Bytes
-	}
-
-	certData, err = base64.StdEncoding.DecodeString(certEncodedData)
-	if err != nil {
-		return dsig.MemoryX509CertificateStore{}, err
+	} else {
+		certData, err = base64.StdEncoding.DecodeString(certEncodedData)
+		if err != nil {
+			return dsig.MemoryX509CertificateStore{}, err
+		}
 	}
 
 	idpCert, err := x509.ParseCertificate(certData)

--- a/object/saml_sp.go
+++ b/object/saml_sp.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -152,10 +153,19 @@ func buildSpCertificateStore(provider *Provider, samlResponse string) (certStore
 		certEncodedData = provider.IdP
 	}
 
-	certData, err := base64.StdEncoding.DecodeString(certEncodedData)
+	var certData []byte
+	block, _ := pem.Decode(certData)
+	if block != nil {
+		// this was a PEM file
+		// block.Bytes are DER encoded so the following code block should happily accept it
+		certData = block.Bytes
+	}
+
+	certData, err = base64.StdEncoding.DecodeString(certEncodedData)
 	if err != nil {
 		return dsig.MemoryX509CertificateStore{}, err
 	}
+
 	idpCert, err := x509.ParseCertificate(certData)
 	if err != nil {
 		return dsig.MemoryX509CertificateStore{}, err


### PR DESCRIPTION
Currently, our SAML parser only accepts a DER file. This PR is supposed to add support for PEM files as an optional valid type as well.

