### PR TITLE
feat: fix QRCode param error in payUrl and successUrl

### DIFF
--- a/web/src/ProductBuyPage.js
+++ b/web/src/ProductBuyPage.js
@@ -243,7 +243,7 @@ class ProductBuyPage extends React.Component {
               this.callWechatPay(attachInfo);
               return ;
             }
-            payUrl = `/qrcode/${payment.owner}/${payment.name}?providerName=${provider.name}&payUrl=${encodeURI(payment.payUrl)}&successUrl=${encodeURI(payment.successUrl)}`;
+            payUrl = `/qrcode/${payment.owner}/${payment.name}?providerName=${provider.name}&payUrl=${encodeURIComponent(payment.payUrl)}&successUrl=${encodeURIComponent(payment.successUrl)}`;
           }
           Setting.goToLink(payUrl);
         } else {


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor/issues/4272

fix: fix qrcode param error #4272

encodeURI will not encode the special character of url, so we need to use encodeURIComponent to solve this problem