### PR TITLE
feat: normalize email to lowercase to prevent duplicate accounts

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -218,7 +218,7 @@ func (c *ApiController) Signup() {
 		Tag:               authForm.Tag,
 		Education:         authForm.Education,
 		Avatar:            organization.DefaultAvatar,
-		Email:             authForm.Email,
+		Email:             strings.ToLower(authForm.Email),
 		Phone:             authForm.Phone,
 		CountryCode:       authForm.CountryCode,
 		Address:           []string{},

--- a/object/check.go
+++ b/object/check.go
@@ -59,8 +59,11 @@ func CheckUserSignup(application *Application, organization *Organization, authF
 		if HasUserByField(organization.Name, "name", authForm.Username) {
 			return i18n.Translate(lang, "check:Username already exists")
 		}
-		if HasUserByField(organization.Name, "email", authForm.Email) {
-			return i18n.Translate(lang, "check:Email already exists")
+		if authForm.Email != "" {
+			normalizedEmail := strings.ToLower(authForm.Email)
+			if HasUserByField(organization.Name, "email", normalizedEmail) {
+				return i18n.Translate(lang, "check:Email already exists")
+			}
 		}
 		if HasUserByField(organization.Name, "phone", authForm.Phone) {
 			return i18n.Translate(lang, "check:Phone already exists")
@@ -80,7 +83,8 @@ func CheckUserSignup(application *Application, organization *Organization, authF
 				return i18n.Translate(lang, "check:Email cannot be empty")
 			}
 		} else {
-			if HasUserByField(organization.Name, "email", authForm.Email) {
+			normalizedEmail := strings.ToLower(authForm.Email)
+			if HasUserByField(organization.Name, "email", normalizedEmail) {
 				return i18n.Translate(lang, "check:Email already exists")
 			} else if !util.IsEmailValid(authForm.Email) {
 				return i18n.Translate(lang, "check:Email is invalid")

--- a/object/user_util.go
+++ b/object/user_util.go
@@ -74,7 +74,8 @@ func GetUserByFields(organization string, field string) (*User, error) {
 
 	// check email
 	if strings.Contains(field, "@") {
-		user, err = GetUserByField(organization, "email", field)
+		normalizedEmail := strings.ToLower(field)
+		user, err = GetUserByField(organization, "email", normalizedEmail)
 		if user != nil || err != nil {
 			return user, err
 		}


### PR DESCRIPTION
This PR fixes the email case sensitivity issue that allowed users to create multiple accounts using the same email address with different letter cases (e.g., `tayeh@...` vs `Tayeh@...`).

  ## Problem

  Currently, Casdoor treats emails as case-sensitive, which allows duplicate accounts:
  - User signs up with `tayeh@..` → Account created ✅
  - User signs up with `Tayeh@...` → Another account created ❌
  - User signs up with `TAYEH@...` → Yet another account created ❌

  This violates RFC 5321, which specifies that email addresses should be case-insensitive.
  
  
  # Solution

  Normalize all email addresses to lowercase in three key locations:

  1. **Validation** (`object/check.go`): Convert email to lowercase before checking for duplicates during signup
  2. **Storage** (`controllers/account.go`): Store email in lowercase format in the database
  3. **Lookup** (`object/user_util.go`): Convert email to lowercase during login/user search

  ## Changes Made

  ### Files Modified:
  - `object/check.go` - Lines 62-67, 85-87
    - Added `strings.ToLower(authForm.Email)` before duplicate email check
    - Added safety check for empty email in username validation block

  - `controllers/account.go` - Line 221
    - Changed `Email: authForm.Email` to `Email: strings.ToLower(authForm.Email)`

  - `object/user_util.go` - Lines 77-78
    - Added email normalization in `GetUserByFields` function for case-insensitive login