### PR TITLE
TLS Certificate Verification Disabled for Active Directory Syncer

### DIFF
--- a/object/syncer.go
+++ b/object/syncer.go
@@ -37,11 +37,12 @@ type Syncer struct {
 	Name        string `xorm:"varchar(100) notnull pk" json:"name"`
 	CreatedTime string `xorm:"varchar(100)" json:"createdTime"`
 
-	Organization string `xorm:"varchar(100)" json:"organization"`
-	Type         string `xorm:"varchar(100)" json:"type"`
-	DatabaseType string `xorm:"varchar(100)" json:"databaseType"`
-	SslMode      string `xorm:"varchar(100)" json:"sslMode"`
-	SshType      string `xorm:"varchar(100)" json:"sshType"`
+	Organization           string `xorm:"varchar(100)" json:"organization"`
+	Type                   string `xorm:"varchar(100)" json:"type"`
+	DatabaseType           string `xorm:"varchar(100)" json:"databaseType"`
+	SslMode                string `xorm:"varchar(100)" json:"sslMode"`
+	SshType                string `xorm:"varchar(100)" json:"sshType"`
+	LdapInsecureSkipVerify bool   `xorm:"bool" json:"ldapInsecureSkipVerify"`
 
 	Host             string         `xorm:"varchar(100)" json:"host"`
 	Port             int            `json:"port"`

--- a/object/syncer_activedirectory.go
+++ b/object/syncer_activedirectory.go
@@ -148,7 +148,7 @@ func (p *ActiveDirectorySyncerProvider) getLdapConn() (*goldap.Conn, error) {
 	// Check if SSL is enabled (port 636 typically indicates LDAPS)
 	if port == 636 {
 		tlsConfig := &tls.Config{
-			InsecureSkipVerify: true, // TODO: Make this configurable
+			InsecureSkipVerify: p.Syncer.LdapInsecureSkipVerify,
 		}
 		conn, err = goldap.DialTLS("tcp", fmt.Sprintf("%s:%d", host, port), tlsConfig)
 	} else {


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

## TLS Certificate Verification Disabled for Active Directory Syncer

## Location
"object/syncer_activedirectory.go:103-105
## Description
TLS certificate verification is disabled for Active Directory LDAPS connections.

## Analysis Notes
The scanner correctly identifies that TLS certificate verification is disabled. Analysis: (1) At line 103-105, InsecureSkipVerify is hardcoded to true with a TODO comment acknowledging this is a known issue. (2) This affects all LDAPS connections (port 636) from the Active Directory syncer. (3) The syncer transmits sensitive credentials (line 116: conn.Bind(user, password)) and retrieves user data including potentially sensitive attributes. (4) An attacker with network position (MITM) could intercept AD credentials and user data during synchronization. (5) While syncer configuration requires admin privileges (via authz filter), the vulnerability affects the security of the sync operation itself, not just configuration. (6) The code explicitly acknowledges this needs to be fixed ('TODO: Make this configurable'). (7) Recommendation: Make certificate verification configurable with secure defaults (verification enabled). Add a configuration option for development/testing scenarios with clear security warnings. This is a genuine vulnerability that should be addressed.

## Fix Applied
Added \"LdapInsecureSkipVerify\" configuration field to the Syncer struct with a default value of \"false\", ensuring TLS certificate verification is enabled by default for Active Directory LDAPS connections. Administrators can explicitly set this to \"true\" only for development/testing environments with self-signed certificates. This addresses the security vulnerability while maintaining flexibility for legitimate use cases.

## Tests/Linters Ran

- go fmt ./object/syncer.go ./object/syncer_activedirectory.go - passed
- go build - compiled successfully (syntax validation)
- No existing tests for Active Directory syncer to run
- Manual code review: verified the fix correctly uses the new configuration field