### PR TITLE
fix: correct BalanceCredit behavior to act as an allowable overdraft limit

### DIFF
--- a/object/organization.go
+++ b/object/organization.go
@@ -615,8 +615,8 @@ func UpdateOrganizationBalance(owner string, name string, balance float64, curre
 	if isOrgBalance {
 		newBalance = AddPrices(organization.OrgBalance, convertedBalance)
 		// Check organization balance credit limit
-		if newBalance < organization.BalanceCredit {
-			return fmt.Errorf(i18n.Translate(lang, "general:Insufficient balance: new organization balance %v would be below credit limit %v"), newBalance, organization.BalanceCredit)
+		if newBalance+organization.BalanceCredit < 0 {
+			return fmt.Errorf(i18n.Translate(lang, "general:Insufficient balance: new organization balance %v would exceed credit limit %v"), newBalance, organization.BalanceCredit)
 		}
 		organization.OrgBalance = newBalance
 		columns = []string{"org_balance"}

--- a/object/transaction_validate.go
+++ b/object/transaction_validate.go
@@ -63,8 +63,8 @@ func validateOrganizationBalance(owner string, name string, balance float64, cur
 	if isOrgBalance {
 		newBalance = AddPrices(organization.OrgBalance, convertedBalance)
 		// Check organization balance credit limit
-		if newBalance < organization.BalanceCredit {
-			return fmt.Errorf(i18n.Translate(lang, "general:Insufficient balance: new organization balance %v would be below credit limit %v"), newBalance, organization.BalanceCredit)
+		if newBalance+organization.BalanceCredit < 0 {
+			return fmt.Errorf(i18n.Translate(lang, "general:Insufficient balance: new organization balance %v would exceed credit limit %v"), newBalance, organization.BalanceCredit)
 		}
 	} else {
 		// User balance is just a sum of all users' balances, no credit limit check here
@@ -121,8 +121,8 @@ func validateUserBalance(owner string, name string, balance float64, currency st
 	}
 
 	// Validate new balance against credit limit
-	if newBalance < balanceCredit {
-		return fmt.Errorf(i18n.Translate(lang, "general:Insufficient balance: new balance %v would be below credit limit %v"), newBalance, balanceCredit)
+	if newBalance+balanceCredit < 0 {
+		return fmt.Errorf(i18n.Translate(lang, "general:Insufficient balance: new balance %v would exceed credit limit %v"), newBalance, balanceCredit)
 	}
 
 	// In validation mode, we don't actually update the balance

--- a/object/user.go
+++ b/object/user.go
@@ -1573,8 +1573,8 @@ func UpdateUserBalance(owner string, name string, balance float64, currency stri
 	}
 
 	// Validate new balance against credit limit
-	if newBalance < balanceCredit {
-		return fmt.Errorf(i18n.Translate(lang, "general:Insufficient balance: new balance %v would be below credit limit %v"), newBalance, balanceCredit)
+	if newBalance+balanceCredit < 0 {
+		return fmt.Errorf(i18n.Translate(lang, "general:Insufficient balance: new balance %v would exceed credit limit %v"), newBalance, balanceCredit)
 	}
 
 	user.Balance = newBalance


### PR DESCRIPTION
### What does this PR do?
This PR fixes the behavior of `BalanceCredit` to act as an allowable overdraft limit instead of a hard bottom threshold limit, aligning it with standard "Credit" behavior.

### Why is this PR needed?
Currently, the system asserts `if newBalance < balanceCredit`. 
This is counter-intuitive and behaves incorrectly. For instance, if a user has `$0` balance and `$10` balance credit, instead of allowing the user to spend up to `$10` on credit (reaching a new balance of `-10`), the system immediately stops the transaction because `-10` is less than `10`. This practically renders the `BalanceCredit` useless as a credit mechanism unless users use it strictly as a positive minimum floor constraint.

### How was it fixed?
By changing the validation bounds from comparing strictly against `< balanceCredit` to enforcing `newBalance + balanceCredit < 0` 