### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/object/permission_upload.go
+++ b/object/permission_upload.go
@@ -43,7 +43,6 @@ func UploadPermissions(owner string, path string) (bool, error) {
 
 	newPermissions := []*Permission{}
 	for index, line := range table {
-		line := line
 		if index == 0 || parseLineItem(&line, 0) == "" {
 			continue
 		}

--- a/object/role_upload.go
+++ b/object/role_upload.go
@@ -43,7 +43,6 @@ func UploadRoles(owner string, path string) (bool, error) {
 
 	newRoles := []*Role{}
 	for index, line := range table {
-		line := line
 		if index == 0 || parseLineItem(&line, 0) == "" {
 			continue
 		}

--- a/object/user_avatar_favicon.go
+++ b/object/user_avatar_favicon.go
@@ -124,7 +124,6 @@ func chooseFaviconLinkBySizes(links []Link) *Link {
 	var chosenLink *Link
 
 	for _, link := range links {
-		link := link
 		if chosenLink == nil || compareSizes(link.Sizes, chosenLink.Sizes) > 0 {
 			chosenLink = &link
 		}


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore