### PR TITLE
fix: add roles and permissions to default update columns

### DIFF
--- a/object/user.go
+++ b/object/user.go
@@ -804,7 +804,7 @@ func UpdateUser(id string, user *User, columns []string, isAdmin bool) (bool, er
 			"owner", "display_name", "avatar", "first_name", "last_name",
 			"location", "address", "country_code", "region", "language", "affiliation", "title", "id_card_type", "id_card", "homepage", "bio", "tag", "language", "gender", "birthday", "education", "score", "karma", "ranking", "signup_application",
 			"is_admin", "is_forbidden", "is_deleted", "hash", "is_default_avatar", "properties", "webauthnCredentials", "managedAccounts", "face_ids", "mfaAccounts",
-			"signin_wrong_times", "last_change_password_time", "last_signin_wrong_time", "groups", "access_key", "access_secret", "mfa_phone_enabled", "mfa_email_enabled",
+			"signin_wrong_times", "last_change_password_time", "last_signin_wrong_time", "groups", "roles", "permissions", "access_key", "access_secret", "mfa_phone_enabled", "mfa_email_enabled",
 			"github", "google", "qq", "wechat", "facebook", "dingtalk", "weibo", "gitee", "linkedin", "wecom", "lark", "gitlab", "adfs",
 			"baidu", "alipay", "casdoor", "infoflow", "apple", "azuread", "azureadb2c", "slack", "steam", "bilibili", "okta", "douyin", "kwai", "line", "amazon",
 			"auth0", "battlenet", "bitbucket", "box", "cloudfoundry", "dailymotion", "deezer", "digitalocean", "discord", "dropbox",


### PR DESCRIPTION
### Overview
This PR fixes a bug where the `roles` and `permissions` fields cannot be updated via the `/api/update-user` endpoint, even when explicitly requested using the `columns` parameter.

### Problem
In `object/user.go` line 807, the default columns list is missing:
- `roles`
- `permissions`

This prevents role and permission updates from being persisted to the database.

### Solution
Add `roles` and `permissions` to the default columns list.

### Testing
Tested that:
- API accepts the update request with `columns=['roles']`
- Without this fix: API returns success but roles are not persisted
- With this fix: Roles should be properly updated

### Impact
Enables:
- Programmatic role assignment via API
- Automated user provisioning workflows
- External system integrations for role management

### Related Issue
Fixes #4360