### PR TITLE
TLS Certificate Verification Disabled for SUBMAIL Email Provider

### DIFF
--- a/email/provider.go
+++ b/email/provider.go
@@ -18,7 +18,7 @@ type EmailProvider interface {
 	Send(fromAddress string, fromName string, toAddress []string, subject string, content string) error
 }
 
-func GetEmailProvider(typ string, clientId string, clientSecret string, host string, port int, disableSsl bool, endpoint string, method string, httpHeaders map[string]string, bodyMapping map[string]string, contentType string, enableProxy bool) EmailProvider {
+func GetEmailProvider(typ string, clientId string, clientSecret string, host string, port int, disableSsl bool, endpoint string, method string, httpHeaders map[string]string, bodyMapping map[string]string, contentType string, enableProxy bool, insecureSkipVerify bool) EmailProvider {
 	if typ == "Azure ACS" {
 		return NewAzureACSEmailProvider(clientSecret, host)
 	} else if typ == "Custom HTTP Email" {
@@ -26,6 +26,6 @@ func GetEmailProvider(typ string, clientId string, clientSecret string, host str
 	} else if typ == "SendGrid" {
 		return NewSendgridEmailProvider(clientSecret, host, endpoint)
 	} else {
-		return NewSmtpEmailProvider(clientId, clientSecret, host, port, typ, disableSsl, enableProxy)
+		return NewSmtpEmailProvider(clientId, clientSecret, host, port, typ, disableSsl, enableProxy, insecureSkipVerify)
 	}
 }

--- a/email/smtp.go
+++ b/email/smtp.go
@@ -25,9 +25,9 @@ type SmtpEmailProvider struct {
 	Dialer *gomail.Dialer
 }
 
-func NewSmtpEmailProvider(userName string, password string, host string, port int, typ string, disableSsl bool, enableProxy bool) *SmtpEmailProvider {
+func NewSmtpEmailProvider(userName string, password string, host string, port int, typ string, disableSsl bool, enableProxy bool, insecureSkipVerify bool) *SmtpEmailProvider {
 	dialer := gomail.NewDialer(host, port, userName, password)
-	if typ == "SUBMAIL" {
+	if insecureSkipVerify {
 		dialer.TLSConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 

--- a/object/email.go
+++ b/object/email.go
@@ -20,7 +20,7 @@ import "github.com/casdoor/casdoor/email"
 
 // TestSmtpServer Test the SMTP server
 func TestSmtpServer(provider *Provider) error {
-	smtpEmailProvider := email.NewSmtpEmailProvider(provider.ClientId, provider.ClientSecret, provider.Host, provider.Port, provider.Type, provider.DisableSsl, provider.EnableProxy)
+	smtpEmailProvider := email.NewSmtpEmailProvider(provider.ClientId, provider.ClientSecret, provider.Host, provider.Port, provider.Type, provider.DisableSsl, provider.EnableProxy, provider.InsecureSkipVerify)
 	sender, err := smtpEmailProvider.Dialer.Dial()
 	if err != nil {
 		return err
@@ -31,7 +31,7 @@ func TestSmtpServer(provider *Provider) error {
 }
 
 func SendEmail(provider *Provider, title string, content string, dest []string, sender string) error {
-	emailProvider := email.GetEmailProvider(provider.Type, provider.ClientId, provider.ClientSecret, provider.Host, provider.Port, provider.DisableSsl, provider.Endpoint, provider.Method, provider.HttpHeaders, provider.UserMapping, provider.IssuerUrl, provider.EnableProxy)
+	emailProvider := email.GetEmailProvider(provider.Type, provider.ClientId, provider.ClientSecret, provider.Host, provider.Port, provider.DisableSsl, provider.Endpoint, provider.Method, provider.HttpHeaders, provider.UserMapping, provider.IssuerUrl, provider.EnableProxy, provider.InsecureSkipVerify)
 
 	fromAddress := provider.ClientId2
 	if fromAddress == "" {

--- a/object/provider.go
+++ b/object/provider.go
@@ -75,9 +75,10 @@ type Provider struct {
 	EnableSignAuthnRequest bool   `json:"enableSignAuthnRequest"`
 	EmailRegex             string `xorm:"varchar(200)" json:"emailRegex"`
 
-	ProviderUrl string `xorm:"varchar(200)" json:"providerUrl"`
-	EnableProxy bool   `json:"enableProxy"`
-	EnablePkce  bool   `json:"enablePkce"`
+	ProviderUrl        string `xorm:"varchar(200)" json:"providerUrl"`
+	EnableProxy        bool   `json:"enableProxy"`
+	EnablePkce         bool   `json:"enablePkce"`
+	InsecureSkipVerify bool   `json:"insecureSkipVerify"`
 }
 
 func GetMaskedProvider(provider *Provider, isMaskEnabled bool) *Provider {


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

## TLS Certificate Verification Disabled for SUBMAIL Email Provider

## Location
`email/smtp.go:31`

## Description
TLS certificate verification is disabled for SUBMAIL email provider SMTP connections.

## Analysis Notes
InsecureSkipVerify: true is unconditionally set for all SUBMAIL provider connections. This disables TLS certificate validation, making connections vulnerable to man-in-the-middle attacks. Unlike other findings, this is NOT configurable by the admin - it's hardcoded for all SUBMAIL users. Emails often contain sensitive data like verification codes, password reset links, and MFA codes. An attacker in a network position (e.g., compromised network, ISP-level, or cloud provider) could intercept and modify email traffic. This appears to be a workaround for SUBMAIL's certificate configuration issues, but it should either: (1) be made configurable with a warning, (2) be removed if SUBMAIL has fixed their certificates, or (3) at minimum be documented as a known limitation. The hardcoded nature and sensitivity of email content makes this a real vulnerability.

## Fix Applied
Replaced the hardcoded `InsecureSkipVerify: true` for SUBMAIL with a configurable per-provider setting via the new `InsecureSkipVerify` field in the Provider struct. By default, TLS certificates are now verified (secure by default). Admins who need to bypass certificate verification for specific environments can explicitly enable this via the provider configuration.

## Tests/Linters Ran
- `go fmt ./...` - Code formatted successfully
- `gofmt -l` on affected files - All files properly formatted
- Note: Full test suite (`go test`) and `go vet` could not be run due to Go version mismatch in the environment (system has Go 1.19, project requires Go 1.23)
