### PR TITLE
feat: enable storing OAuth avatars in default storage provider

### DIFF
--- a/object/user_util.go
+++ b/object/user_util.go
@@ -248,10 +248,33 @@ func SetUserOAuthProperties(organization *Organization, user *User, providerType
 	}
 
 	if userInfo.AvatarUrl != "" {
-		propertyName := fmt.Sprintf("oauth_%s_avatarUrl", providerType)
-		setUserProperty(user, propertyName, userInfo.AvatarUrl)
-		if user.Avatar == "" || user.Avatar == organization.DefaultAvatar {
-			user.Avatar = userInfo.AvatarUrl
+		if defaultStorageProvider == nil {
+			propertyName := fmt.Sprintf("oauth_%s_avatarUrl", providerType)
+			setUserProperty(user, propertyName, userInfo.AvatarUrl)
+			if user.Avatar == "" || user.Avatar == organization.DefaultAvatar {
+				user.Avatar = userInfo.AvatarUrl
+			}
+		} else {
+			propertyName := fmt.Sprintf("oauth_%s_avatarUrl", providerType)
+
+			cdnAvatarUrl, err := getPermanentAvatarUrl(user.Owner, user.Name, userInfo.AvatarUrl, false)
+			if err != nil {
+				return false, err
+			}
+
+			if getUserProperty(user, propertyName) != cdnAvatarUrl {
+				cdnAvatarUrl, err = getPermanentAvatarUrl(user.Owner, user.Name, userInfo.AvatarUrl, true)
+				if err != nil {
+					return false, err
+				}
+			}
+
+			setUserProperty(user, propertyName, cdnAvatarUrl)
+
+			if user.Avatar == "" || user.Avatar == organization.DefaultAvatar || user.Avatar == userInfo.AvatarUrl {
+				user.Avatar = cdnAvatarUrl
+				user.PermanentAvatar = cdnAvatarUrl
+			}
 		}
 	}
 


### PR DESCRIPTION

### Completed the OAuth avatar sync flow when a default storage provider is configured.

The newly added `else` branch does the following:

- It first calls `getPermanentAvatarUrl(..., false)` to compute the target CDN URL for the user's avatar in the default storage backend.
- It uses the `oauth_<provider>_avatarUrl` property to determine whether the avatar has already been synced.
- If the stored property value does not match the expected CDN URL, it calls `getPermanentAvatarUrl(..., true)` to download the third-party avatar and upload it to the default storage backend.
- After the upload, it updates the property to store the CDN URL instead of the original third-party avatar URL.
- It only updates `user.Avatar` and `user.PermanentAvatar` to the new CDN URL when the current avatar is empty, still uses the organization default avatar, or still points to the third-party avatar URL, so user-customized avatars are not overwritten