### PR TITLE
feat: add missing "min" param for Cloud PNVS SMS provider

### DIFF
--- a/object/sms.go
+++ b/object/sms.go
@@ -15,8 +15,10 @@
 package object
 
 import (
+	"strconv"
 	"strings"
 
+	"github.com/casdoor/casdoor/conf"
 	sender "github.com/casdoor/go-sms-sender"
 )
 
@@ -61,6 +63,13 @@ func SendSms(provider *Provider, content string, phoneNumbers ...string) error {
 		params["0"] = content
 	} else {
 		params["code"] = content
+		if provider.Type == "Alibaba Cloud PNVS SMS" {
+			timeoutInMinutes, err := conf.GetConfigInt64("verificationCodeTimeout")
+			if err != nil || timeoutInMinutes <= 0 {
+				timeoutInMinutes = 10
+			}
+			params["min"] = strconv.FormatInt(timeoutInMinutes, 10)
+		}
 	}
 
 	err = client.SendMessage(params, phoneNumbers...)

--- a/util/network.go
+++ b/util/network.go
@@ -27,6 +27,7 @@ func GetHostname() string {
 
 	return name
 }
+
 func IsInternetIp(ip string) bool {
 	ipStr, _, err := net.SplitHostPort(ip)
 	if err != nil {


### PR DESCRIPTION
The PNVS `SendSmsVerifyCode` API requires `templateParam` to contain both `code` and `min` keys. The missing `min` key caused SMS sending to fail with:

> Invalid content for template variable min.

This PR adds the `min` parameter to the template params when the provider type is `Alibaba Cloud PNVS SMS`. The value is read from the `verificationCodeTimeout` config (default: 10 minutes).

**Changes:**
- `object/sms.go`: Add `min` key to params map for PNVS SMS provider, using `conf.GetConfigInt64("verificationCodeTimeout")` with a fallback of 10

Fixes #5173