### PR TITLE
fix: use unionid instead of job_number as user name in the OAuth provider

### DIFF
--- a/idp/dingtalk.go
+++ b/idp/dingtalk.go
@@ -284,9 +284,9 @@ func (idp *DingTalkIdProvider) getUserCorpEmail(userId string, accessToken strin
 	var data struct {
 		ErrMessage string `json:"errmsg"`
 		Result     struct {
-			Mobile    string `json:"mobile"`
-			Email     string `json:"email"`
-			UnionId   string `json:"unionid"`
+			Mobile  string `json:"mobile"`
+			Email   string `json:"email"`
+			UnionId string `json:"unionid"`
 		} `json:"result"`
 	}
 	err = json.Unmarshal(respBytes, &data)


### PR DESCRIPTION
In DingTalk, job_number is never unique - two employees can have the same job_number, and a person's job_number can change over time. The original implementation uses job_number as casdoor username, which is just wrong, as casdoor username under the same owner must be unique. This PR fixes this issue by anchoring casdoor username to unionid instead, which is officially documented as the unique identifier for DingTalk user.