### PR TITLE
feat: support recharge products with preset amounts and disable custom amount option.

### DIFF
--- a/object/product.go
+++ b/object/product.go
@@ -27,18 +27,20 @@ type Product struct {
 	CreatedTime string `xorm:"varchar(100)" json:"createdTime"`
 	DisplayName string `xorm:"varchar(100)" json:"displayName"`
 
-	Image       string   `xorm:"varchar(100)" json:"image"`
-	Detail      string   `xorm:"varchar(1000)" json:"detail"`
-	Description string   `xorm:"varchar(200)" json:"description"`
-	Tag         string   `xorm:"varchar(100)" json:"tag"`
-	Currency    string   `xorm:"varchar(100)" json:"currency"`
-	Price       float64  `json:"price"`
-	Quantity    int      `json:"quantity"`
-	Sold        int      `json:"sold"`
-	IsRecharge  bool     `json:"isRecharge"`
-	Providers   []string `xorm:"varchar(255)" json:"providers"`
-	ReturnUrl   string   `xorm:"varchar(1000)" json:"returnUrl"`
-	SuccessUrl  string   `xorm:"varchar(1000)" json:"successUrl"`
+	Image                 string    `xorm:"varchar(100)" json:"image"`
+	Detail                string    `xorm:"varchar(1000)" json:"detail"`
+	Description           string    `xorm:"varchar(200)" json:"description"`
+	Tag                   string    `xorm:"varchar(100)" json:"tag"`
+	Currency              string    `xorm:"varchar(100)" json:"currency"`
+	Price                 float64   `json:"price"`
+	Quantity              int       `json:"quantity"`
+	Sold                  int       `json:"sold"`
+	IsRecharge            bool      `json:"isRecharge"`
+	RechargeOptions       []float64 `xorm:"varchar(500)" json:"rechargeOptions"`
+	DisableCustomRecharge bool      `json:"disableCustomRecharge"`
+	Providers             []string  `xorm:"varchar(255)" json:"providers"`
+	ReturnUrl             string    `xorm:"varchar(1000)" json:"returnUrl"`
+	SuccessUrl            string    `xorm:"varchar(1000)" json:"successUrl"`
 
 	State string `xorm:"varchar(100)" json:"state"`
 
@@ -107,7 +109,6 @@ func UpdateProduct(id string, product *Product) (bool, error) {
 	} else if p == nil {
 		return false, nil
 	}
-
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(product)
 	if err != nil {
 		return false, err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Merchants can define preset recharge amounts and disable custom amounts.
  * Purchase page shows selectable preset recharge choices, a conditional custom amount input, and defaults to a preset when custom input is disallowed.
  * Product edit adds controls to manage preset values and a toggle to disallow custom amounts.

* **Bug Fixes**
  * Prevent saving a recharge product when custom amounts are disallowed and no presets exist.

* **Refactor**
  * UI rendering reorganized for clearer recharge flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->