### PR TITLE
feat: introduce new error system 

### DIFF
--- a/controllers/util.go
+++ b/controllers/util.go
@@ -58,6 +58,24 @@ func (c *ApiController) ResponseError(error string, data ...interface{}) {
 	c.ResponseJsonData(resp, data...)
 }
 
+// ResponseErrorFromError handles errors, automatically translating TranslatableError types
+// Usage: c.ResponseErrorFromError(err)
+func (c *ApiController) ResponseTError(err error, data ...interface{}) {
+	if err == nil {
+		c.ResponseError(c.T("general:Unknown error"), data...)
+		return
+	}
+
+	if transErr, ok := err.(*i18n.TranslatableError); ok {
+		language := c.GetAcceptLanguage()
+		translatedMsg := transErr.TranslateWithLanguage(language)
+		c.ResponseError(translatedMsg, data...)
+		return
+	}
+
+	c.ResponseError(err.Error(), data...)
+}
+
 func (c *ApiController) T(error string) string {
 	return i18n.Translate(c.GetAcceptLanguage(), error)
 }


### PR DESCRIPTION
#4375 

## Changes

- **New `TranslatableError` type** (`i18n/util.go`): An error type that stores translation keys and parameters, allowing translation to happen when the error is displayed
- **New `ResponseTError` method** (`controllers/util.go`): Automatically handles `TranslatableError` types and translates them based on the user's language
- **Convenience function `i18n.T()`**: Provides a simple way to create `TranslatableError` instances

## Usage

```go
err := i18n.T("general:User %s not found", userId)

// Handle and translate automatically
c.ResponseTError(err)
```

## TODO

- [ ] Add regex for `i18n.T()` regexes to capture messages

