### PR TITLE
fix: ticket error handling in HandleOfficialAccountEvent()

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -1218,7 +1218,7 @@ func (c *ApiController) HandleOfficialAccountEvent() {
 		return
 	}
 	if data.Ticket == "" {
-		c.ResponseError(err.Error())
+		c.ResponseError("empty ticket")
 		return
 	}
 
@@ -1233,10 +1233,6 @@ func (c *ApiController) HandleOfficialAccountEvent() {
 		return
 	}
 
-	if data.Ticket == "" {
-		c.ResponseError("empty ticket")
-		return
-	}
 	if !idp.VerifyWechatSignature(provider.Content, nonce, timestamp, signature) {
 		c.ResponseError("invalid signature")
 		return


### PR DESCRIPTION
Moved the 'empty ticket' error response to an earlier check and removed redundant code in HandleOfficialAccountEvent for improved clarity and flow.