### PR TITLE
feat: drop legacy // +build comment

### DIFF
--- a/deployment/deploy_test.go
+++ b/deployment/deploy_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !skipCi
-// +build !skipCi
 
 package deployment
 

--- a/i18n/generate_test.go
+++ b/i18n/generate_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !skipCi
-// +build !skipCi
 
 package i18n
 

--- a/object/init_data_dump_test.go
+++ b/object/init_data_dump_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !skipCi
-// +build !skipCi
 
 package object
 

--- a/object/product_test.go
+++ b/object/product_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !skipCi
-// +build !skipCi
 
 package object
 

--- a/object/syncer_user_test.go
+++ b/object/syncer_user_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skipCi
-// +build !skipCi
 
 package object
 

--- a/object/transaction_test.go
+++ b/object/transaction_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !skipCi
-// +build !skipCi
 
 package object
 

--- a/radius/server_test.go
+++ b/radius/server_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !skipCi
-// +build !skipCi
 
 package radius
 

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !skipCi
-// +build !skipCi
 
 package sync
 

--- a/sync_v2/cmd_test.go
+++ b/sync_v2/cmd_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !skipCi
-// +build !skipCi
 
 package sync_v2
 

--- a/sync_v2/table_test.go
+++ b/sync_v2/table_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !skipCi
-// +build !skipCi
 
 package sync_v2
 

--- a/util/system_test.go
+++ b/util/system_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !skipCi
-// +build !skipCi
 
 package util
 

--- a/xlsx/xlsx_test.go
+++ b/xlsx/xlsx_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !skipCi
-// +build !skipCi
 
 package xlsx
 


### PR DESCRIPTION
From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build constraint syntax to modern standards across test files for improved maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->