### PR TITLE
feat: Add phone number to CustomUserInfo

### DIFF
--- a/idp/custom.go
+++ b/idp/custom.go
@@ -90,6 +90,7 @@ type CustomUserInfo struct {
 	DisplayName string `mapstructure:"displayName"`
 	Email       string `mapstructure:"email"`
 	AvatarUrl   string `mapstructure:"avatarUrl"`
+	Phone       string `mapstructure:"phone"`
 }
 
 func (idp *CustomIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error) {
@@ -153,6 +154,7 @@ func (idp *CustomIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error)
 		Username:    customUserinfo.Username,
 		DisplayName: customUserinfo.DisplayName,
 		Email:       customUserinfo.Email,
+		Phone:       customUserinfo.Phone,
 		AvatarUrl:   customUserinfo.AvatarUrl,
 	}
 	return userInfo, nil


### PR DESCRIPTION
fix: https://github.com/casdoor/casdoor/issues/4717

The `CustomUserInfo` struct has been updated to include a `Phone` field. This allows for capturing and storing phone numbers from custom identity providers.

The `GetUserInfo` method in `CustomIdProvider` now maps the `phone` field from the custom user info to the `Phone` field in the `UserInfo` struct.