### PR TITLE
fix: use pre-configured IdP certificate for SAML signature validation

### DIFF
--- a/object/saml_sp.go
+++ b/object/saml_sp.go
@@ -154,13 +154,10 @@ func buildSpKeyStore() (dsig.X509KeyStore, error) {
 
 func buildSpCertificateStore(provider *Provider, samlResponse string) (certStore dsig.MemoryX509CertificateStore, err error) {
 	certEncodedData := ""
-	if samlResponse != "" {
-		certEncodedData, err = getCertificateFromSamlResponse(samlResponse, provider.Type)
-		if err != nil {
-			return
-		}
-	} else if provider.IdP != "" {
+	if provider.IdP != "" {
 		certEncodedData = provider.IdP
+	} else {
+		return certStore, fmt.Errorf("provider IdP certificate is not configured")
 	}
 
 	var certData []byte


### PR DESCRIPTION
## Summary

- Always use the administrator-configured `provider.IdP` certificate in `buildSpCertificateStore()` instead of extracting it from the incoming SAMLResponse
- Return an error if no IdP certificate is configured, preventing misconfigured providers from silently accepting unsigned assertions

Fixes https://github.com/casdoor/casdoor/issues/5313

## Changes

**`object/saml_sp.go`** — `buildSpCertificateStore()`:
- Removed the code path that called `getCertificateFromSamlResponse()` to extract the certificate from the SAML response
- The function now always uses `provider.IdP` as the trust anchor
- Added an error return when `provider.IdP` is not configured

## Test plan

- [ ] Verify SAML login still works with a legitimate IdP (certificate configured in provider settings)
- [ ] Verify that a SAMLResponse signed with an arbitrary self-signed certificate is rejected
- [ ] Verify that a provider without a configured IdP certificate returns an error