### PR TITLE
fix: replace unsafe eval with JSON.parse in parseObject (CWE-94)

### DIFF
--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -940,7 +940,7 @@ export function getMfaItemsByRules(user, organization, mfaRules = []) {
 
 export function parseObject(s) {
   try {
-    return eval("(" + s + ")");
+    return JSON.parse(s);
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
## Summary

Fixes #5333 — The `parseObject` function used `eval("(" + s + ")")` to parse strings, which can execute arbitrary JavaScript if called with untrusted input.

## Changes

- Replaced `eval("(" + s + ")")` with `JSON.parse(s)` in the `parseObject` function
- This is a safe drop-in replacement because the Go backend always produces valid JSON, so `JSON.parse` will correctly parse all legitimate inputs while rejecting code injection attempts

## CWE Reference

- **CWE-94**: Improper Control of Generation of Code ('Code Injection')
- **Severity**: Medium

## Testing

- Verify that all pages using `parseObject` continue to work correctly (the function is used for parsing backend responses)
- Verify that `parseObject('{"key": "value"}')` returns the expected object
- Verify that `parseObject('alert(1)')` returns `null` instead of executing code

---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*