### PR TITLE
feat: add Antd Select UI option for language selector

### DIFF
--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -695,7 +695,7 @@ class LoginPage extends React.Component {
       return (
         <div key={resultItemKey} className="login-languages">
           <div dangerouslySetInnerHTML={{__html: ("<style>" + signinItem.customCss?.replaceAll("<style>", "").replaceAll("</style>", "") + "</style>")}} />
-          <LanguageSelect languages={application.organizationObj.languages} type={signinItem.rule === "Select" ? "Select" : undefined} onClick={key => {this.setState({userLang: key});}} />
+          <LanguageSelect languages={application.organizationObj.languages} type={signinItem.rule} onClick={key => {this.setState({userLang: key});}} />
         </div>
       );
     } else if (signinItem.name === "Signin methods") {

--- a/web/src/common/select/LanguageSelect.js
+++ b/web/src/common/select/LanguageSelect.js
@@ -50,11 +50,14 @@ class LanguageSelect extends React.Component {
 
   renderSelect(languageItems) {
     const currentLanguage = Setting.getLanguage();
+    const validKeys = languageItems.map(item => item.key);
+    const selectedValue = validKeys.includes(currentLanguage) ? currentLanguage : validKeys[0];
+
     const options = languageItems.map(item => ({
       value: item.key,
       label: (
         <span style={{display: "flex", alignItems: "center", gap: "8px"}}>
-          {flagIcon(Setting.Countries.find(c => c.key === item.key)?.country, item.key)}
+          {item.icon}
           {item.label}
         </span>
       ),
@@ -64,7 +67,7 @@ class LanguageSelect extends React.Component {
       <Select
         virtual={false}
         style={{width: "140px", ...this.props.style}}
-        value={currentLanguage}
+        value={selectedValue}
         onChange={(value) => {
           if (typeof this.state.onClick === "function") {
             this.state.onClick(value);

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -52,7 +52,6 @@
     "Disable SAML attributes - Tooltip": "Disable SAML attributes - Tooltip",
     "Disable signin": "Disable signin",
     "Disable signin - Tooltip": "Disable user login operations",
-    "Dropdown": "Dropdown",
     "Dynamic": "Dynamic",
     "Edit Application": "Edit Application",
     "Enable Email linking": "Enable Email linking",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -52,7 +52,6 @@
     "Disable SAML attributes - Tooltip": "是否禁用SAML响应中的属性",
     "Disable signin": "禁止登录",
     "Disable signin - Tooltip": "禁止用户进行登录操作",
-    "Dropdown": "下拉菜单",
     "Dynamic": "动态开启",
     "Edit Application": "编辑应用",
     "Enable Email linking": "自动关联邮箱相同的账号",

--- a/web/src/table/SigninTable.js
+++ b/web/src/table/SigninTable.js
@@ -271,7 +271,7 @@ class SigninTable extends React.Component {
           }
           if (record.name === "Languages") {
             options = [
-              {id: "None", name: i18next.t("application:Dropdown")},
+              {id: "Dropdown", name: i18next.t("general:Default")},
               {id: "Select", name: i18next.t("application:Select")},
             ];
           }


### PR DESCRIPTION
Add a configurable "Rule" option for the **Languages** signin item in the application edit page. Administrators can choose between two language selector styles:

- **Dropdown** (default) — the current globe icon that opens a dropdown menu
- **Select** — an Antd Select widget displaying the current language with flag icons and language names

## Changes

- `web/src/common/select/LanguageSelect.js` — Add `renderSelect()` method and support `type="Select"` prop
- `web/src/table/SigninTable.js` — Add rule options (Dropdown/Select) for the Languages signin item
- `web/src/auth/LoginPage.js` — Pass `signinItem.rule` to `LanguageSelect` component
- `web/src/locales/en/data.json` — Add "Dropdown" i18n key
- `web/src/locales/zh/data.json` — Add "Dropdown" i18n key (下拉菜单)

**5 files changed, 46 insertions(+), 2 deletions(-)**

Fixes #4922