### PR TITLE
feat: support popup=2 mode for iframe-based login without navigation.

### DIFF
--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -326,8 +326,11 @@ class LoginPage extends React.Component {
 
   sendPopupData(message, redirectUri) {
     const params = new URLSearchParams(this.props.location.search);
-    if (params.get("popup") === "1") {
+    const popup = params.get("popup");
+    if (popup === "1") {
       window.opener.postMessage(message, redirectUri);
+    } else if (popup === "2") {
+      window.parent.postMessage(message, redirectUri);
     }
   }
 
@@ -386,7 +389,10 @@ class LoginPage extends React.Component {
           }, 1000);
         }
       } else {
-        Setting.goToLink(redirectUrl);
+        const popup = new URLSearchParams(this.props.location.search).get("popup");
+        if (popup !== "2") {
+          Setting.goToLink(redirectUrl);
+        }
         this.sendPopupData({type: "loginSuccess", data: {code: code, state: oAuthParams.state}}, oAuthParams.redirectUri);
       }
     }


### PR DESCRIPTION
fix #5290
## Changes
- **sendPopupData()**: Extended to support both:
  - popup=1: `window.opener.postMessage()` (existing, backward-compatible)
  - popup=2: `window.parent.postMessage()` (new, for iframe modal mode)
  
- **postCodeLoginAction()**: Skip page navigation when popup=2 is used
  - Prevents unwanted page redirects in iframe mode
  - Maintains existing popup=1 behavior unchanged

## Basic Usage (popup=2 Mode)
```javascript
// Parent page
const iframe = document.createElement('iframe');
iframe.src = 'https://casdoor/login/oauth/authorize?...&popup=2';

window.addEventListener('message', (e) => {
  if (e.data.type === 'loginSuccess') {
    const { code, state } = e.data.data;
    // Exchange code for token without page navigation
  }
});
```
## Follow-up Work
- Add popup=2 iframe-based login support to Casdoor SDKs.