### PR TITLE
fix: fix checking shared-app login permission in user organization

### DIFF
--- a/object/check.go
+++ b/object/check.go
@@ -587,7 +587,12 @@ func CheckLoginPermission(userId string, application *Application) (bool, error)
 		return true, nil
 	}
 
-	permissions, err := GetPermissions(application.Organization)
+	permissionOrganization := application.Organization
+	if application.IsShared {
+		permissionOrganization = owner
+	}
+
+	permissions, err := GetPermissions(permissionOrganization)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
fix #5326
# Cause

In shared-app OAuth login, permission checks could use the default application organization, causing linked-organization users to be rejected with "Unauthorized operation".

# Changed

Use the signed-in user's organization for shared-app login permission checks.