### PR TITLE
feat: expose get-all-* Casbin endpoints in Swagger

### DIFF
--- a/controllers/casbin_api.go
+++ b/controllers/casbin_api.go
@@ -303,6 +303,13 @@ func (c *ApiController) BatchEnforce() {
 	c.ResponseOk(res, keyRes)
 }
 
+// GetAllObjects
+// @Title GetAllObjects
+// @Tag Enforcer API
+// @Description Get all objects for a user (Casbin API)
+// @Param   userId    query   string  false   "user id like built-in/admin"
+// @Success 200 {object} controllers.Response The Response object
+// @router /get-all-objects [get]
 func (c *ApiController) GetAllObjects() {
 	userId := c.Ctx.Input.Query("userId")
 	if userId == "" {
@@ -322,6 +329,13 @@ func (c *ApiController) GetAllObjects() {
 	c.ResponseOk(objects)
 }
 
+// GetAllActions
+// @Title GetAllActions
+// @Tag Enforcer API
+// @Description Get all actions for a user (Casbin API)
+// @Param   userId    query   string  false   "user id like built-in/admin"
+// @Success 200 {object} controllers.Response The Response object
+// @router /get-all-actions [get]
 func (c *ApiController) GetAllActions() {
 	userId := c.Ctx.Input.Query("userId")
 	if userId == "" {
@@ -341,6 +355,13 @@ func (c *ApiController) GetAllActions() {
 	c.ResponseOk(actions)
 }
 
+// GetAllRoles
+// @Title GetAllRoles
+// @Tag Enforcer API
+// @Description Get all roles for a user (Casbin API)
+// @Param   userId    query   string  false   "user id like built-in/admin"
+// @Success 200 {object} controllers.Response The Response object
+// @router /get-all-roles [get]
 func (c *ApiController) GetAllRoles() {
 	userId := c.Ctx.Input.Query("userId")
 	if userId == "" {


### PR DESCRIPTION
## Summary
- Add Swagger annotations for `get-all-objects`, `get-all-actions`, and `get-all-roles` Casbin endpoints so they appear in `/swagger`.
- This documents existing routes already registered in `routers/router.go`.

## Why
These endpoints are reachable but not visible in Swagger because they lack annotations, which makes discovery difficult for API consumers.

## Notes
- No behavior change; documentation only.
- Parameters and response types mirror existing patterns used by `Enforce` and `BatchEnforce` endpoints.

## Checklist
- [x] Documentation only
- [x] No breaking changes
