### PR TITLE
fix: prevent owner field tampering in entity update APIs

### DIFF
--- a/object/adapter.go
+++ b/object/adapter.go
@@ -116,6 +116,7 @@ func UpdateAdapter(id string, adapter *Adapter) (bool, error) {
 	if adapter.Password == "***" {
 		session.Omit("password")
 	}
+	adapter.Owner = owner
 	affected, err := session.Update(adapter)
 	if err != nil {
 		return false, err

--- a/object/agent.go
+++ b/object/agent.go
@@ -71,6 +71,7 @@ func UpdateAgent(id string, agent *Agent) (bool, error) {
 
 	agent.UpdatedTime = util.GetCurrentTime()
 
+	agent.Owner = owner
 	_, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(agent)
 	if err != nil {
 		return false, err

--- a/object/application.go
+++ b/object/application.go
@@ -428,6 +428,7 @@ func UpdateApplication(id string, application *Application, isGlobalAdmin bool, 
 	if application.ClientSecret == "***" {
 		session.Omit("client_secret")
 	}
+	application.Owner = owner
 	affected, err := session.Update(application)
 	if err != nil {
 		return false, err

--- a/object/cert.go
+++ b/object/cert.go
@@ -194,6 +194,7 @@ func UpdateCert(id string, cert *Cert) (bool, error) {
 		return false, err
 	}
 
+	cert.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(cert)
 	if err != nil {
 		return false, err

--- a/object/enforcer.go
+++ b/object/enforcer.go
@@ -102,6 +102,7 @@ func UpdateEnforcer(id string, enforcer *Enforcer) (bool, error) {
 		return false, nil
 	}
 
+	enforcer.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(enforcer)
 	if err != nil {
 		return false, err

--- a/object/entry.go
+++ b/object/entry.go
@@ -75,6 +75,7 @@ func UpdateEntry(id string, entry *Entry) (bool, error) {
 
 	entry.UpdatedTime = util.GetCurrentTime()
 
+	entry.Owner = owner
 	_, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(entry)
 	if err != nil {
 		return false, err

--- a/object/form.go
+++ b/object/form.go
@@ -119,6 +119,7 @@ func UpdateForm(id string, form *Form) (bool, error) {
 		return false, nil
 	}
 
+	form.Owner = owner
 	_, err = ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(form)
 	if err != nil {
 		return false, err

--- a/object/group.go
+++ b/object/group.go
@@ -164,6 +164,7 @@ func UpdateGroup(id string, group *Group) (bool, error) {
 		}
 	}
 
+	group.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(group)
 	if err != nil {
 		return false, err

--- a/object/invitation.go
+++ b/object/invitation.go
@@ -157,6 +157,7 @@ func UpdateInvitation(id string, invitation *Invitation, lang string) (bool, err
 		return false, err
 	}
 
+	invitation.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(invitation)
 	if err != nil {
 		return false, err

--- a/object/key.go
+++ b/object/key.go
@@ -153,6 +153,7 @@ func UpdateKey(id string, key *Key) (bool, error) {
 
 	key.UpdatedTime = util.GetCurrentTime()
 
+	key.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(key)
 	if err != nil {
 		return false, err

--- a/object/ldap.go
+++ b/object/ldap.go
@@ -152,6 +152,7 @@ func UpdateLdap(ldap *Ldap) (bool, error) {
 		ldap.Password = l.Password
 	}
 
+	ldap.Owner = l.Owner
 	affected, err := ormer.Engine.ID(ldap.Id).Cols("owner", "server_name", "host",
 		"port", "enable_ssl", "username", "password", "base_dn", "filter", "filter_fields", "auto_sync", "default_group", "password_type", "allow_self_signed_cert", "custom_attributes", "enable_groups").Update(ldap)
 	if err != nil {

--- a/object/model.go
+++ b/object/model.go
@@ -136,6 +136,7 @@ func UpdateModel(id string, modelObj *Model) (bool, error) {
 		}
 	}
 
+	modelObj.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(modelObj)
 	if err != nil {
 		return false, err

--- a/object/order.go
+++ b/object/order.go
@@ -176,6 +176,7 @@ func UpdateOrder(id string, order *Order) (bool, error) {
 		order.Price = price
 	}
 
+	order.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(order)
 	if err != nil {
 		return false, err

--- a/object/organization.go
+++ b/object/organization.go
@@ -268,6 +268,7 @@ func UpdateOrganization(id string, organization *Organization, isGlobalAdmin boo
 		session.Omit("master_verification_code")
 	}
 
+	organization.Owner = owner
 	affected, err := session.Update(organization)
 	if err != nil {
 		return false, err

--- a/object/payment.go
+++ b/object/payment.go
@@ -184,6 +184,7 @@ func UpdatePayment(id string, payment *Payment) (bool, error) {
 		return false, nil
 	}
 
+	payment.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(payment)
 	if err != nil {
 		return false, err

--- a/object/permission.go
+++ b/object/permission.go
@@ -153,6 +153,7 @@ func UpdatePermission(id string, permission *Permission) (bool, error) {
 		}
 	}
 
+	permission.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(permission)
 	if err != nil {
 		return false, err

--- a/object/plan.go
+++ b/object/plan.go
@@ -127,6 +127,7 @@ func UpdatePlan(id string, plan *Plan) (bool, error) {
 		return false, nil
 	}
 
+	plan.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(plan)
 	if err != nil {
 		return false, err

--- a/object/pricing.go
+++ b/object/pricing.go
@@ -130,6 +130,7 @@ func UpdatePricing(id string, pricing *Pricing) (bool, error) {
 		return false, nil
 	}
 
+	pricing.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(pricing)
 	if err != nil {
 		return false, err

--- a/object/product.go
+++ b/object/product.go
@@ -145,6 +145,7 @@ func UpdateProduct(id string, product *Product) (bool, error) {
 		return false, err
 	}
 
+	product.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(product)
 	if err != nil {
 		return false, err

--- a/object/provider.go
+++ b/object/provider.go
@@ -258,6 +258,7 @@ func UpdateProvider(id string, provider *Provider) (bool, error) {
 		provider.IntranetEndpoint = util.GetEndPoint(provider.IntranetEndpoint)
 	}
 
+	provider.Owner = owner
 	affected, err := session.Update(provider)
 	if err != nil {
 		return false, err

--- a/object/resource.go
+++ b/object/resource.go
@@ -107,6 +107,7 @@ func UpdateResource(id string, resource *Resource) (bool, error) {
 		return false, nil
 	}
 
+	resource.Owner = owner
 	_, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(resource)
 	if err != nil {
 		return false, err

--- a/object/role.go
+++ b/object/role.go
@@ -121,6 +121,7 @@ func UpdateRole(id string, role *Role) (bool, error) {
 		}
 	}
 
+	role.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(role)
 	if err != nil {
 		return false, err

--- a/object/rule.go
+++ b/object/rule.go
@@ -79,6 +79,7 @@ func UpdateRule(id string, rule *Rule) (bool, error) {
 		return false, nil
 	}
 	rule.UpdatedTime = util.GetCurrentTime()
+	rule.Owner = owner
 	_, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(rule)
 	if err != nil {
 		return false, err

--- a/object/server.go
+++ b/object/server.go
@@ -88,6 +88,7 @@ func UpdateServer(id string, server *Server) (bool, error) {
 
 	_ = syncServerTools(server)
 
+	server.Owner = owner
 	_, err = ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(server)
 	if err != nil {
 		return false, err
@@ -128,6 +129,7 @@ func SyncMcpTool(id string, server *Server, isCleared bool) (bool, error) {
 		return false, err
 	}
 
+	server.Owner = owner
 	_, err = ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(server)
 	if err != nil {
 		return false, err

--- a/object/site.go
+++ b/object/site.go
@@ -156,6 +156,7 @@ func UpdateSite(id string, site *Site) (bool, error) {
 
 	site.UpdatedTime = util.GetCurrentTime()
 
+	site.Owner = owner
 	_, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(site)
 	if err != nil {
 		return false, err
@@ -177,6 +178,7 @@ func UpdateSiteNoRefresh(id string, site *Site) (bool, error) {
 		return false, nil
 	}
 
+	site.Owner = owner
 	_, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(site)
 	if err != nil {
 		return false, err

--- a/object/subscription.go
+++ b/object/subscription.go
@@ -248,6 +248,7 @@ func UpdateSubscription(id string, subscription *Subscription) (bool, error) {
 		return false, nil
 	}
 
+	subscription.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(subscription)
 	if err != nil {
 		return false, err

--- a/object/syncer.go
+++ b/object/syncer.go
@@ -181,6 +181,7 @@ func UpdateSyncer(id string, syncer *Syncer, isGlobalAdmin bool, lang string) (b
 	if syncer.Password == "***" {
 		syncer.Password = s.Password
 	}
+	syncer.Owner = owner
 	affected, err := session.Update(syncer)
 	if err != nil {
 		return false, err

--- a/object/ticket.go
+++ b/object/ticket.go
@@ -114,6 +114,7 @@ func UpdateTicket(id string, ticket *Ticket) (bool, error) {
 		return false, nil
 	}
 
+	ticket.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(ticket)
 	if err != nil {
 		return false, err

--- a/object/token.go
+++ b/object/token.go
@@ -199,6 +199,7 @@ func UpdateToken(id string, token *Token, isGlobalAdmin bool) (bool, error) {
 
 	token.popularHashes()
 
+	token.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(token)
 	if err != nil {
 		return false, err

--- a/object/transaction.go
+++ b/object/transaction.go
@@ -133,6 +133,7 @@ func UpdateTransaction(id string, transaction *Transaction, lang string) (bool, 
 		return false, err
 	}
 
+	transaction.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(transaction)
 	if err != nil {
 		return false, err

--- a/object/user.go
+++ b/object/user.go
@@ -838,6 +838,8 @@ func UpdateUser(id string, user *User, columns []string, isAdmin bool) (bool, er
 		}
 	}
 
+	user.Owner = owner
+
 	if len(columns) == 0 {
 		columns = []string{
 			"owner", "display_name", "avatar", "first_name", "last_name",
@@ -942,6 +944,7 @@ func UpdateUserForAllFields(id string, user *User) (bool, error) {
 		}
 	}
 
+	user.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(user)
 	if err != nil {
 		return false, err

--- a/object/webhook.go
+++ b/object/webhook.go
@@ -127,6 +127,7 @@ func UpdateWebhook(id string, webhook *Webhook, isGlobalAdmin bool, lang string)
 		return false, errors.New(i18n.Translate(lang, "auth:Unauthorized operation"))
 	}
 
+	webhook.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(webhook)
 	if err != nil {
 		return false, err

--- a/object/webhook_event.go
+++ b/object/webhook_event.go
@@ -198,6 +198,7 @@ func UpdateWebhookEvent(id string, event *WebhookEvent) (bool, error) {
 
 	event.UpdatedTime = util.GetCurrentTime()
 
+	event.Owner = owner
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(event)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
## Summary

- Fix a cross-organization privilege escalation vulnerability where org admins could transfer entities to other organizations by tampering with the `owner` field in update API request bodies
- The authz filter correctly validates permissions using the `id` query parameter, but the object-layer update functions wrote the body's `owner` field directly to the database without validation
- Force `entity.Owner = owner` (from the validated `id` param) before every `AllCols().Update()` and `Cols`-based update that includes `owner`, across all 33 affected files (35 update functions)

### Attack vector (before fix)

```
POST /api/update-group?id=orgA/myGroup
Body: {"owner": "orgB", "name": "myGroup", ...}

1. authz filter: objOwner="orgA" from id param → subOwner==objOwner ✓
2. controller: deserializes body with owner="orgB"
3. object layer: UPDATE group SET owner='orgB' WHERE owner='orgA' AND name='myGroup'
4. Entity transferred to orgB — privilege escalation
```

### Affected entities (35 functions, 33 files)

- **Identity**: Organization, Group, User (UpdateUser + UpdateUserForAllFields), Invitation
- **Authentication**: Application, Provider, Cert, Key, Resource
- **Authorization**: Role, Permission, Model, Adapter, Enforcer
- **LLM AI**: Agent, Server (UpdateServer + SyncMcpTool), Entry, Site (UpdateSite + UpdateSiteNoRefresh), Rule
- **Audit**: Token, Webhook, WebhookEvent, Form, Ticket
- **Business**: Product, Plan, Pricing, Subscription, Payment, Transaction, Order
- **Admin**: Syncer, Ldap

## Test plan

- [ ] As org admin of OrgA, update a group with `"owner": "OrgB"` in request body → owner should remain OrgA
- [ ] As global admin, normal update operations should work unchanged
- [ ] Verify all CRUD operations still function correctly after the fix