### PR TITLE
feat(ldap-sync): support multiple default groups, limit 1 physical group

### DIFF
--- a/object/ldap.go
+++ b/object/ldap.go
@@ -33,7 +33,7 @@ type Ldap struct {
 	BaseDn              string            `xorm:"varchar(500)" json:"baseDn"`
 	Filter              string            `xorm:"varchar(200)" json:"filter"`
 	FilterFields        []string          `xorm:"varchar(100)" json:"filterFields"`
-	DefaultGroup        string            `xorm:"varchar(100)" json:"defaultGroup"`
+	DefaultGroup        []string          `xorm:"varchar(1000)" json:"defaultGroup"`
 	PasswordType        string            `xorm:"varchar(100)" json:"passwordType"`
 	CustomAttributes    map[string]string `json:"customAttributes"`
 

--- a/object/ldap_conn.go
+++ b/object/ldap_conn.go
@@ -370,8 +370,8 @@ func SyncLdapUsers(owner string, syncUsers []LdapUser, ldapId string) (existUser
 				Properties:        syncUser.Attributes,
 			}
 
-			if ldap.DefaultGroup != "" {
-				newUser.Groups = []string{ldap.DefaultGroup}
+			if len(ldap.DefaultGroup) > 0 {
+				newUser.Groups = ldap.DefaultGroup
 			}
 
 			affected, err := AddUser(newUser, "en")

--- a/web/src/LdapEditPage.js
+++ b/web/src/LdapEditPage.js
@@ -259,7 +259,21 @@ class LdapEditPage extends React.Component {
             {Setting.getLabel(i18next.t("ldap:Default group"), i18next.t("ldap:Default group - Tooltip"))} :
           </Col>
           <Col span={21}>
-            <Select virtual={false} style={{width: "100%"}} value={this.state.ldap.defaultGroup ?? []} onChange={(value => {
+            <Select virtual={false} mode="multiple" style={{width: "100%"}} value={this.state.ldap.defaultGroup ?? []} onChange={(value => {
+              const groups = this.state.groups;
+              const physicalGroups = value.filter(groupId => {
+                const group = groups.find(g => `${g.owner}/${g.name}` === groupId);
+                return group && group.type === "Physical";
+              });
+              if (physicalGroups.length > 1) {
+                const lastPhysicalGroup = physicalGroups[physicalGroups.length - 1];
+                const virtualGroups = value.filter(groupId => {
+                  const group = groups.find(g => `${g.owner}/${g.name}` === groupId);
+                  return group && group.type !== "Physical";
+                });
+                value = [...virtualGroups, lastPhysicalGroup];
+                Setting.showMessage("warning", i18next.t("general:You can only select one physical group"));
+              }
               this.updateLdapField("defaultGroup", value);
             })}
             >


### PR DESCRIPTION
Feature: Support Multiple Default Groups for LDAP Sync
Summary
Enhanced LDAP synchronization to support selecting multiple default groups with validation rules:

Physical groups: Maximum 1 can be selected
Virtual groups: Multiple can be selected
Users can select 1 physical group + multiple virtual groups simultaneously
Changes Made
Backend Changes
1. 
object/ldap.go

Changed DefaultGroup field from string to []string
Updated database column from varchar(100) to varchar(1000) to accommodate multiple group IDs
2. 
object/ldap_conn.go

Updated 
SyncLdapUsers
 function to assign all selected default groups to newly synced users
Changed condition from checking empty string to checking slice length
Frontend Changes
3. 
web/src/LdapEditPage.js

Changed "Default group" selector from single-select to multi-select mode
Implemented client-side validation:
Automatically limits physical group selection to 1
Shows warning message when user attempts to select multiple physical groups
Keeps only the last selected physical group + all virtual groups
No limit on virtual group selection
Technical Details
Data Model: DefaultGroup is now stored as a JSON array in the database
Backward Compatibility: Existing single-group configurations will need manual migration
Validation: Physical/Virtual group type checking is performed on the frontend using the Group.Type field

Testing
<img width="1788" height="429" alt="6584aefa366d49107086794c8e3dca9e" src="https://github.com/user-attachments/assets/6e1ca601-95bf-44b7-adf9-289929423c2e" />
<img width="1983" height="1403" alt="0983eed4555b7c523fac11ae074b6f77" src="https://github.com/user-attachments/assets/a549185b-ef02-4f17-afb3-dcf5f8638d40" />

