### PR TITLE
feat: update payment providers when organization changes in PlanEditPage

### DIFF
--- a/web/src/PlanEditPage.js
+++ b/web/src/PlanEditPage.js
@@ -150,6 +150,7 @@ class PlanEditPage extends React.Component {
               this.updatePlanField("owner", owner);
               this.getUsers(owner);
               this.getRoles(owner);
+              this.getPaymentProviders(owner);
             })}
             options={this.state.organizations.map((organization) => Setting.getOption(organization.name, organization.name))
             } />


### PR DESCRIPTION
Fix missing payment provider refresh when changing organization in the plan edit form. Added getPaymentProviders call to organization change handler to ensure payment providers are updated for the selected organization.

🤖 Generated with [Claude Code](https://claude.ai/code)