### PR TITLE
feat: always return array if item contains roles, groups or permissions in JWT

### DIFF
--- a/object/application.go
+++ b/object/application.go
@@ -63,6 +63,7 @@ type SamlItem struct {
 type JwtItem struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
+	Type  string `json:"type"`
 }
 
 type Application struct {

--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -413,6 +413,12 @@ func getClaimsCustom(claims Claims, tokenField []string, tokenAttributes []*JwtI
 
 	for _, item := range tokenAttributes {
 		valueList := replaceAttributeValue(claims.User, item.Value)
+		if strings.Contains(item.Value, "$user.roles") ||
+			strings.Contains(item.Value, "$user.groups") ||
+			strings.Contains(item.Value, "$user.permissions") {
+			res[item.Name] = valueList
+			continue
+		}
 
 		if len(valueList) == 1 {
 			res[item.Name] = valueList[0]

--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -417,7 +417,7 @@ func getClaimsCustom(claims Claims, tokenField []string, tokenAttributes []*JwtI
 			strings.Contains(item.Value, "$user.groups") ||
 			strings.Contains(item.Value, "$user.permissions") {
 			res[item.Name] = valueList
-		} else {
+		} else if len(valueList) > 0 {
 			res[item.Name] = valueList[0]
 		}
 	}

--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -417,13 +417,8 @@ func getClaimsCustom(claims Claims, tokenField []string, tokenAttributes []*JwtI
 			strings.Contains(item.Value, "$user.groups") ||
 			strings.Contains(item.Value, "$user.permissions") {
 			res[item.Name] = valueList
-			continue
-		}
-
-		if len(valueList) == 1 {
-			res[item.Name] = valueList[0]
 		} else {
-			res[item.Name] = valueList
+			res[item.Name] = valueList[0]
 		}
 	}
 

--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -413,12 +413,14 @@ func getClaimsCustom(claims Claims, tokenField []string, tokenAttributes []*JwtI
 
 	for _, item := range tokenAttributes {
 		valueList := replaceAttributeValue(claims.User, item.Value)
-		if strings.Contains(item.Value, "$user.roles") ||
-			strings.Contains(item.Value, "$user.groups") ||
-			strings.Contains(item.Value, "$user.permissions") {
-			res[item.Name] = valueList
-		} else if len(valueList) > 0 {
+		if len(valueList) == 0 {
+			continue
+		}
+
+		if item.Type == "String" {
 			res[item.Name] = valueList[0]
+		} else {
+			res[item.Name] = valueList
 		}
 	}
 

--- a/web/src/table/TokenAttributeTable.js
+++ b/web/src/table/TokenAttributeTable.js
@@ -14,7 +14,7 @@
 
 import React from "react";
 import {DeleteOutlined, DownOutlined, UpOutlined} from "@ant-design/icons";
-import {Button, Col, Input, Row, Table, Tooltip} from "antd";
+import {Button, Col, Input, Row, Select, Table, Tooltip} from "antd";
 import * as Setting from "../Setting";
 import i18next from "i18next";
 
@@ -84,6 +84,29 @@ class TokenAttributeTable extends React.Component {
             <Input value={text} onChange={e => {
               this.updateField(table, index, "value", e.target.value);
             }} />
+          );
+        },
+      },
+      {
+        title: i18next.t("general:Type"),
+        dataIndex: "type",
+        key: "type",
+        width: "200px",
+        render: (text, record, index) => {
+          return (
+            <Select virtual={false} style={{width: "100%"}}
+              value={text}
+              defaultValue="Array"
+              options={[
+                {value: "Array", label: i18next.t("application:Array")},
+                {value: "String", label: i18next.t("application:String")},
+              ].map((item) =>
+                Setting.getOption(item.label, item.value))
+              }
+              onChange={value => {
+                this.updateField(table, index, "type", value);
+              }} >
+            </Select>
           );
         },
       },

--- a/web/src/table/TokenAttributeTable.js
+++ b/web/src/table/TokenAttributeTable.js
@@ -95,8 +95,7 @@ class TokenAttributeTable extends React.Component {
         render: (text, record, index) => {
           return (
             <Select virtual={false} style={{width: "100%"}}
-              value={text}
-              defaultValue="Array"
+              value={text ?? "Array"}
               options={[
                 {value: "Array", label: i18next.t("application:Array")},
                 {value: "String", label: i18next.t("application:String")},


### PR DESCRIPTION
fix: #4622 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token attribute editor now includes a configurable "Type" option (Array or String) per attribute.
  * JWT items now include a "type" field in their JSON representation.

* **Bug Fixes**
  * Empty attribute values are omitted from tokens.
  * Single-element non-string attributes are preserved as lists; string attributes remain single values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->