### PR TITLE
fix: avoid redundant session creation for API-based auth

### DIFF
--- a/controllers/base.go
+++ b/controllers/base.go
@@ -184,6 +184,16 @@ func (c *ApiController) ClearTokenSession() {
 }
 
 func (c *ApiController) GetSessionOidc() (string, string) {
+	// Check context data first (set by AutoSigninFilter for API-based auth)
+	if ctxScope := c.Ctx.Input.GetData("scope"); ctxScope != nil {
+		scope, _ := ctxScope.(string)
+		aud := ""
+		if ctxAud := c.Ctx.Input.GetData("aud"); ctxAud != nil {
+			aud, _ = ctxAud.(string)
+		}
+		return scope, aud
+	}
+
 	sessionData := c.GetSessionData()
 	if sessionData != nil &&
 		sessionData.ExpireTime != 0 &&

--- a/routers/authz_filter.go
+++ b/routers/authz_filter.go
@@ -44,6 +44,12 @@ type ObjectWithOrg struct {
 }
 
 func getUsername(ctx *context.Context) (username string) {
+	if ctxUser := ctx.Input.GetData("username"); ctxUser != nil {
+		if u, ok := ctxUser.(string); ok && u != "" {
+			return u
+		}
+	}
+
 	username, ok := ctx.Input.Session("username").(string)
 	if !ok || username == "" {
 		username, _ = getUsernameByClientIdSecret(ctx)

--- a/routers/auto_signin_filter.go
+++ b/routers/auto_signin_filter.go
@@ -81,8 +81,8 @@ func AutoSigninFilter(ctx *context.Context) {
 			return
 		}
 
-		setSessionUser(ctx, userId)
-		setSessionOidc(ctx, token.Scope, application.ClientId)
+		setContextUser(ctx, userId)
+		setContextOidc(ctx, token.Scope, application.ClientId)
 		return
 	}
 
@@ -94,7 +94,7 @@ func AutoSigninFilter(ctx *context.Context) {
 			responseError(ctx, err.Error())
 		}
 
-		setSessionUser(ctx, userId)
+		setContextUser(ctx, userId)
 	}
 
 	// "/page?clientId=123&clientSecret=456"
@@ -104,7 +104,7 @@ func AutoSigninFilter(ctx *context.Context) {
 		return
 	}
 	if userId != "" {
-		setSessionUser(ctx, userId)
+		setContextUser(ctx, userId)
 		return
 	}
 
@@ -124,6 +124,6 @@ func AutoSigninFilter(ctx *context.Context) {
 			return
 		}
 
-		setSessionUser(ctx, userId)
+		setContextUser(ctx, userId)
 	}
 }

--- a/routers/base.go
+++ b/routers/base.go
@@ -154,6 +154,12 @@ func getUsernameByKeys(ctx *context.Context) (string, error) {
 }
 
 func getSessionUser(ctx *context.Context) string {
+	if ctxUser := ctx.Input.GetData("username"); ctxUser != nil {
+		if username, ok := ctxUser.(string); ok {
+			return username
+		}
+	}
+
 	user := ctx.Input.CruSession.Get(stdcontext.Background(), "username")
 	if user == nil {
 		return ""
@@ -170,6 +176,15 @@ func setSessionUser(ctx *context.Context, user string) {
 
 	// https://github.com/beego/beego/issues/3445#issuecomment-455411915
 	ctx.Input.CruSession.SessionRelease(stdcontext.Background(), ctx.ResponseWriter)
+}
+
+func setContextUser(ctx *context.Context, user string) {
+	ctx.Input.SetData("username", user)
+}
+
+func setContextOidc(ctx *context.Context, scope string, aud string) {
+	ctx.Input.SetData("scope", scope)
+	ctx.Input.SetData("aud", aud)
 }
 
 func setSessionExpire(ctx *context.Context, ExpireTime int64) {


### PR DESCRIPTION
`AutoSigninFilter` creates a new server-side session on every API request authenticated via access token, access key/secret, client ID/secret, or URL credentials. This causes unnecessary session storage overhead and resource usage.

## Root Cause

`setSessionUser()` writes to `CruSession` and calls `SessionRelease()`, creating a persistent session for each request. For stateless API calls, this is redundant — the user identity only needs to exist for the duration of the request.

## Fix

Store user identity in beego's request context data (`ctx.Input.SetData`) instead of creating sessions for API-based auth in `AutoSigninFilter`. The existing session-based login flow (browser sessions) is unaffected.

- `routers/auto_signin_filter.go` — Use `setContextUser()` and `setContextOidc()` instead of `setSessionUser()` and `setSessionOidc()`
- `routers/base.go` — Add `setContextUser()`, `setContextOidc()` helpers; update `getSessionUser()` to check context data first
- `routers/authz_filter.go` — Update `getUsername()` to check context data first
- `controllers/base.go` — Update `GetSessionOidc()` to check context data first

**4 files changed, 36 insertions(+), 5 deletions(-)**

This is consistent with the existing pattern in `ApiFilter` (line 294 of `authz_filter.go`) and `GetSessionUsername()` (line 109 of `controllers/base.go`) which already use `ctx.Input.SetData`/`GetData` for request-scoped user identity.

Fixes #3119