### PR TITLE
fix(signup): remove additional binding providers step in the signup process (#5130)

### DIFF
--- a/util/network.go
+++ b/util/network.go
@@ -27,6 +27,7 @@ func GetHostname() string {
 
 	return name
 }
+
 func IsInternetIp(ip string) bool {
 	ipStr, _, err := net.SplitHostPort(ip)
 	if err != nil {

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -753,8 +753,19 @@ export function getAllPromptedProviderItems(application) {
   return application.providers?.filter(providerItem => isProviderPrompted(providerItem));
 }
 
+const PromptRenderableSignupItemNames = new Set([
+  "Country/Region",
+]);
+
+export function isPromptableSignupItem(signupItem) {
+  if (!signupItem) {
+    return false;
+  }
+  return isSignupItemPrompted(signupItem) && PromptRenderableSignupItemNames.has(signupItem.name);
+}
+
 export function getAllPromptedSignupItems(application) {
-  return application.signupItems?.filter(signupItem => isSignupItemPrompted(signupItem));
+  return application.signupItems?.filter(isPromptableSignupItem);
 }
 
 export function getSignupItem(application, itemName) {


### PR DESCRIPTION
Closes #5130

After reproducing the issue with the provided init data, I found that PromptPage could be triggered by signupItems where visible=true and prompted=true(e.g., Invitation code), but PromptPage only renders input for "Country/Region".
This caused users to enter a PromptPage with no editable fields and only a Submit and complete button.

Fix:
1. Added a prompt-renderable signup item whitelist.
2. Added isPromptableSignupItem() to ensure a signup item is both prompted and actually renderable.
3. Updated getAllPromptedSignupItems() to use this check.

Result: 
1. Prevents empty PromptPage navigation in signup flow.
2. Keeps behavior aligned with current PromptPage rendering support.
3. Frontend-only change; no backend/API impact.