### PR TITLE
fix: preserve default file logging and strip ANSI colors from stderr logger

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,6 +49,29 @@ func main() {
 
 	routers.InitAPI()
 	object.InitFlag()
+
+	var logAdapter string
+	logConfigMap := make(map[string]interface{})
+	err := json.Unmarshal([]byte(conf.GetConfigString("logConfig")), &logConfigMap)
+	if err != nil {
+		panic(err)
+	}
+	_, ok := logConfigMap["adapter"]
+	if !ok {
+		logAdapter = "file"
+	} else {
+		logAdapter = logConfigMap["adapter"].(string)
+	}
+	if logAdapter == "console" {
+		logAdapter = util.AdapterStderr
+	}
+	logs.Reset()
+	err = logs.SetLogger(logAdapter, conf.GetConfigString("logConfig"))
+	if err != nil {
+		panic(err)
+	}
+	logs.SetLogFuncCall(false)
+
 	object.InitAdapter()
 	object.CreateTables()
 
@@ -98,30 +121,8 @@ func main() {
 	web.InsertFilter("*", web.BeforeRouter, routers.FieldValidationFilter)
 	web.InsertFilter("*", web.AfterExec, routers.AfterRecordMessage, web.WithReturnOnOutput(false))
 
-	var logAdapter string
-	logConfigMap := make(map[string]interface{})
-	err := json.Unmarshal([]byte(conf.GetConfigString("logConfig")), &logConfigMap)
-	if err != nil {
-		panic(err)
-	}
-	_, ok := logConfigMap["adapter"]
-	if !ok {
-		logAdapter = "file"
-	} else {
-		logAdapter = logConfigMap["adapter"].(string)
-	}
-	if logAdapter == "console" {
-		logAdapter = util.AdapterStderr
-		logs.Reset()
-	}
-	err = logs.SetLogger(logAdapter, conf.GetConfigString("logConfig"))
-	if err != nil {
-		panic(err)
-	}
-
 	port := web.AppConfig.DefaultInt("httpport", 8000)
 	// logs.SetLevel(logs.LevelInformational)
-	logs.SetLogFuncCall(false)
 
 	err = util.StopOldInstance(port)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -110,7 +110,8 @@ func main() {
 	} else {
 		logAdapter = logConfigMap["adapter"].(string)
 	}
-	if logAdapter == "console" || logAdapter == util.AdapterStderr {
+	if logAdapter == "console" {
+		logAdapter = util.AdapterStderr
 		logs.Reset()
 	}
 	err = logs.SetLogger(logAdapter, conf.GetConfigString("logConfig"))

--- a/util/logger.go
+++ b/util/logger.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"sync"
 	"time"
 
@@ -33,6 +34,8 @@ const AdapterStderr = "stderr"
 var logLevelNames = [logs.LevelDebug + 1]string{
 	"emergency", "alert", "critical", "error", "warning", "notice", "info", "debug",
 }
+
+var ansiEscapeRegexp = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 // defaultTimeFormat is the timestamp format used in plain-text log output.
 const defaultTimeFormat = "2006/01/02 15:04:05.000 "
@@ -90,7 +93,7 @@ type stderrWriter struct {
 
 // Format implements logs.LogFormatter. It provides plain-text output without color escapes.
 func (w *stderrWriter) Format(lm *logs.LogMsg) string {
-	msg := lm.OldStyleFormat()
+	msg := ansiEscapeRegexp.ReplaceAllString(lm.OldStyleFormat(), "")
 	t := lm.When.Format(defaultTimeFormat)
 	return t + msg
 }

--- a/util/logger.go
+++ b/util/logger.go
@@ -53,6 +53,7 @@ func (j *JSONFormatter) Format(lm *logs.LogMsg) string {
 	if len(lm.Args) > 0 {
 		msg = fmt.Sprintf(lm.Msg, lm.Args...)
 	}
+	msg = ansiEscapeRegexp.ReplaceAllString(msg, "")
 
 	level := "unknown"
 	if lm.Level >= 0 && lm.Level <= logs.LevelDebug {

--- a/util/logger.go
+++ b/util/logger.go
@@ -47,6 +47,7 @@ const defaultTimeFormat = "2006/01/02 15:04:05.000 "
 //	logConfig = {"adapter":"file","filename":"logs/casdoor.log","formatter":"json"}
 type JSONFormatter struct{}
 
+// Format renders a log message as a JSON string.
 func (j *JSONFormatter) Format(lm *logs.LogMsg) string {
 	msg := lm.Msg
 	if len(lm.Args) > 0 {


### PR DESCRIPTION
fix: https://github.com/casdoor/casdoor/issues/5211

Fixed color display issues in the console;
Formatted logs are limited by the fact that Beego logger has not yet been implemented.