### PR TITLE
fix(provider): change "from address" → "to address"

### DIFF
--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -271,7 +271,7 @@ class ProviderEditPage extends React.Component {
         <Input value={this.state.provider.userMapping.fromName} onChange={e => {
           this.updateUserMappingField("fromName", e.target.value);
         }} />
-        {Setting.getLabel(i18next.t("provider:From address"), i18next.t("provider:From address - Tooltip"))} :
+        {Setting.getLabel(i18next.t("provider:To address"), i18next.t("provider:To address - Tooltip"))} :
         <Input value={this.state.provider.userMapping.toAddress} onChange={e => {
           this.updateUserMappingField("toAddress", e.target.value);
         }} />

--- a/web/src/locales/de/data.json
+++ b/web/src/locales/de/data.json
@@ -919,6 +919,8 @@
     "Follow-up action - Tooltip": "Wenn Sie „WeChat Open Platform zur Anmeldung verwenden“ wählen, müssen Benutzer sich nach dem Folgen des offiziellen Kontos auf der WeChat Open Platform anmelden.",
     "From address": "Absenderadresse",
     "From address - Tooltip": "Von Adresse",
+    "To address": "Empfängeradresse",
+    "To address - Tooltip": "E-Mail-Adresse des Empfängers",
     "From name": "Absendername",
     "From name - Tooltip": "Von Name",
     "Get phone number": "Telefonnummer abrufen",

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -919,6 +919,8 @@
     "Follow-up action - Tooltip": "If you choose \"Use WeChat Open Platform to login\", users need to login on the WeChat Open Platform after following the wechat official account.",
     "From address": "From address",
     "From address - Tooltip": "Email address of \"From\"",
+    "To address": "To address",
+    "To address - Tooltip": "Email address of \"To\"",
     "From name": "From name",
     "From name - Tooltip": "Name of \"From\"",
     "Get phone number": "Get phone number",

--- a/web/src/locales/es/data.json
+++ b/web/src/locales/es/data.json
@@ -919,6 +919,8 @@
     "Follow-up action - Tooltip": "Si eliges \"Usar la plataforma abierta de WeChat para iniciar sesión\", los usuarios deben iniciar sesión en la plataforma abierta de WeChat después de seguir la cuenta oficial de WeChat.",
     "From address": "Dirección de origen",
     "From address - Tooltip": "Desde dirección",
+    "To address": "Dirección del destinatario",
+    "To address - Tooltip": "Dirección de correo electrónico del destinatario",
     "From name": "Nombre de origen",
     "From name - Tooltip": "Desde nombre",
     "Get phone number": "Obtener número de teléfono",

--- a/web/src/locales/fr/data.json
+++ b/web/src/locales/fr/data.json
@@ -919,6 +919,8 @@
     "Follow-up action - Tooltip": "Si vous choisissez \"Utiliser la plateforme ouverte WeChat pour se connecter\", les utilisateurs doivent se connecter sur la plateforme ouverte WeChat après avoir suivi le compte officiel WeChat.",
     "From address": "Adresse de l'expéditeur",
     "From address - Tooltip": "Depuis l'adresse",
+    "To address": "Adresse du destinataire",
+    "To address - Tooltip": "Adresse e-mail du destinataire",
     "From name": "Nom de l'expéditeur",
     "From name - Tooltip": "Depuis le nom",
     "Get phone number": "Obtenir le numéro de téléphone",

--- a/web/src/locales/it/data.json
+++ b/web/src/locales/it/data.json
@@ -919,6 +919,8 @@
     "Follow-up action - Tooltip": "Se scegli \"Usa WeChat Open Platform per accedere\", gli utenti dovranno autenticarsi su WeChat Open Platform dopo aver seguito l'account ufficiale",
     "From address": "Indirizzo mittente",
     "From address - Tooltip": "Indirizzo Email di \"Da\"",
+    "To address": "Indirizzo destinatario",
+    "To address - Tooltip": "Indirizzo email del destinatario",
     "From name": "Nome mittente",
     "From name - Tooltip": "Nome di \"Da\"",
     "Get phone number": "Ottieni numero di telefono",

--- a/web/src/locales/ja/data.json
+++ b/web/src/locales/ja/data.json
@@ -919,6 +919,8 @@
     "Follow-up action - Tooltip": "「WeChat Open Platformでログイン」を選択した場合、ユーザーはWeChat公式アカウントをフォローした後にWeChat Open Platformでログインする必要があります",
     "From address": "送信元アドレス",
     "From address - Tooltip": "送信元アドレス",
+    "To address": "宛先アドレス",
+    "To address - Tooltip": "宛先のメールアドレス",
     "From name": "送信元名",
     "From name - Tooltip": "送信元名",
     "Get phone number": "電話番号を取得",

--- a/web/src/locales/ko/data.json
+++ b/web/src/locales/ko/data.json
@@ -919,6 +919,8 @@
     "Follow-up action - Tooltip": "\\\"위챗 오픈 플랫폼으로 로그인\\\"을 선택하면, 사용자는 위챗 공식 계정을 팔로우한 후 위챗 오픈 플랫폼에서 로그인해야 합니다.",
     "From address": "보낸 주소",
     "From address - Tooltip": "발신자 이메일 주소",
+    "To address": "받는 주소",
+    "To address - Tooltip": "받는 사람 이메일 주소",
     "From name": "보낸 이름",
     "From name - Tooltip": "발신자 표시 이름",
     "Get phone number": "전화번호 가져오기",

--- a/web/src/locales/pt/data.json
+++ b/web/src/locales/pt/data.json
@@ -919,6 +919,8 @@
     "Follow-up action - Tooltip": "Se você escolher \"Usar WeChat Open Platform para login\", os usuários precisarão fazer login na WeChat Open Platform após seguir a conta oficial WeChat.",
     "From address": "Endereço de origem",
     "From address - Tooltip": "Endereço de e-mail do remetente",
+    "To address": "Endereço do destinatário",
+    "To address - Tooltip": "Endereço de e-mail do destinatário",
     "From name": "Nome de origem",
     "From name - Tooltip": "Nome do remetente",
     "Get phone number": "Obter número de telefone",

--- a/web/src/locales/ru/data.json
+++ b/web/src/locales/ru/data.json
@@ -919,6 +919,8 @@
     "Follow-up action - Tooltip": "Если вы выберете \"Использовать WeChat Open Platform для входа\", пользователям нужно будет войти на WeChat Open Platform после подписки на официальный аккаунт.",
     "From address": "Адрес отправителя",
     "From address - Tooltip": "Адрес электронной почты отправителя",
+    "To address": "Адрес получателя",
+    "To address - Tooltip": "Адрес электронной почты получателя",
     "From name": "Имя отправителя",
     "From name - Tooltip": "Отображаемое имя отправителя",
     "Get phone number": "Получить номер телефона",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -919,6 +919,8 @@
     "Follow-up action - Tooltip": "如果你选择“使用微信开放平台进行登录”，用户在扫描二维码并关注公众号后需要在微信开放平台进行登录",
     "From address": "发件人地址",
     "From address - Tooltip": "邮件里发件人的邮箱地址",
+    "To address": "收件人地址",
+    "To address - Tooltip": "收件人的邮箱",
     "From name": "发件人名称",
     "From name - Tooltip": "邮件里发件人的显示名称",
     "Get phone number": "获取手机号码",


### PR DESCRIPTION
* Added translations for “To address” and “To address - Tooltip” in multiple localization files
* Updated label display in `ProviderEditPage.js` to use “To address” instead of “From address”
* Added corresponding user mapping support for the recipient address field