### PR TITLE
feat: replace fmt.Errorf with errors.New for non-formatted error messages

### DIFF
--- a/controllers/util.go
+++ b/controllers/util.go
@@ -15,6 +15,7 @@
 package controllers
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -221,7 +222,7 @@ func (c *ApiController) GetProviderFromContext(category string) (*object.Provide
 		}
 
 		if provider == nil {
-			err = fmt.Errorf(c.T("util:The provider: %s is not found"), providerName)
+			err = errors.New(c.T("util:The provider: %s is not found"), providerName)
 			return nil, err
 		}
 
@@ -230,7 +231,7 @@ func (c *ApiController) GetProviderFromContext(category string) (*object.Provide
 
 	userId, ok := c.RequireSignedIn()
 	if !ok {
-		return nil, fmt.Errorf(c.T("general:Please login first"))
+		return nil, errors.New(c.T("general:Please login first"))
 	}
 
 	application, err := object.GetApplicationByUserId(userId)
@@ -239,7 +240,7 @@ func (c *ApiController) GetProviderFromContext(category string) (*object.Provide
 	}
 
 	if application == nil {
-		return nil, fmt.Errorf(c.T("util:No application is found for userId: %s"), userId)
+		return nil, errors.New(c.T("util:No application is found for userId: %s"), userId)
 	}
 
 	provider, err := application.GetProviderByCategory(category)
@@ -248,7 +249,7 @@ func (c *ApiController) GetProviderFromContext(category string) (*object.Provide
 	}
 
 	if provider == nil {
-		return nil, fmt.Errorf(c.T("util:No provider for category: %s is found for application: %s"), category, application.Name)
+		return nil, errors.New(c.T("util:No provider for category: %s is found for application: %s"), category, application.Name)
 	}
 
 	return provider, nil
@@ -260,7 +261,7 @@ func checkQuotaForApplication(count int) error {
 		return nil
 	}
 	if count >= quota {
-		return fmt.Errorf("application quota is exceeded")
+		return errors.New("application quota is exceeded")
 	}
 	return nil
 }
@@ -271,7 +272,7 @@ func checkQuotaForOrganization(count int) error {
 		return nil
 	}
 	if count >= quota {
-		return fmt.Errorf("organization quota is exceeded")
+		return errors.New("organization quota is exceeded")
 	}
 	return nil
 }
@@ -282,7 +283,7 @@ func checkQuotaForProvider(count int) error {
 		return nil
 	}
 	if count >= quota {
-		return fmt.Errorf("provider quota is exceeded")
+		return errors.New("provider quota is exceeded")
 	}
 	return nil
 }
@@ -299,7 +300,7 @@ func checkQuotaForUser() error {
 	}
 
 	if int(count) >= quota {
-		return fmt.Errorf("user quota is exceeded")
+		return errors.New("user quota is exceeded")
 	}
 	return nil
 }

--- a/idp/adfs.go
+++ b/idp/adfs.go
@@ -17,6 +17,7 @@ package idp
 import (
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -102,7 +103,7 @@ func (idp *AdfsIdProvider) GetToken(code string) (*oauth2.Token, error) {
 		return nil, err
 	}
 	if pToken.ErrMsg != "" {
-		return nil, fmt.Errorf(pToken.ErrMsg)
+		return nil, errors.New(pToken.ErrMsg)
 	}
 
 	token := &oauth2.Token{

--- a/idp/dingtalk.go
+++ b/idp/dingtalk.go
@@ -16,6 +16,7 @@ package idp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -97,7 +98,7 @@ func (idp *DingTalkIdProvider) GetToken(code string) (*oauth2.Token, error) {
 	}
 
 	if pToken.ErrCode != 0 {
-		return nil, fmt.Errorf("pToken.Errcode = %d, pToken.Errmsg = %s", pToken.ErrCode, pToken.ErrMsg)
+		return nil, errors.New(("pToken.Errcode = %d, pToken.Errmsg = %s", pToken.ErrCode, pToken.ErrMsg)
 	}
 
 	token := &oauth2.Token{
@@ -261,9 +262,9 @@ func (idp *DingTalkIdProvider) getUserId(unionId string, accessToken string) (st
 		return "", err
 	}
 	if data.ErrCode == 60121 {
-		return "", fmt.Errorf("该应用只允许本企业内部用户登录，您不属于该企业，无法登录")
+		return "", errors.New(("该应用只允许本企业内部用户登录，您不属于该企业，无法登录")
 	} else if data.ErrCode != 0 {
-		return "", fmt.Errorf(data.ErrMessage)
+		return "", errors.New((data.ErrMessage)
 	}
 	return data.Result.UserId, nil
 }
@@ -290,7 +291,7 @@ func (idp *DingTalkIdProvider) getUserCorpEmail(userId string, accessToken strin
 		return "", "", "", err
 	}
 	if data.ErrMessage != "ok" {
-		return "", "", "", fmt.Errorf(data.ErrMessage)
+		return "", "", "", errors.New((data.ErrMessage)
 	}
 	return data.Result.Mobile, data.Result.Email, data.Result.JobNumber, nil
 }

--- a/idp/wechat.go
+++ b/idp/wechat.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -124,7 +125,7 @@ func (idp *WeChatIdProvider) GetToken(code string) (*oauth2.Token, error) {
 
 	// {"errcode":40163,"errmsg":"code been used, rid: 6206378a-793424c0-2e4091cc"}
 	if strings.Contains(buf.String(), "errcode") {
-		return nil, fmt.Errorf(buf.String())
+		return nil, errors.New(buf.String())
 	}
 
 	var wechatAccessToken WechatAccessToken
@@ -184,7 +185,7 @@ func (idp *WeChatIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error)
 		Lock.RUnlock()
 
 		if !ok || mapValue.WechatUnionId == "" {
-			return nil, fmt.Errorf("error ticket")
+			return nil, errors.New("error ticket")
 		}
 
 		Lock.Lock()
@@ -287,7 +288,7 @@ func GetWechatOfficialAccountQRCode(clientId string, clientSecret string, provid
 	}
 
 	if errMsg != "" {
-		return "", "", fmt.Errorf("Fail to fetch WeChat QRcode: %s", errMsg)
+		return "", "", errors.New("Fail to fetch WeChat QRcode: %s", errMsg)
 	}
 
 	client := new(http.Client)

--- a/object/application.go
+++ b/object/application.go
@@ -15,6 +15,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -611,7 +612,7 @@ func GetMaskedApplications(applications []*Application, userId string) []*Applic
 
 func GetAllowedApplications(applications []*Application, userId string, lang string) ([]*Application, error) {
 	if userId == "" {
-		return nil, fmt.Errorf(i18n.Translate(lang, "auth:Unauthorized operation"))
+		return nil, errors.New(i18n.Translate(lang, "auth:Unauthorized operation"))
 	}
 
 	if isUserIdGlobalAdmin(userId) {
@@ -623,7 +624,7 @@ func GetAllowedApplications(applications []*Application, userId string, lang str
 		return nil, err
 	}
 	if user == nil {
-		return nil, fmt.Errorf(i18n.Translate(lang, "auth:Unauthorized operation"))
+		return nil, errors.New(i18n.Translate(lang, "auth:Unauthorized operation"))
 	}
 
 	if user.IsAdmin {
@@ -653,7 +654,7 @@ func UpdateApplication(id string, application *Application, isGlobalAdmin bool, 
 	}
 
 	if !isGlobalAdmin && oldApplication.Organization != application.Organization {
-		return false, fmt.Errorf(i18n.Translate(lang, "auth:Unauthorized operation"))
+		return false, errors.New(i18n.Translate(lang, "auth:Unauthorized operation"))
 	}
 
 	if name == "app-built-in" {

--- a/object/check_ip.go
+++ b/object/check_ip.go
@@ -15,6 +15,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -25,7 +26,7 @@ import (
 func CheckEntryIp(clientIp string, user *User, application *Application, organization *Organization, lang string) error {
 	entryIp := net.ParseIP(clientIp)
 	if entryIp == nil {
-		return fmt.Errorf(i18n.Translate(lang, "check:Failed to parse client IP: %s"), clientIp)
+		return errors.New(i18n.Translate(lang, "check:Failed to parse client IP: %s"), clientIp)
 	} else if entryIp.IsLoopback() {
 		return nil
 	}
@@ -77,7 +78,7 @@ func isEntryIpAllowd(ipWhitelistStr string, entryIp net.IP, lang string) error {
 			return err
 		}
 		if ipNet == nil {
-			return fmt.Errorf(i18n.Translate(lang, "check:CIDR for IP: %s should not be empty"), entryIp.String())
+			return errors.New(i18n.Translate(lang, "check:CIDR for IP: %s should not be empty"), entryIp.String())
 		}
 
 		if ipNet.Contains(entryIp) {
@@ -85,7 +86,7 @@ func isEntryIpAllowd(ipWhitelistStr string, entryIp net.IP, lang string) error {
 		}
 	}
 
-	return fmt.Errorf(i18n.Translate(lang, "check:Your IP address: %s has been banned according to the configuration of: "), entryIp.String())
+	return errors.New(i18n.Translate(lang, "check:Your IP address: %s has been banned according to the configuration of: "), entryIp.String())
 }
 
 func CheckIpWhitelist(ipWhitelistStr string, lang string) error {
@@ -96,7 +97,7 @@ func CheckIpWhitelist(ipWhitelistStr string, lang string) error {
 	ipWhiteList := strings.Split(ipWhitelistStr, ",")
 	for _, ip := range ipWhiteList {
 		if _, _, err := net.ParseCIDR(ip); err != nil {
-			return fmt.Errorf(i18n.Translate(lang, "check:%s does not meet the CIDR format requirements: %s"), ip, err.Error())
+			return errors.New(i18n.Translate(lang, "check:%s does not meet the CIDR format requirements: %s"), ip, err.Error())
 		}
 	}
 

--- a/object/check_password_expired.go
+++ b/object/check_password_expired.go
@@ -15,6 +15,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -28,7 +29,7 @@ func checkPasswordExpired(user *User, lang string) error {
 		return err
 	}
 	if organization == nil {
-		return fmt.Errorf(i18n.Translate(lang, "check:Organization does not exist"))
+		return errors.New(i18n.Translate(lang, "check:Organization does not exist"))
 	}
 
 	passwordExpireDays := organization.PasswordExpireDays
@@ -39,7 +40,7 @@ func checkPasswordExpired(user *User, lang string) error {
 	lastChangePasswordTime := user.LastChangePasswordTime
 	if lastChangePasswordTime == "" {
 		if user.CreatedTime == "" {
-			return fmt.Errorf(i18n.Translate(lang, "check:Your password has expired. Please reset your password by clicking \"Forgot password\""))
+			return errors.New(i18n.Translate(lang, "check:Your password has expired. Please reset your password by clicking \"Forgot password\""))
 		}
 		lastChangePasswordTime = user.CreatedTime
 	}
@@ -47,7 +48,7 @@ func checkPasswordExpired(user *User, lang string) error {
 	lastTime := util.String2Time(lastChangePasswordTime)
 	expireTime := lastTime.AddDate(0, 0, passwordExpireDays)
 	if time.Now().After(expireTime) {
-		return fmt.Errorf(i18n.Translate(lang, "check:Your password has expired. Please reset your password by clicking \"Forgot password\""))
+		return errors.New(i18n.Translate(lang, "check:Your password has expired. Please reset your password by clicking \"Forgot password\""))
 	}
 	return nil
 }

--- a/object/check_util.go
+++ b/object/check_util.go
@@ -15,6 +15,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -99,11 +100,11 @@ func recordSigninErrorInfo(user *User, lang string, options ...bool) error {
 
 	leftChances := failedSigninLimit - user.SigninWrongTimes
 	if leftChances == 0 && enableCaptcha {
-		return fmt.Errorf(i18n.Translate(lang, "check:password or code is incorrect"))
+		return errors.New(i18n.Translate(lang, "check:password or code is incorrect"))
 	} else if leftChances >= 0 {
-		return fmt.Errorf(i18n.Translate(lang, "check:password or code is incorrect, you have %s remaining chances"), strconv.Itoa(leftChances))
+		return errors.New(i18n.Translate(lang, "check:password or code is incorrect, you have %s remaining chances"), strconv.Itoa(leftChances))
 	}
 
 	// don't show the chance error message if the user has no chance left
-	return fmt.Errorf(i18n.Translate(lang, "check:You have entered the wrong password or code too many times, please wait for %d minutes and try again"), failedSigninFrozenTime)
+	return errors.New(i18n.Translate(lang, "check:You have entered the wrong password or code too many times, please wait for %d minutes and try again"), failedSigninFrozenTime)
 }

--- a/object/ldap_conn.go
+++ b/object/ldap_conn.go
@@ -432,7 +432,7 @@ func ResetLdapPassword(user *User, oldPassword string, newPassword string, lang 
 		}
 		if len(searchResult.Entries) > 1 {
 			conn.Close()
-			return fmt.Errorf(i18n.Translate(lang, "check:Multiple accounts with same uid, please check your ldap server"))
+			return errors.New(i18n.Translate(lang, "check:Multiple accounts with same uid, please check your ldap server"))
 		}
 
 		userDn := searchResult.Entries[0].DN

--- a/object/pricing.go
+++ b/object/pricing.go
@@ -15,6 +15,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/casdoor/casdoor/i18n"
@@ -46,7 +47,7 @@ func (pricing *Pricing) HasPlan(planName string, lang string) (bool, error) {
 		return false, err
 	}
 	if plan == nil {
-		return false, fmt.Errorf(i18n.Translate(lang, "auth:The plan: %s does not exist"), planId)
+		return false, errors.New(i18n.Translate(lang, "auth:The plan: %s does not exist"), planId)
 	}
 
 	if util.InSlice(pricing.Plans, plan.Name) {
@@ -153,7 +154,7 @@ func CheckPricingAndPlan(owner, pricingName, planName string, lang string) error
 	pricing, err := GetPricing(pricingId)
 	if pricing == nil || err != nil {
 		if pricing == nil && err == nil {
-			err = fmt.Errorf(i18n.Translate(lang, "auth:The pricing: %s does not exist"), pricingName)
+			err = errors.New(i18n.Translate(lang, "auth:The pricing: %s does not exist"), pricingName)
 		}
 		return err
 	}
@@ -162,7 +163,7 @@ func CheckPricingAndPlan(owner, pricingName, planName string, lang string) error
 		return err
 	}
 	if !ok {
-		return fmt.Errorf(i18n.Translate(lang, "auth:The pricing: %s does not have plan: %s"), pricingName, planName)
+		return errors.New(i18n.Translate(lang, "auth:The pricing: %s does not have plan: %s"), pricingName, planName)
 	}
 	return nil
 }

--- a/object/provider.go
+++ b/object/provider.go
@@ -15,6 +15,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -357,7 +358,7 @@ func GetCaptchaProviderByOwnerName(applicationId, lang string) (*Provider, error
 	}
 
 	if !existed {
-		return nil, fmt.Errorf(i18n.Translate(lang, "provider:the provider: %s does not exist"), applicationId)
+		return nil, errors.New(i18n.Translate(lang, "provider:the provider: %s does not exist"), applicationId)
 	}
 
 	return &provider, nil
@@ -373,7 +374,7 @@ func GetCaptchaProviderByApplication(applicationId, isCurrentProvider, lang stri
 	}
 
 	if application == nil || len(application.Providers) == 0 {
-		return nil, fmt.Errorf(i18n.Translate(lang, "provider:Invalid application id"))
+		return nil, errors.New(i18n.Translate(lang, "provider:Invalid application id"))
 	}
 	for _, provider := range application.Providers {
 		if provider.Provider == nil {
@@ -395,7 +396,7 @@ func GetFaceIdProviderByOwnerName(applicationId, lang string) (*Provider, error)
 	}
 
 	if !existed {
-		return nil, fmt.Errorf(i18n.Translate(lang, "provider:the provider: %s does not exist"), applicationId)
+		return nil, errors.New(i18n.Translate(lang, "provider:the provider: %s does not exist"), applicationId)
 	}
 
 	return &provider, nil
@@ -411,7 +412,7 @@ func GetFaceIdProviderByApplication(applicationId, isCurrentProvider, lang strin
 	}
 
 	if application == nil || len(application.Providers) == 0 {
-		return nil, fmt.Errorf(i18n.Translate(lang, "provider:Invalid application id"))
+		return nil, errors.New(i18n.Translate(lang, "provider:Invalid application id"))
 	}
 	for _, provider := range application.Providers {
 		if provider.Provider == nil {

--- a/object/saml_sp.go
+++ b/object/saml_sp.go
@@ -19,6 +19,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -75,7 +76,7 @@ func GenerateSamlRequest(id, relayState, host, lang string) (auth string, method
 		return "", "", err
 	}
 	if provider.Category != "SAML" {
-		return "", "", fmt.Errorf(i18n.Translate(lang, "saml_sp:provider %s's category is not SAML"), provider.Name)
+		return "", "", errors.New(i18n.Translate(lang, "saml_sp:provider %s's category is not SAML"), provider.Name)
 	}
 
 	sp, err := buildSp(provider, "", host)

--- a/object/storage.go
+++ b/object/storage.go
@@ -16,6 +16,7 @@ package object
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/url"
 	"path"
@@ -135,7 +136,7 @@ func getStorageProvider(provider *Provider, lang string) (oss.StorageInterface, 
 		return nil, err
 	}
 	if storageProvider == nil {
-		return nil, fmt.Errorf(i18n.Translate(lang, "storage:The provider type: %s is not supported"), provider.Type)
+		return nil, errors.New(i18n.Translate(lang, "storage:The provider type: %s is not supported"), provider.Type)
 	}
 
 	if provider.Domain == "" {
@@ -197,7 +198,7 @@ func UploadFileSafe(provider *Provider, fullFilePath string, fileBuffer *bytes.B
 func DeleteFile(provider *Provider, objectKey string, lang string) error {
 	// check fullFilePath is there security issue
 	if strings.Contains(objectKey, "..") {
-		return fmt.Errorf(i18n.Translate(lang, "storage:The objectKey: %s is not allowed"), objectKey)
+		return errors.New(i18n.Translate(lang, "storage:The objectKey: %s is not allowed"), objectKey)
 	}
 
 	storageProvider, err := getStorageProvider(provider, lang)

--- a/object/syncer.go
+++ b/object/syncer.go
@@ -15,6 +15,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/casdoor/casdoor/i18n"
@@ -162,7 +163,7 @@ func UpdateSyncer(id string, syncer *Syncer, isGlobalAdmin bool, lang string) (b
 	} else if s == nil {
 		return false, nil
 	} else if !isGlobalAdmin && s.Organization != syncer.Organization {
-		return false, fmt.Errorf(i18n.Translate(lang, "auth:Unauthorized operation"))
+		return false, errors.New(i18n.Translate(lang, "auth:Unauthorized operation"))
 	}
 
 	session := ormer.Engine.ID(core.PK{owner, name}).AllCols()

--- a/object/token_cas.go
+++ b/object/token_cas.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -134,7 +135,7 @@ var pgtToServiceResponse sync.Map
 
 func CheckCasLogin(application *Application, lang string, service string) error {
 	if len(application.RedirectUris) > 0 && !application.IsRedirectUriValid(service) {
-		return fmt.Errorf(i18n.Translate(lang, "token:Redirect URI: %s doesn't exist in the allowed Redirect URI list"), service)
+		return errors.New(i18n.Translate(lang, "token:Redirect URI: %s doesn't exist in the allowed Redirect URI list"), service)
 	}
 	return nil
 }

--- a/object/user.go
+++ b/object/user.go
@@ -17,6 +17,7 @@ package object
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -911,7 +912,7 @@ func AddUser(user *User, lang string) (bool, error) {
 	}
 
 	if user.Owner == "" || user.Name == "" {
-		return false, fmt.Errorf(i18n.Translate(lang, "user:the user's owner and name should not be empty"))
+		return false, errors.New(i18n.Translate(lang, "user:the user's owner and name should not be empty"))
 	}
 
 	if CheckUsernameWithEmail(user.Name, "en") != "" {
@@ -923,7 +924,7 @@ func AddUser(user *User, lang string) (bool, error) {
 		return false, err
 	}
 	if organization == nil {
-		return false, fmt.Errorf(i18n.Translate(lang, "auth:the organization: %s is not found"), user.Owner)
+		return false, errors.New(i18n.Translate(lang, "auth:the organization: %s is not found"), user.Owner)
 	}
 
 	if user.Owner != "built-in" {
@@ -932,12 +933,12 @@ func AddUser(user *User, lang string) (bool, error) {
 			return false, err
 		}
 		if applicationCount == 0 {
-			return false, fmt.Errorf(i18n.Translate(lang, "general:The organization: %s should have one application at least"), organization.Owner)
+			return false, errors.New(i18n.Translate(lang, "general:The organization: %s should have one application at least"), organization.Owner)
 		}
 	}
 
 	if organization.Name == "built-in" && !organization.HasPrivilegeConsent && user.Name != "admin" {
-		return false, fmt.Errorf(i18n.Translate(lang, "organization:adding a new user to the 'built-in' organization is currently disabled. Please note: all users in the 'built-in' organization are global administrators in Casdoor. Refer to the docs: https://casdoor.org/docs/basic/core-concepts#how-does-casdoor-manage-itself. If you still wish to create a user for the 'built-in' organization, go to the organization's settings page and enable the 'Has privilege consent' option."))
+		return false, errors.New(i18n.Translate(lang, "organization:adding a new user to the 'built-in' organization is currently disabled. Please note: all users in the 'built-in' organization are global administrators in Casdoor. Refer to the docs: https://casdoor.org/docs/basic/core-concepts#how-does-casdoor-manage-itself. If you still wish to create a user for the 'built-in' organization, go to the organization's settings page and enable the 'Has privilege consent' option."))
 	}
 
 	if organization.DefaultPassword != "" && user.Password == "123" {
@@ -1378,7 +1379,7 @@ func (user *User) GetUserFullGroupPath() ([]string, error) {
 
 		curGroup, ok := groupMap[group.ParentId]
 		if !ok {
-			return []string{}, fmt.Errorf(i18n.Translate("en", "auth:The group: %s does not exist"), group.ParentId)
+			return []string{}, errors.New(i18n.Translate("en", "auth:The group: %s does not exist"), group.ParentId)
 		}
 		for {
 			groupPath = util.GetId(curGroup.Name, groupPath)
@@ -1388,7 +1389,7 @@ func (user *User) GetUserFullGroupPath() ([]string, error) {
 
 			curGroup, ok = groupMap[curGroup.ParentId]
 			if !ok {
-				return []string{}, fmt.Errorf(i18n.Translate("en", "auth:The group: %s does not exist"), curGroup.ParentId)
+				return []string{}, errors.New(i18n.Translate("en", "auth:The group: %s does not exist"), curGroup.ParentId)
 			}
 		}
 

--- a/object/user_upload.go
+++ b/object/user_upload.go
@@ -15,6 +15,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -101,7 +102,7 @@ func UploadUsers(owner string, path string, userObj *User, lang string) (bool, e
 		return false, err
 	}
 	if organization == nil {
-		return false, fmt.Errorf(i18n.Translate(lang, "auth:The organization: %s does not exist"), organizationName)
+		return false, errors.New(i18n.Translate(lang, "auth:The organization: %s does not exist"), organizationName)
 	}
 
 	newUsers := []*User{}

--- a/object/verification.go
+++ b/object/verification.go
@@ -15,6 +15,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -88,7 +89,7 @@ func IsAllowSend(user *User, remoteAddr, recordType string, application *Applica
 
 	now := time.Now().Unix()
 	if has && now-record.Time < resendTimeoutInSeconds {
-		return fmt.Errorf("you can only send one code in %ds", resendTimeoutInSeconds)
+		return errors.New("you can only send one code in %ds", resendTimeoutInSeconds)
 	}
 
 	return nil
@@ -325,13 +326,13 @@ func CheckSigninCode(user *User, dest, code, lang string) error {
 	case wrongCodeError:
 		return recordSigninErrorInfo(user, lang)
 	default:
-		return fmt.Errorf(result.Msg)
+		return errors.New(result.Msg)
 	}
 }
 
 func CheckFaceId(user *User, faceId []float64, lang string) error {
 	if len(user.FaceIds) == 0 {
-		return fmt.Errorf(i18n.Translate(lang, "check:Face data does not exist, cannot log in"))
+		return errors.New(i18n.Translate(lang, "check:Face data does not exist, cannot log in"))
 	}
 
 	for _, userFaceId := range user.FaceIds {
@@ -348,7 +349,7 @@ func CheckFaceId(user *User, faceId []float64, lang string) error {
 		}
 	}
 
-	return fmt.Errorf(i18n.Translate(lang, "check:Face data mismatch"))
+	return errors.New(i18n.Translate(lang, "check:Face data mismatch"))
 }
 
 func GetVerifyType(username string) (verificationCodeType string) {

--- a/object/webhook.go
+++ b/object/webhook.go
@@ -15,6 +15,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/casdoor/casdoor/i18n"
@@ -112,7 +113,7 @@ func UpdateWebhook(id string, webhook *Webhook, isGlobalAdmin bool, lang string)
 	} else if w == nil {
 		return false, nil
 	} else if !isGlobalAdmin && w.Organization != webhook.Organization {
-		return false, fmt.Errorf(i18n.Translate(lang, "auth:Unauthorized operation"))
+		return false, errors.New(i18n.Translate(lang, "auth:Unauthorized operation"))
 	}
 
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(webhook)

--- a/pp/paypal.go
+++ b/pp/paypal.go
@@ -108,7 +108,7 @@ func (pp *PaypalPaymentProvider) Notify(body []byte, orderId string) (*NotifyRes
 			notifyResult.NotifyMessage = errDetail.Description
 			return notifyResult, nil
 		default:
-			err = fmt.Errorf(errDetail.Description)
+			err = errors.New(errDetail.Description)
 			return nil, err
 		}
 	}
@@ -125,7 +125,7 @@ func (pp *PaypalPaymentProvider) Notify(body []byte, orderId string) (*NotifyRes
 			notifyResult.NotifyMessage = errDetail.Description
 			return notifyResult, nil
 		default:
-			err = fmt.Errorf(errDetail.Description)
+			err = errors.New(errDetail.Description)
 			return nil, err
 		}
 	}

--- a/routers/static_filter.go
+++ b/routers/static_filter.go
@@ -16,6 +16,7 @@ package routers
 
 import (
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -93,7 +94,7 @@ func fastAutoSignin(ctx *context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	} else if code.Message != "" {
-		return "", fmt.Errorf(code.Message)
+		return "", errors.New(code.Message)
 	}
 
 	sep := "?"


### PR DESCRIPTION
Refactor: Replace fmt.Errorf with errors.New for i18n messages

- Changed `fmt.Errorf` to `errors.New` for non-formatted error strings
- Fixes non-constant format string warning from linter, preparing for upcoming Go versions
- Improves performance by avoiding unnecessary formatting