### PR TITLE
feat(storage): add RRSA support for Alibaba Cloud OSS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/alibabacloud-go/openapi-util v0.1.0
 	github.com/alibabacloud-go/tea v1.3.2
 	github.com/alibabacloud-go/tea-utils/v2 v2.0.7
+	github.com/aliyun/aliyun-oss-go-sdk v2.2.2+incompatible
+	github.com/aliyun/credentials-go v1.3.10
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.95.0
 	github.com/beego/beego/v2 v2.3.8
 	github.com/beevik/etree v1.1.0
@@ -110,8 +112,6 @@ require (
 	github.com/alibabacloud-go/tea-utils v1.3.6 // indirect
 	github.com/alibabacloud-go/tea-xml v1.1.3 // indirect
 	github.com/aliyun/alibaba-cloud-sdk-go v1.62.545 // indirect
-	github.com/aliyun/aliyun-oss-go-sdk v2.2.2+incompatible // indirect
-	github.com/aliyun/credentials-go v1.3.10 // indirect
 	github.com/apistd/uni-go-sdk v0.0.2 // indirect
 	github.com/atc0005/go-teams-notify/v2 v2.13.0 // indirect
 	github.com/aws/aws-sdk-go v1.45.5 // indirect

--- a/storage/aliyun_oss.go
+++ b/storage/aliyun_oss.go
@@ -15,11 +15,55 @@
 package storage
 
 import (
-	"github.com/casdoor/oss"
+	"os"
+
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/aliyun/credentials-go/credentials"
+	casdoorOss "github.com/casdoor/oss"
 	"github.com/casdoor/oss/aliyun"
 )
 
-func NewAliyunOssStorageProvider(clientId string, clientSecret string, region string, bucket string, endpoint string) oss.StorageInterface {
+func NewAliyunOssStorageProvider(clientId string, clientSecret string, region string, bucket string, endpoint string) casdoorOss.StorageInterface {
+	// Check if RRSA is available (empty credentials + environment variables set)
+	if (clientId == "" || clientId == "rrsa") &&
+		(clientSecret == "" || clientSecret == "rrsa") &&
+		os.Getenv("ALIBABA_CLOUD_ROLE_ARN") != "" {
+		// Use RRSA to get temporary credentials
+		config := &credentials.Config{}
+		config.SetType("oidc_role_arn")
+		config.SetRoleArn(os.Getenv("ALIBABA_CLOUD_ROLE_ARN"))
+		config.SetOIDCProviderArn(os.Getenv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN"))
+		config.SetOIDCTokenFilePath(os.Getenv("ALIBABA_CLOUD_OIDC_TOKEN_FILE"))
+		config.SetRoleSessionName("casdoor-oss")
+
+		// Set STS endpoint if provided
+		if stsEndpoint := os.Getenv("ALIBABA_CLOUD_STS_ENDPOINT"); stsEndpoint != "" {
+			config.SetSTSEndpoint(stsEndpoint)
+		}
+
+		credential, err := credentials.NewCredential(config)
+		if err == nil {
+			accessKeyId, errId := credential.GetAccessKeyId()
+			accessKeySecret, errSecret := credential.GetAccessKeySecret()
+			securityToken, errToken := credential.GetSecurityToken()
+
+			if errId == nil && errSecret == nil && errToken == nil &&
+				accessKeyId != nil && accessKeySecret != nil && securityToken != nil {
+				// Successfully obtained RRSA credentials
+				sp := aliyun.New(&aliyun.Config{
+					AccessID:      *accessKeyId,
+					AccessKey:     *accessKeySecret,
+					Bucket:        bucket,
+					Endpoint:      endpoint,
+					ClientOptions: []oss.ClientOption{oss.SecurityToken(*securityToken)},
+				})
+				return sp
+			}
+		}
+		// If RRSA fails, fall through to static credentials (which will fail if empty)
+	}
+
+	// Use static credentials (existing behavior)
 	sp := aliyun.New(&aliyun.Config{
 		AccessID:  clientId,
 		AccessKey: clientSecret,

--- a/storage/aliyun_oss_test.go
+++ b/storage/aliyun_oss_test.go
@@ -1,0 +1,90 @@
+// Copyright 2021 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNewAliyunOssStorageProvider_StaticCredentials(t *testing.T) {
+	// Test with static credentials (existing behavior)
+	provider := NewAliyunOssStorageProvider("testAccessId", "testAccessKey", "oss-cn-hangzhou", "test-bucket", "https://oss-cn-hangzhou.aliyuncs.com")
+	if provider == nil {
+		t.Error("Expected provider to be created with static credentials")
+	}
+}
+
+func TestNewAliyunOssStorageProvider_RRSADetection(t *testing.T) {
+	// Save original environment
+	originalRoleArn := os.Getenv("ALIBABA_CLOUD_ROLE_ARN")
+	originalProviderArn := os.Getenv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN")
+	originalTokenFile := os.Getenv("ALIBABA_CLOUD_OIDC_TOKEN_FILE")
+
+	// Restore environment after test
+	defer func() {
+		if originalRoleArn == "" {
+			os.Unsetenv("ALIBABA_CLOUD_ROLE_ARN")
+		} else {
+			os.Setenv("ALIBABA_CLOUD_ROLE_ARN", originalRoleArn)
+		}
+		if originalProviderArn == "" {
+			os.Unsetenv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN")
+		} else {
+			os.Setenv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", originalProviderArn)
+		}
+		if originalTokenFile == "" {
+			os.Unsetenv("ALIBABA_CLOUD_OIDC_TOKEN_FILE")
+		} else {
+			os.Setenv("ALIBABA_CLOUD_OIDC_TOKEN_FILE", originalTokenFile)
+		}
+	}()
+
+	// Test RRSA detection with environment variables set
+	os.Setenv("ALIBABA_CLOUD_ROLE_ARN", "acs:ram::123456789:role/test-role")
+	os.Setenv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", "acs:ram::123456789:oidc-provider/test-provider")
+	os.Setenv("ALIBABA_CLOUD_OIDC_TOKEN_FILE", "/var/run/secrets/token")
+
+	// This should attempt to use RRSA (will fall back to static credentials if RRSA fails due to missing token file)
+	provider := NewAliyunOssStorageProvider("", "", "oss-cn-hangzhou", "test-bucket", "https://oss-cn-hangzhou.aliyuncs.com")
+	if provider == nil {
+		t.Error("Expected provider to be created even if RRSA fails")
+	}
+
+	// Test with "rrsa" as placeholder value
+	provider = NewAliyunOssStorageProvider("rrsa", "rrsa", "oss-cn-hangzhou", "test-bucket", "https://oss-cn-hangzhou.aliyuncs.com")
+	if provider == nil {
+		t.Error("Expected provider to be created with 'rrsa' placeholder")
+	}
+}
+
+func TestNewAliyunOssStorageProvider_NoRRSA(t *testing.T) {
+	// Ensure RRSA environment variables are not set
+	originalRoleArn := os.Getenv("ALIBABA_CLOUD_ROLE_ARN")
+	defer func() {
+		if originalRoleArn == "" {
+			os.Unsetenv("ALIBABA_CLOUD_ROLE_ARN")
+		} else {
+			os.Setenv("ALIBABA_CLOUD_ROLE_ARN", originalRoleArn)
+		}
+	}()
+	os.Unsetenv("ALIBABA_CLOUD_ROLE_ARN")
+
+	// Should use static credentials (which will be empty in this case)
+	provider := NewAliyunOssStorageProvider("", "", "oss-cn-hangzhou", "test-bucket", "https://oss-cn-hangzhou.aliyuncs.com")
+	if provider == nil {
+		t.Error("Expected provider to be created with static credentials")
+	}
+}


### PR DESCRIPTION
Issue reference: Re-submission of #4800.
Core Changes:
This PR introduces native RRSA (RAM Roles for Service Accounts) support for the Alibaba Cloud OSS storage provider.
Previously, the OSS provider relied exclusively on static AccessKey and SecretKey. This update enables Casdoor to perform "Zero-Credential" authentication by exchanging OIDC tokens for temporary STS credentials.
Logic implemented:
If AccessKey and SecretKey are empty or set to "rrsa", the provider will automatically look for RRSA environment variables (ALIBABA_CLOUD_ROLE_ARN, ALIBABA_CLOUD_OIDC_TOKEN_FILE).
Integrated github.com/aliyun/credentials-go to manage the token exchange lifecycle.
Fallback to traditional static credentials if RRSA variables are not detected.
Production Verification:
Environment: Alibaba Cloud ACK Pro (Managed Kubernetes).
Validation:
Built a custom image via GitHub Actions including these changes.
Deployed to ACK Pro with RRSA enabled and ServiceAccount annotated.
Cleared AK/SK fields in Casdoor UI.
Result: Successfully uploaded user avatars to OSS. Verified via Alibaba Cloud ActionTrail that the request was signed using the assumed RAM role.