### PR TITLE
fix: enforce MFA check in social login binding-rule path

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -1040,6 +1040,10 @@ func (c *ApiController) Login() {
 					return
 				}
 
+				if checkMfaEnable(c, user, organization, verificationType) {
+					return
+				}
+
 				resp = c.HandleLoggedIn(application, user, &authForm)
 
 				c.Ctx.Input.SetParam("recordUserId", user.GetId())


### PR DESCRIPTION
## Summary

- Add missing `checkMfaEnable()` call before `HandleLoggedIn()` in the binding-rule code path of `Login()` handler
- MFA is now consistently enforced regardless of whether the user is matched by direct provider-ID or by binding rule (email/phone/name)

Fixes https://github.com/casdoor/casdoor/issues/5315

## Changes

**`controllers/auth.go`**:
- Added `checkMfaEnable(c, user, organization, verificationType)` call after `LinkUserAccount()` and before `HandleLoggedIn()` in the binding-rule path

## Test plan

- [ ] Verify MFA-enabled user logging in via direct provider-ID match still gets MFA challenge
- [ ] Verify MFA-enabled user logging in via binding-rule match (e.g., email match) now gets MFA challenge
- [ ] Verify non-MFA user can still log in via binding-rule match without issue