### PR TITLE
feat: add provider-based entry viewers for SELinux logs

### DIFF
--- a/web/src/EntryListPage.js
+++ b/web/src/EntryListPage.js
@@ -119,7 +119,7 @@ class EntryListPage extends BaseListPage {
       .catch(() => {
         this.setState({
           providerMap: {},
-          providerOwner: owner,
+          providerOwner: "",
         });
         return {};
       });

--- a/web/src/EntryMessageViewer.js
+++ b/web/src/EntryMessageViewer.js
@@ -28,9 +28,12 @@ class EntryMessageViewer extends React.Component {
       selectedTraceSpan: null,
       provider: null,
     };
+    this.pendingProviderRequestKey = "";
+    this.isUnmounted = false;
   }
 
   componentDidMount() {
+    this.isUnmounted = false;
     this.getProvider();
   }
 
@@ -44,8 +47,14 @@ class EntryMessageViewer extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    this.isUnmounted = true;
+    this.pendingProviderRequestKey = "";
+  }
+
   getProvider() {
     if (this.props.provider) {
+      this.pendingProviderRequestKey = "";
       if (this.state.provider !== null) {
         this.setState({provider: null});
       }
@@ -56,14 +65,22 @@ class EntryMessageViewer extends React.Component {
     const owner = this.props.entry?.owner;
 
     if (!providerName || !owner) {
+      this.pendingProviderRequestKey = "";
       if (this.state.provider !== null) {
         this.setState({provider: null});
       }
       return;
     }
 
+    const requestKey = `${owner}/${providerName}`;
+    this.pendingProviderRequestKey = requestKey;
+
     ProviderBackend.getProvider(owner, providerName)
       .then((res) => {
+        if (this.isUnmounted || this.pendingProviderRequestKey !== requestKey) {
+          return;
+        }
+
         if (res.status === "ok") {
           this.setState({
             provider: res.data ?? null,
@@ -75,6 +92,10 @@ class EntryMessageViewer extends React.Component {
         }
       })
       .catch(() => {
+        if (this.isUnmounted || this.pendingProviderRequestKey !== requestKey) {
+          return;
+        }
+
         this.setState({
           provider: null,
         });
@@ -461,14 +482,9 @@ class EntryMessageViewer extends React.Component {
 
     const category = `${provider.category ?? ""}`.trim();
     const type = `${provider.type ?? ""}`.trim();
-    const subType = `${provider.subType ?? ""}`.trim();
 
     if (category === "Log" && type === "SELinux Log") {
       return "selinux";
-    }
-
-    if (category === "Log" && type === "Agent" && subType === "OpenClaw") {
-      return "openclaw";
     }
 
     return "";

--- a/web/src/SELinuxEntryViewer.js
+++ b/web/src/SELinuxEntryViewer.js
@@ -43,13 +43,18 @@ class SELinuxEntryViewer extends React.Component {
     }
   }
 
+  escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
   extractValue(message, key) {
-    const quotedMatch = message.match(new RegExp(`${key}="([^"]*)"`, "i"));
+    const escapedKey = this.escapeRegExp(key);
+    const quotedMatch = message.match(new RegExp(`(?:^|\\s)${escapedKey}="([^"]*)"`, "i"));
     if (quotedMatch) {
       return quotedMatch[1];
     }
 
-    const plainMatch = message.match(new RegExp(`${key}=([^\\s]+)`, "i"));
+    const plainMatch = message.match(new RegExp(`(?:^|\\s)${escapedKey}=([^\\s]+)`, "i"));
     return plainMatch ? plainMatch[1] : "";
   }
 


### PR DESCRIPTION
## Summary

This PR adds a frontend-only SELinux log viewer for entries.

## What changed

- add `SELinuxEntryViewer` to parse SELinux audit messages into a structured view
- route entry viewers on the frontend using provider `category/type/subType`
- reuse the same viewer logic on both:
  - entry detail page
  - entry list page message popover
- preload log providers on the list page to avoid per-row API calls