### PR TITLE
feat: redirect to account page for forced password change

### DIFF
--- a/web/src/ManagementPage.js
+++ b/web/src/ManagementPage.js
@@ -455,7 +455,11 @@ function ManagementPage(props) {
     } else if (props.account === undefined) {
       return null;
     } else if (props.account.needUpdatePassword) {
-      return <Redirect to={"/forget/" + props.application.name} />;
+      if (window.location.pathname === "/account") {
+        return component;
+      } else {
+        return <Redirect to="/account" />;
+      }
     } else {
       return component;
     }

--- a/web/src/auth/AuthCallback.js
+++ b/web/src/auth/AuthCallback.js
@@ -95,7 +95,7 @@ class AuthCallback extends React.Component {
       if (responseType === "login") {
         if (res.data3) {
           sessionStorage.setItem("signinUrl", signinUrl);
-          Setting.goToLinkSoft(this, `/forget/${applicationName}`);
+          Setting.goToLinkSoft(this, "/account");
           return;
         }
         Setting.showMessage("success", "Logged in successfully");
@@ -104,7 +104,7 @@ class AuthCallback extends React.Component {
       } else if (responseType === "code") {
         if (res.data3) {
           sessionStorage.setItem("signinUrl", signinUrl);
-          Setting.goToLinkSoft(this, `/forget/${applicationName}`);
+          Setting.goToLinkSoft(this, "/account");
           return;
         }
 
@@ -121,7 +121,7 @@ class AuthCallback extends React.Component {
       } else if (responseTypes.includes("token") || responseTypes.includes("id_token")) {
         if (res.data3) {
           sessionStorage.setItem("signinUrl", signinUrl);
-          Setting.goToLinkSoft(this, `/forget/${applicationName}`);
+          Setting.goToLinkSoft(this, "/account");
           return;
         }
 
@@ -154,7 +154,7 @@ class AuthCallback extends React.Component {
         } else {
           if (res.data3) {
             sessionStorage.setItem("signinUrl", signinUrl);
-            Setting.goToLinkSoft(this, `/forget/${applicationName}`);
+            Setting.goToLinkSoft(this, "/account");
             return;
           }
           const SAMLResponse = res.data;

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -365,7 +365,7 @@ class LoginPage extends React.Component {
 
     if (resp.data3) {
       sessionStorage.setItem("signinUrl", window.location.pathname + window.location.search);
-      Setting.goToLinkSoft(ths, `/forget/${application.name}`);
+      Setting.goToLinkSoft(ths, "/account");
       return;
     }
 
@@ -537,7 +537,8 @@ class LoginPage extends React.Component {
             if (responseType === "login") {
               if (res.data3) {
                 sessionStorage.setItem("signinUrl", window.location.pathname + window.location.search);
-                Setting.goToLinkSoft(this, `/forget/${this.state.applicationName}`);
+                Setting.goToLinkSoft(this, "/account");
+                return;
               }
               Setting.showMessage("success", i18next.t("application:Logged in successfully"));
               this.props.onLoginSuccess();
@@ -551,7 +552,8 @@ class LoginPage extends React.Component {
             } else if (responseTypes.includes("token") || responseTypes.includes("id_token")) {
               if (res.data3) {
                 sessionStorage.setItem("signinUrl", window.location.pathname + window.location.search);
-                Setting.goToLinkSoft(this, `/forget/${this.state.applicationName}`);
+                Setting.goToLinkSoft(this, "/account");
+                return;
               }
               const amendatoryResponseType = responseType === "token" ? "access_token" : responseType;
               const accessToken = res.data;
@@ -573,7 +575,8 @@ class LoginPage extends React.Component {
               }
               if (res.data3) {
                 sessionStorage.setItem("signinUrl", window.location.pathname + window.location.search);
-                Setting.goToLinkSoft(this, `/forget/${this.state.applicationName}`);
+                Setting.goToLinkSoft(this, "/account");
+                return;
               }
               if (res.data2.method === "POST") {
                 this.setState({

--- a/web/src/common/modal/PasswordModal.js
+++ b/web/src/common/modal/PasswordModal.js
@@ -129,6 +129,9 @@ export const PasswordModal = (props) => {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("user:Password set successfully"));
           setVisible(false);
+          if (account.owner === user.owner && account.name === userName) {
+            account.needUpdatePassword = false;
+          }
         } else {
           Setting.showMessage("error", i18next.t(`user:${res.msg}`));
         }


### PR DESCRIPTION
When `needUpdatePassword` is true, users are currently redirected to the `/forget` page, which requires email/phone verification — an awkward UX since the user already knows their current password.

This PR redirects to the `/account` page instead, where users can directly change their password via the password modal.

**Changes:**
- `web/src/ManagementPage.js`: Allow `/account` access when `needUpdatePassword` is true; redirect all other management pages to `/account`
- `web/src/auth/LoginPage.js`: Update all `data3` (needUpdatePassword) redirects from `/forget` to `/account`
- `web/src/auth/AuthCallback.js`: Same redirect update for OAuth/SAML callback flows
- `web/src/common/modal/PasswordModal.js`: Clear `needUpdatePassword` flag locally after successful password change

Fixes #3697