### PR TITLE
fix: sendSilentSigninData to parent page after successful signin

### DIFF
--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -378,6 +378,7 @@ class LoginPage extends React.Component {
             this.onUpdateAccount(account);
 
             if (Setting.isPromptAnswered(account, application)) {
+              this.sendSilentSigninData("success", resp.data);
               Setting.goToLink(redirectUrl);
             } else {
               Setting.goToLinkSoft(ths, `/prompt/${application.name}?redirectUri=${oAuthParams.redirectUri}&code=${code}&state=${oAuthParams.state}`);
@@ -400,6 +401,7 @@ class LoginPage extends React.Component {
       } else {
         Setting.goToLink(redirectUrl);
         this.sendPopupData({type: "loginSuccess", data: {code: code, state: oAuthParams.state}}, oAuthParams.redirectUri);
+        this.sendSilentSigninData("success", resp.data);
       }
     }
   }
@@ -1179,9 +1181,9 @@ class LoginPage extends React.Component {
     );
   }
 
-  sendSilentSigninData(data) {
+  sendSilentSigninData(data, resp = null) {
     if (Setting.inIframe()) {
-      const message = {tag: "Casdoor", type: "SilentSignin", data: data};
+      const message = {tag: "Casdoor", type: "SilentSignin", data: data, resp: resp};
       window.parent.postMessage(message, "*");
     }
   }


### PR DESCRIPTION
fix: #4621 

@huynhduc28051999 can you help me test this pr? in my test ,now silentSignin can successfully return oauth response data 
<img width="1575" height="232" alt="image" src="https://github.com/user-attachments/assets/279acf4a-b631-49c3-8f83-252aa5a6ce4d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
* Enhanced the silent sign-in authentication mechanism to better support comprehensive response data transmission and handling. These improvements strengthen the reliability and stability of automatic re-authentication workflows, provide more robust error handling capabilities, and ensure more consistent and dependable login experiences across various authentication scenarios and edge cases encountered during the user authentication process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->