### PR TITLE
fix: improve error handling for DingTalkIdProvider.GetUserInfo()

### DIFF
--- a/idp/dingtalk.go
+++ b/idp/dingtalk.go
@@ -157,6 +157,10 @@ func (idp *DingTalkIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, erro
 		return nil, err
 	}
 
+	if dtUserInfo.OpenId == "" || dtUserInfo.UnionId == "" {
+		return nil, fmt.Errorf(string(data))
+	}
+
 	countryCode, err := util.GetCountryCode(dtUserInfo.StateCode, dtUserInfo.Mobile)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
ref:
- https://casdoor.org/zh/docs/provider/oauth/DingTalk/
- https://github.com/casdoor/casdoor/discussions/2191


OK respone:
```
HTTP/2 200 OK
Content-Type: application/json;charset=utf-8
```

```json
{
	"nick": "张三",
	"unionId": "****",
	"openId": "****",
	"mobile": "18900000000",
	"stateCode": "86",
	"visitor": false
}
```

---

If no `Contact.User.Read` permission， https://api.dingtalk.com/v1.0/contact/users/me respone is 

```
HTTP/2 403 Forbidden
Content-Type: application/json;charset=utf-8
```

```json
{
	"code": "Forbidden.AccessDenied.AccessTokenPermissionDenied",
	"requestid": "MASK",
	"message": "没有调用该接口的权限，接口权限申请参考：https://open.dingtalk.com/document/orgapp-server/add-api-permission",
	"accessdenieddetail": {
		"requiredScopes": [
			"Contact.User.Read"
		]
	}
}
```


