### PR TITLE
feat: add back buy-product API for compatibility

### DIFF
--- a/authz/authz.go
+++ b/authz/authz.go
@@ -69,6 +69,7 @@ p, *, *, GET, /api/get-resources, *, *
 p, *, *, GET, /api/get-records, *, *
 p, *, *, GET, /api/get-product, *, *
 p, *, *, GET, /api/get-products, *, *
+p, *, *, POST, /api/buy-product, *, *
 p, *, *, GET, /api/get-order, *, *
 p, *, *, GET, /api/get-orders, *, *
 p, *, *, GET, /api/get-user-orders, *, *

--- a/controllers/product.go
+++ b/controllers/product.go
@@ -16,6 +16,8 @@ package controllers
 
 import (
 	"encoding/json"
+	"fmt"
+	"strconv"
 
 	"github.com/beego/beego/v2/core/utils/pagination"
 	"github.com/casdoor/casdoor/object"
@@ -148,4 +150,79 @@ func (c *ApiController) DeleteProduct() {
 
 	c.Data["json"] = wrapActionResponse(object.DeleteProduct(&product))
 	c.ServeJSON()
+}
+
+// BuyProduct
+// @Title BuyProduct (Deprecated)
+// @Tag Product API
+// @Description buy product using the deprecated compatibility endpoint, prefer place-order plus pay-order for new integrations
+// @Param   id             query    string  true   "The id ( owner/name ) of the product"
+// @Param   providerName   query    string  true   "The name of the provider"
+// @Param   pricingName    query    string  false  "The name of the pricing (for subscription)"
+// @Param   planName       query    string  false  "The name of the plan (for subscription)"
+// @Param   userName       query    string  false  "The username to buy product for (admin only)"
+// @Param   paymentEnv     query    string  false  "The payment environment"
+// @Param   customPrice    query    number  false  "Custom price for recharge products"
+// @Success 200 {object} controllers.Response The Response object
+// @router /buy-product [post]
+func (c *ApiController) BuyProduct() {
+	id := c.Ctx.Input.Query("id")
+	host := c.Ctx.Request.Host
+	providerName := c.Ctx.Input.Query("providerName")
+	paymentEnv := c.Ctx.Input.Query("paymentEnv")
+	customPriceStr := c.Ctx.Input.Query("customPrice")
+	if customPriceStr == "" {
+		customPriceStr = "0"
+	}
+
+	customPrice, err := strconv.ParseFloat(customPriceStr, 64)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	pricingName := c.Ctx.Input.Query("pricingName")
+	planName := c.Ctx.Input.Query("planName")
+	paidUserName := c.Ctx.Input.Query("userName")
+
+	owner, _, err := util.GetOwnerAndNameFromIdWithError(id)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	var userId string
+	if paidUserName != "" {
+		userId = util.GetId(owner, paidUserName)
+		if userId != c.GetSessionUsername() && !c.IsAdmin() && userId != c.GetPaidUsername() {
+			c.ResponseError(c.T("general:Only admin user can specify user"))
+			return
+		}
+
+		c.SetSession("paidUsername", "")
+	} else {
+		userId = c.GetSessionUsername()
+	}
+	if userId == "" {
+		c.ResponseError(c.T("general:Please login first"))
+		return
+	}
+
+	user, err := object.GetUser(userId)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	if user == nil {
+		c.ResponseError(fmt.Sprintf(c.T("general:The user: %s doesn't exist"), userId))
+		return
+	}
+
+	payment, attachInfo, err := object.BuyProduct(id, user, providerName, pricingName, planName, host, paymentEnv, customPrice, c.GetAcceptLanguage())
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.ResponseOk(payment, attachInfo)
 }

--- a/object/product.go
+++ b/object/product.go
@@ -257,6 +257,26 @@ func (product *Product) getProvider(providerName string) (*Provider, error) {
 	return provider, nil
 }
 
+func BuyProduct(id string, user *User, providerName, pricingName, planName, host, paymentEnv string, customPrice float64, lang string) (payment *Payment, attachInfo map[string]interface{}, err error) {
+	owner, productName, err := util.GetOwnerAndNameFromIdWithError(id)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	order, err := PlaceOrder(owner, []ProductInfo{{
+		Name:        productName,
+		Price:       customPrice,
+		Quantity:    1,
+		PricingName: pricingName,
+		PlanName:    planName,
+	}}, user)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return PayOrder(providerName, host, paymentEnv, order, lang)
+}
+
 func ExtendProductWithProviders(product *Product) error {
 	if product == nil {
 		return nil

--- a/routers/router.go
+++ b/routers/router.go
@@ -246,6 +246,7 @@ func InitAPI() {
 	web.Router("/api/update-product", &controllers.ApiController{}, "POST:UpdateProduct")
 	web.Router("/api/add-product", &controllers.ApiController{}, "POST:AddProduct")
 	web.Router("/api/delete-product", &controllers.ApiController{}, "POST:DeleteProduct")
+	web.Router("/api/buy-product", &controllers.ApiController{}, "POST:BuyProduct")
 
 	web.Router("/api/get-orders", &controllers.ApiController{}, "GET:GetOrders")
 	web.Router("/api/get-user-orders", &controllers.ApiController{}, "GET:GetUserOrders")

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1138,6 +1138,70 @@
                 }
             }
         },
+        "/api/buy-product": {
+            "post": {
+                "tags": [
+                    "Product API"
+                ],
+                "description": "buy product using the deprecated compatibility endpoint, prefer place-order plus pay-order for new integrations",
+                "operationId": "ApiController.BuyProduct",
+                "deprecated": true,
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "id",
+                        "description": "The id ( owner/name ) of the product",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "providerName",
+                        "description": "The name of the provider",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pricingName",
+                        "description": "The name of the pricing (for subscription)",
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "planName",
+                        "description": "The name of the plan (for subscription)",
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "userName",
+                        "description": "The username to buy product for (admin only)",
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "paymentEnv",
+                        "description": "The payment environment",
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "customPrice",
+                        "description": "Custom price for recharge products",
+                        "type": "number"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The Response object",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/api/delete-adapter": {
             "post": {
                 "tags": [

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -734,6 +734,49 @@ paths:
           description: The Response object
           schema:
             $ref: '#/definitions/object.Userinfo'
+  /api/buy-product:
+    post:
+      tags:
+      - Product API
+      description: buy product using the deprecated compatibility endpoint, prefer place-order plus pay-order for new integrations
+      operationId: ApiController.BuyProduct
+      deprecated: true
+      parameters:
+      - in: query
+        name: id
+        description: The id ( owner/name ) of the product
+        required: true
+        type: string
+      - in: query
+        name: providerName
+        description: The name of the provider
+        required: true
+        type: string
+      - in: query
+        name: pricingName
+        description: The name of the pricing (for subscription)
+        type: string
+      - in: query
+        name: planName
+        description: The name of the plan (for subscription)
+        type: string
+      - in: query
+        name: userName
+        description: The username to buy product for (admin only)
+        type: string
+      - in: query
+        name: paymentEnv
+        description: The payment environment
+        type: string
+      - in: query
+        name: customPrice
+        description: Custom price for recharge products
+        type: number
+      responses:
+        "200":
+          description: The Response object
+          schema:
+            $ref: '#/definitions/controllers.Response'
   /api/delete-adapter:
     post:
       tags:


### PR DESCRIPTION
fix: https://github.com/casdoor/casdoor/issues/5348

Instead of removing `/api/buy-product` , we may need to restores the legacy `/api/buy-product` endpoint as a compatibility layer for existing integrations.

Changes

- restore `POST /api/buy-product` route
- add `/api/buy-product` back to the public API allowlist in `authz`
- reintroduce `controllers.BuyProduct` as a thin compatibility controller
- add `object.BuyProduct` as the compatibility wrapper over:
  - `object.PlaceOrder`
  - `object.PayOrder`
- restore Swagger docs for `/api/buy-product` and mark it as deprecated compatibility API