### PR TITLE
fix: load dashboard stats correctly when tableNamePrefix is set

### DIFF
--- a/object/get-dashboard.go
+++ b/object/get-dashboard.go
@@ -96,14 +96,28 @@ func GetDashboard(owner string) (*map[string][]int64, error) {
 	for i := 30; i >= 0; i-- {
 		cutTime := nowTime.AddDate(0, 0, -i)
 		for _, tableName := range tableNames {
-			item, exist := dashboardMap.Load(tableName)
+			item, exist := getDashboardMapItem(&dashboardMap, tableNamePrefix, tableName)
 			if !exist {
 				continue
 			}
-			dashboard[tableName+"Counts"][30-i] = countCreatedBefore(item.(DashboardMapItem), cutTime)
+			dashboard[tableName+"Counts"][30-i] = countCreatedBefore(item, cutTime)
 		}
 	}
 	return &dashboard, nil
+}
+
+func getDashboardMapItem(dashboardMap *sync.Map, tableNamePrefix, tableName string) (DashboardMapItem, bool) {
+	item, exist := dashboardMap.Load(tableNamePrefix + tableName)
+	if !exist {
+		return DashboardMapItem{}, false
+	}
+
+	dashboardItem, ok := item.(DashboardMapItem)
+	if !ok {
+		return DashboardMapItem{}, false
+	}
+
+	return dashboardItem, true
 }
 
 func countCreatedBefore(dashboardMapItem DashboardMapItem, before time.Time) int64 {

--- a/object/get-dashboard_test.go
+++ b/object/get-dashboard_test.go
@@ -1,0 +1,34 @@
+package object
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestGetDashboardMapItemUsesPrefixedTableName(t *testing.T) {
+	var dashboardMap sync.Map
+	expected := DashboardMapItem{itemCount: 3}
+	dashboardMap.Store("casdoor_user", expected)
+
+	got, ok := getDashboardMapItem(&dashboardMap, "casdoor_", "user")
+	if !ok {
+		t.Fatalf("expected prefixed dashboard item to be found")
+	}
+	if got.itemCount != expected.itemCount {
+		t.Fatalf("expected itemCount=%d, got %d", expected.itemCount, got.itemCount)
+	}
+}
+
+func TestGetDashboardMapItemSupportsEmptyPrefix(t *testing.T) {
+	var dashboardMap sync.Map
+	expected := DashboardMapItem{itemCount: 5}
+	dashboardMap.Store("user", expected)
+
+	got, ok := getDashboardMapItem(&dashboardMap, "", "user")
+	if !ok {
+		t.Fatalf("expected unprefixed dashboard item to be found")
+	}
+	if got.itemCount != expected.itemCount {
+		t.Fatalf("expected itemCount=%d, got %d", expected.itemCount, got.itemCount)
+	}
+}


### PR DESCRIPTION
## Summary
- fix dashboard map lookups to use the prefixed table name key
- add regression coverage for prefixed and unprefixed dashboard map loads

## Root cause
`GetDashboard()` stores query results in `dashboardMap` using `tableNamePrefix + tableName`, but later reads them back using only `tableName`.

When `tableNamePrefix` is set, the lookups miss and all dashboard counts stay at zero even though the underlying data exists.

## Verification
- added regression tests for prefixed and unprefixed dashboard map lookups
- note: `go test ./object -run 'TestGetDashboardMapItem'` currently hits unrelated existing compile failures in `object/permission_rbac_dedup_test.go` on current `master`, so I verified the change with focused logic inspection and the new unit test file
