### PR TITLE
fix: prevent non-global-admin from tampering entity owner field

### DIFF
--- a/controllers/adapter.go
+++ b/controllers/adapter.go
@@ -102,6 +102,8 @@ func (c *ApiController) UpdateAdapter() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { adapter.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateAdapter(id, &adapter))
 	c.ServeJSON()
 }

--- a/controllers/agent.go
+++ b/controllers/agent.go
@@ -106,6 +106,8 @@ func (c *ApiController) UpdateAgent() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { agent.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateAgent(id, &agent))
 	c.ServeJSON()
 }

--- a/controllers/application.go
+++ b/controllers/application.go
@@ -232,6 +232,8 @@ func (c *ApiController) UpdateApplication() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { application.Owner = owner })
+
 	if err = object.CheckIpWhitelist(application.IpWhitelist, c.GetAcceptLanguage()); err != nil {
 		c.ResponseError(err.Error())
 		return

--- a/controllers/cert.go
+++ b/controllers/cert.go
@@ -142,6 +142,8 @@ func (c *ApiController) UpdateCert() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { cert.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateCert(id, &cert))
 	c.ServeJSON()
 }

--- a/controllers/enforcer.go
+++ b/controllers/enforcer.go
@@ -114,6 +114,8 @@ func (c *ApiController) UpdateEnforcer() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { enforcer.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateEnforcer(id, &enforcer))
 	c.ServeJSON()
 }

--- a/controllers/entry.go
+++ b/controllers/entry.go
@@ -125,6 +125,8 @@ func (c *ApiController) UpdateEntry() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { entry.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateEntry(id, &entry))
 	c.ServeJSON()
 }

--- a/controllers/form.go
+++ b/controllers/form.go
@@ -117,6 +117,8 @@ func (c *ApiController) UpdateForm() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { form.Owner = owner })
+
 	success, err := object.UpdateForm(id, &form)
 	if err != nil {
 		c.ResponseError(err.Error())

--- a/controllers/group.go
+++ b/controllers/group.go
@@ -144,6 +144,8 @@ func (c *ApiController) UpdateGroup() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { group.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateGroup(id, &group))
 	c.ServeJSON()
 }

--- a/controllers/invitation.go
+++ b/controllers/invitation.go
@@ -134,6 +134,8 @@ func (c *ApiController) UpdateInvitation() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { invitation.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateInvitation(id, &invitation, c.GetAcceptLanguage()))
 	c.ServeJSON()
 }

--- a/controllers/key.go
+++ b/controllers/key.go
@@ -174,10 +174,7 @@ func (c *ApiController) UpdateKey() {
 		return
 	}
 
-	if !c.IsGlobalAdmin() && oldKey.Owner != key.Owner {
-		c.ResponseError(c.T("auth:Unauthorized operation"))
-		return
-	}
+	c.enforceOwnerFromId(id, func(owner string) { key.Owner = owner })
 
 	c.Data["json"] = wrapActionResponse(object.UpdateKey(id, &key))
 	c.ServeJSON()

--- a/controllers/ldap.go
+++ b/controllers/ldap.go
@@ -211,6 +211,10 @@ func (c *ApiController) UpdateLdap() {
 		return
 	}
 
+	if !c.IsGlobalAdmin() && prevLdap != nil {
+		ldap.Owner = prevLdap.Owner
+	}
+
 	affected, err := object.UpdateLdap(&ldap)
 	if err != nil {
 		c.ResponseError(err.Error())

--- a/controllers/model.go
+++ b/controllers/model.go
@@ -102,6 +102,8 @@ func (c *ApiController) UpdateModel() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { model.Owner = owner })
+
 	c.Data["json"] = wrapErrorResponse(object.UpdateModelWithCheck(id, &model))
 	c.ServeJSON()
 }

--- a/controllers/order.go
+++ b/controllers/order.go
@@ -152,6 +152,8 @@ func (c *ApiController) UpdateOrder() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { order.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateOrder(id, &order))
 	c.ServeJSON()
 }

--- a/controllers/organization.go
+++ b/controllers/organization.go
@@ -123,6 +123,8 @@ func (c *ApiController) UpdateOrganization() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { organization.Owner = owner })
+
 	if err = object.CheckIpWhitelist(organization.IpWhitelist, c.GetAcceptLanguage()); err != nil {
 		c.ResponseError(err.Error())
 		return

--- a/controllers/payment.go
+++ b/controllers/payment.go
@@ -153,6 +153,8 @@ func (c *ApiController) UpdatePayment() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { payment.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdatePayment(id, &payment))
 	c.ServeJSON()
 }

--- a/controllers/permission.go
+++ b/controllers/permission.go
@@ -141,6 +141,8 @@ func (c *ApiController) UpdatePermission() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { permission.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdatePermission(id, &permission))
 	c.ServeJSON()
 }

--- a/controllers/plan.go
+++ b/controllers/plan.go
@@ -115,6 +115,9 @@ func (c *ApiController) UpdatePlan() {
 		c.ResponseError(err.Error())
 		return
 	}
+
+	c.enforceOwnerFromId(id, func(owner string) { plan.Owner = owner })
+
 	if plan.Product != "" {
 		productId := util.GetId(owner, plan.Product)
 		product, err := object.GetProduct(productId)

--- a/controllers/pricing.go
+++ b/controllers/pricing.go
@@ -102,6 +102,8 @@ func (c *ApiController) UpdatePricing() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { pricing.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdatePricing(id, &pricing))
 	c.ServeJSON()
 }

--- a/controllers/product.go
+++ b/controllers/product.go
@@ -110,6 +110,8 @@ func (c *ApiController) UpdateProduct() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { product.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateProduct(id, &product))
 	c.ServeJSON()
 }

--- a/controllers/provider.go
+++ b/controllers/provider.go
@@ -173,6 +173,8 @@ func (c *ApiController) UpdateProvider() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { provider.Owner = owner })
+
 	ok := c.requireProviderPermission(&provider)
 	if !ok {
 		return

--- a/controllers/resource.go
+++ b/controllers/resource.go
@@ -141,6 +141,8 @@ func (c *ApiController) UpdateResource() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { resource.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateResource(id, &resource))
 	c.ServeJSON()
 }

--- a/controllers/role.go
+++ b/controllers/role.go
@@ -102,6 +102,8 @@ func (c *ApiController) UpdateRole() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { role.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateRole(id, &role))
 	c.ServeJSON()
 }

--- a/controllers/rule.go
+++ b/controllers/rule.go
@@ -126,6 +126,8 @@ func (c *ApiController) AddRule() {
 // @Success 200 {object} controllers.Response The Response object
 // @router /update-rule [post]
 func (c *ApiController) UpdateRule() {
+	id := c.Ctx.Input.Query("id")
+
 	var rule object.Rule
 	err := json.Unmarshal(c.Ctx.Input.RequestBody, &rule)
 	if err != nil {
@@ -133,13 +135,14 @@ func (c *ApiController) UpdateRule() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { rule.Owner = owner })
+
 	err = checkExpressions(rule.Expressions, rule.Type)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
 	}
 
-	id := c.Ctx.Input.Query("id")
 	c.Data["json"] = wrapActionResponse(object.UpdateRule(id, &rule))
 	c.ServeJSON()
 }

--- a/controllers/server.go
+++ b/controllers/server.go
@@ -106,6 +106,8 @@ func (c *ApiController) UpdateServer() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { server.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateServer(id, &server))
 	c.ServeJSON()
 }

--- a/controllers/session.go
+++ b/controllers/session.go
@@ -100,7 +100,10 @@ func (c *ApiController) UpdateSession() {
 		return
 	}
 
-	c.Data["json"] = wrapActionResponse(object.UpdateSession(util.GetSessionId(session.Owner, session.Name, session.Application), &session))
+	id := util.GetSessionId(session.Owner, session.Name, session.Application)
+	c.enforceOwnerFromId(id, func(owner string) { session.Owner = owner })
+
+	c.Data["json"] = wrapActionResponse(object.UpdateSession(id, &session))
 	c.ServeJSON()
 }
 

--- a/controllers/site.go
+++ b/controllers/site.go
@@ -122,6 +122,8 @@ func (c *ApiController) UpdateSite() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { site.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateSite(id, &site))
 	c.ServeJSON()
 }

--- a/controllers/subscription.go
+++ b/controllers/subscription.go
@@ -132,6 +132,8 @@ func (c *ApiController) UpdateSubscription() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { subscription.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateSubscription(id, &subscription))
 	c.ServeJSON()
 }

--- a/controllers/syncer.go
+++ b/controllers/syncer.go
@@ -104,6 +104,8 @@ func (c *ApiController) UpdateSyncer() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { syncer.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateSyncer(id, &syncer, c.IsGlobalAdmin(), c.GetAcceptLanguage()))
 	c.ServeJSON()
 }

--- a/controllers/ticket.go
+++ b/controllers/ticket.go
@@ -138,6 +138,8 @@ func (c *ApiController) UpdateTicket() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { ticket.Owner = owner })
+
 	// Check permission
 	user := c.getCurrentUser()
 	isAdmin := c.IsAdmin()

--- a/controllers/token.go
+++ b/controllers/token.go
@@ -105,6 +105,8 @@ func (c *ApiController) UpdateToken() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { token.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateToken(id, &token, c.IsGlobalAdmin()))
 	c.ServeJSON()
 }

--- a/controllers/transaction.go
+++ b/controllers/transaction.go
@@ -155,6 +155,8 @@ func (c *ApiController) UpdateTransaction() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { transaction.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateTransaction(id, &transaction, c.GetAcceptLanguage()))
 	c.ServeJSON()
 }

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -342,6 +342,8 @@ func (c *ApiController) UpdateUser() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { user.Owner = owner })
+
 	columns := []string{}
 	if columnsStr != "" {
 		columns = strings.Split(columnsStr, ",")

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -59,6 +59,19 @@ func (c *ApiController) ResponseError(error string, data ...interface{}) {
 	c.ResponseJsonData(resp, data...)
 }
 
+// enforceOwnerFromId prevents non-global-admin users from tampering with the
+// owner field in update requests. It extracts the owner from the id query
+// parameter (which has been validated by the authz filter) and forces it onto
+// the entity struct when the caller is not a global admin.
+// Returns the owner and name parsed from id.
+func (c *ApiController) enforceOwnerFromId(id string, setOwner func(owner string)) (string, string) {
+	owner, name := util.GetOwnerAndNameFromIdNoCheck(id)
+	if !c.IsGlobalAdmin() {
+		setOwner(owner)
+	}
+	return owner, name
+}
+
 func (c *ApiController) T(error string) string {
 	return i18n.Translate(c.GetAcceptLanguage(), error)
 }

--- a/controllers/webhook.go
+++ b/controllers/webhook.go
@@ -105,6 +105,8 @@ func (c *ApiController) UpdateWebhook() {
 		return
 	}
 
+	c.enforceOwnerFromId(id, func(owner string) { webhook.Owner = owner })
+
 	c.Data["json"] = wrapActionResponse(object.UpdateWebhook(id, &webhook, c.IsGlobalAdmin(), c.GetAcceptLanguage()))
 	c.ServeJSON()
 }


### PR DESCRIPTION
Add enforceOwnerFromId() helper in controllers that forces the entity's owner to match the id query parameter — but only for non-global-admin users. Global admins can still reassign entities across organizations.

This prevents org admins from transferring entities to other orgs by crafting a request body with a different owner field, while preserving the ability for built-in admins to manage cross-org operations.