### PR TITLE
fix: use SELinux collector for SELinux log providers

### DIFF
--- a/object/log_provider.go
+++ b/object/log_provider.go
@@ -64,12 +64,7 @@ func startLogCollector(provider *Provider) {
 		delete(runningCollectors, id)
 	}
 
-	tag := provider.Title
-	if tag == "" {
-		tag = "casdoor"
-	}
-
-	lp, err := log.NewSystemLogProvider(tag)
+	lp, err := log.GetLogProvider(provider.Type, provider.Host, provider.Port, provider.Title)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This PR fixes SELinux Log providers to use the SELinux log collector instead of the system log collector.