### PR TITLE
feat: add join nodes for OpenClaw session graph

### DIFF
--- a/object/openclaw_session_graph.go
+++ b/object/openclaw_session_graph.go
@@ -454,6 +454,9 @@ func addOpenClawControlFlowEdges(builder *openClawSessionGraphBuilder, assistant
 		}
 		for _, downstreamNodeID := range downstreamNodeIDs {
 			builder.addEdge(joinID, downstreamNodeID)
+			if downstreamNode := builder.nodes[downstreamNodeID]; downstreamNode != nil {
+				downstreamNode.ParentID = joinID
+			}
 			joinedDownstreamNodeIDs[downstreamNodeID] = struct{}{}
 		}
 	}

--- a/object/openclaw_session_graph.go
+++ b/object/openclaw_session_graph.go
@@ -63,8 +63,10 @@ type OpenClawSessionGraphStats struct {
 }
 
 type openClawSessionGraphBuilder struct {
-	graph *OpenClawSessionGraph
-	nodes map[string]*OpenClawSessionGraphNode
+	graph    *OpenClawSessionGraph
+	nodes    map[string]*OpenClawSessionGraphNode
+	edges    []*OpenClawSessionGraphEdge
+	edgeKeys map[string]struct{}
 }
 
 type openClawSessionGraphRecord struct {
@@ -73,10 +75,12 @@ type openClawSessionGraphRecord struct {
 }
 
 type openClawAssistantStepGroup struct {
-	ParentID  string
-	Timestamp string
-	ToolNames []string
-	Text      string
+	ParentID          string
+	Timestamp         string
+	ToolNames         []string
+	Text              string
+	ToolCallNodeIDs   []string
+	ToolResultNodeIDs []string
 }
 
 func GetOpenClawSessionGraph(id string) (*OpenClawSessionGraph, error) {
@@ -284,6 +288,7 @@ func buildOpenClawSessionGraphFromEntries(anchorPayload openClawBehaviorPayload,
 			group.Timestamp = chooseEarlierTimestamp(group.Timestamp, payload.Timestamp)
 			group.ToolNames = append(group.ToolNames, payload.Tool)
 			group.Text = firstNonEmpty(group.Text, payload.AssistantText)
+			group.ToolCallNodeIDs = appendUniqueString(group.ToolCallNodeIDs, nodeID)
 		case "tool_result":
 			toolResultRecords = append(toolResultRecords, record)
 		case "final":
@@ -356,10 +361,115 @@ func buildOpenClawSessionGraphFromEntries(anchorPayload openClawBehaviorPayload,
 			Text:             payload.Text,
 		})
 		appendGraphNodeEntryName(nodeIDsByEntryName, record.Entry, payload.EntryID)
+		if assistantID := findAssistantStepIDForToolResult(parentID, toolCallNodesByAssistant); assistantID != "" {
+			if group := assistantGroups[assistantID]; group != nil {
+				group.ToolResultNodeIDs = appendUniqueString(group.ToolResultNodeIDs, payload.EntryID)
+			}
+		}
 	}
 
+	addOpenClawControlFlowEdges(builder, assistantIDs, assistantGroups)
 	markStoredGraphAnchor(builder, anchorPayload, anchorEntryName, nodeIDsByEntryName)
 	return builder.finalize()
+}
+
+func addOpenClawControlFlowEdges(builder *openClawSessionGraphBuilder, assistantIDs []string, assistantGroups map[string]*openClawAssistantStepGroup) {
+	if builder == nil {
+		return
+	}
+
+	for _, node := range builder.nodes {
+		if node == nil || node.Kind != "task" {
+			continue
+		}
+		builder.addEdge(node.ParentID, node.ID)
+	}
+
+	for _, assistantID := range assistantIDs {
+		group := assistantGroups[assistantID]
+		if group == nil {
+			continue
+		}
+		for _, toolCallNodeID := range group.ToolCallNodeIDs {
+			builder.addEdge(assistantID, toolCallNodeID)
+		}
+	}
+
+	for _, node := range builder.nodes {
+		if node == nil || node.Kind != "tool_result" {
+			continue
+		}
+		builder.addEdge(node.ParentID, node.ID)
+	}
+
+	downstreamRawParents := map[string][]string{}
+	for _, node := range builder.nodes {
+		if node == nil {
+			continue
+		}
+		if node.Kind != "assistant_step" && node.Kind != "final" {
+			continue
+		}
+		if parentID := strings.TrimSpace(node.ParentID); parentID != "" {
+			downstreamRawParents[parentID] = appendUniqueString(downstreamRawParents[parentID], node.ID)
+		}
+	}
+
+	joinedDownstreamNodeIDs := map[string]struct{}{}
+	for _, assistantID := range assistantIDs {
+		group := assistantGroups[assistantID]
+		if group == nil {
+			continue
+		}
+
+		toolCallNodeIDs := uniqueStrings(group.ToolCallNodeIDs)
+		toolResultNodeIDs := uniqueStrings(group.ToolResultNodeIDs)
+		if len(toolCallNodeIDs) <= 1 || len(toolResultNodeIDs) <= 1 {
+			continue
+		}
+
+		downstreamNodeIDs := []string{}
+		for _, toolResultNodeID := range toolResultNodeIDs {
+			downstreamNodeIDs = appendUniqueStrings(downstreamNodeIDs, downstreamRawParents[toolResultNodeID])
+		}
+		if len(downstreamNodeIDs) == 0 {
+			continue
+		}
+
+		joinID := fmt.Sprintf("join:%s", assistantID)
+		joinTimestamp := ""
+		for _, toolResultNodeID := range toolResultNodeIDs {
+			if node := builder.nodes[toolResultNodeID]; node != nil {
+				joinTimestamp = chooseLaterTimestamp(joinTimestamp, node.Timestamp)
+			}
+		}
+		builder.addNode(&OpenClawSessionGraphNode{
+			ID:        joinID,
+			Kind:      "join",
+			Timestamp: joinTimestamp,
+			Summary:   "join",
+		})
+		for _, toolResultNodeID := range toolResultNodeIDs {
+			builder.addEdge(toolResultNodeID, joinID)
+		}
+		for _, downstreamNodeID := range downstreamNodeIDs {
+			builder.addEdge(joinID, downstreamNodeID)
+			joinedDownstreamNodeIDs[downstreamNodeID] = struct{}{}
+		}
+	}
+
+	for _, node := range builder.nodes {
+		if node == nil {
+			continue
+		}
+		switch node.Kind {
+		case "assistant_step", "final":
+			if _, ok := joinedDownstreamNodeIDs[node.ID]; ok {
+				continue
+			}
+			builder.addEdge(node.ParentID, node.ID)
+		}
+	}
 }
 
 func appendGraphNodeEntryName(index map[string][]string, entry *Entry, nodeID string) {
@@ -507,7 +617,9 @@ func newOpenClawSessionGraphBuilder() *openClawSessionGraphBuilder {
 			Nodes: []*OpenClawSessionGraphNode{},
 			Edges: []*OpenClawSessionGraphEdge{},
 		},
-		nodes: map[string]*OpenClawSessionGraphNode{},
+		nodes:    map[string]*OpenClawSessionGraphNode{},
+		edges:    []*OpenClawSessionGraphEdge{},
+		edgeKeys: map[string]struct{}{},
 	}
 }
 
@@ -544,6 +656,28 @@ func (b *openClawSessionGraphBuilder) addNode(node *OpenClawSessionGraphNode) {
 	b.nodes[cloned.ID] = &cloned
 }
 
+func (b *openClawSessionGraphBuilder) addEdge(source, target string) {
+	if b == nil {
+		return
+	}
+
+	source = strings.TrimSpace(source)
+	target = strings.TrimSpace(target)
+	if source == "" || target == "" || source == target {
+		return
+	}
+
+	key := fmt.Sprintf("%s->%s", source, target)
+	if _, ok := b.edgeKeys[key]; ok {
+		return
+	}
+	b.edgeKeys[key] = struct{}{}
+	b.edges = append(b.edges, &OpenClawSessionGraphEdge{
+		Source: source,
+		Target: target,
+	})
+}
+
 func (b *openClawSessionGraphBuilder) finalize() *OpenClawSessionGraph {
 	if b == nil || b.graph == nil {
 		return nil
@@ -567,21 +701,15 @@ func (b *openClawSessionGraphBuilder) finalize() *OpenClawSessionGraph {
 		updateOpenClawSessionGraphStats(&b.graph.Stats, node)
 	}
 
-	edgeKeys := map[string]struct{}{}
-	b.graph.Edges = []*OpenClawSessionGraphEdge{}
-	for _, node := range b.graph.Nodes {
-		if node.ParentID == "" || b.nodes[node.ParentID] == nil {
+	b.graph.Edges = make([]*OpenClawSessionGraphEdge, 0, len(b.edges))
+	for _, edge := range b.edges {
+		if edge == nil {
 			continue
 		}
-		key := fmt.Sprintf("%s->%s", node.ParentID, node.ID)
-		if _, ok := edgeKeys[key]; ok {
+		if b.nodes[edge.Source] == nil || b.nodes[edge.Target] == nil {
 			continue
 		}
-		edgeKeys[key] = struct{}{}
-		b.graph.Edges = append(b.graph.Edges, &OpenClawSessionGraphEdge{
-			Source: node.ParentID,
-			Target: node.ID,
-		})
+		b.graph.Edges = append(b.graph.Edges, edge)
 	}
 
 	sort.Slice(b.graph.Edges, func(i, j int) bool {
@@ -637,6 +765,54 @@ func updateOpenClawSessionGraphStats(stats *OpenClawSessionGraphStats, node *Ope
 	case "final":
 		stats.FinalCount++
 	}
+}
+
+func findAssistantStepIDForToolResult(toolCallNodeID string, toolCallNodesByAssistant map[string][]*OpenClawSessionGraphNode) string {
+	toolCallNodeID = strings.TrimSpace(toolCallNodeID)
+	if toolCallNodeID == "" {
+		return ""
+	}
+
+	for assistantID, candidates := range toolCallNodesByAssistant {
+		for _, candidate := range candidates {
+			if candidate == nil {
+				continue
+			}
+			if strings.TrimSpace(candidate.ID) == toolCallNodeID {
+				return assistantID
+			}
+		}
+	}
+
+	return ""
+}
+
+func appendUniqueString(values []string, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return values
+	}
+	for _, existing := range values {
+		if strings.TrimSpace(existing) == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+func appendUniqueStrings(values []string, additions []string) []string {
+	for _, addition := range additions {
+		values = appendUniqueString(values, addition)
+	}
+	return values
+}
+
+func uniqueStrings(values []string) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		result = appendUniqueString(result, value)
+	}
+	return result
 }
 
 func buildAssistantStepSummary(toolNames []string) string {
@@ -739,6 +915,21 @@ func chooseEarlierTimestamp(current, next string) string {
 		return current
 	}
 	if compareOpenClawGraphTimestamps(next, current) < 0 {
+		return next
+	}
+	return current
+}
+
+func chooseLaterTimestamp(current, next string) string {
+	current = strings.TrimSpace(current)
+	next = strings.TrimSpace(next)
+	if current == "" {
+		return next
+	}
+	if next == "" {
+		return current
+	}
+	if compareOpenClawGraphTimestamps(next, current) > 0 {
 		return next
 	}
 	return current

--- a/web/src/OpenClawSessionGraphUtils.js
+++ b/web/src/OpenClawSessionGraphUtils.js
@@ -55,6 +55,8 @@ export function getOpenClawNodeColor(node) {
     return "#f08c00";
   case "tool_result":
     return node?.ok === false ? "#e03131" : "#2f9e44";
+  case "join":
+    return "#64748b";
   case "final":
     return "#6c5ce7";
   default:
@@ -64,6 +66,54 @@ export function getOpenClawNodeColor(node) {
 
 function normalizeText(value) {
   return `${value ?? ""}`.replace(/\s+/g, " ").trim();
+}
+
+function clampNumber(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getVisualTextLength(text) {
+  return Array.from(`${text ?? ""}`).reduce((length, character) => {
+    return length + (character.charCodeAt(0) > 255 ? 2 : 1);
+  }, 0);
+}
+
+function truncateNodeLabelText(value, maxLength) {
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    return "-";
+  }
+
+  const characters = Array.from(normalized);
+  if (characters.length <= maxLength) {
+    return normalized;
+  }
+
+  return `${characters.slice(0, Math.max(1, maxLength - 3)).join("")}...`;
+}
+
+function getAdaptiveNodeWidth(node, title, subtitle) {
+  const isJoin = node?.kind === "join";
+  const minWidth = isJoin ? 120 : 230;
+  const maxWidth = isJoin ? 180 : 420;
+  const targetLength = Math.max(getVisualTextLength(title), getVisualTextLength(subtitle));
+  const estimatedWidth = isJoin
+    ? 80 + targetLength * 3
+    : 160 + Math.max(0, targetLength - 10) * 4;
+
+  return clampNumber(Math.round(estimatedWidth), minWidth, maxWidth);
+}
+
+function buildNodeDisplayTexts(node) {
+  const rawTitle = getNodeTitle(node);
+  const rawSubtitle = getNodeSubtitle(node);
+  const isJoin = node?.kind === "join";
+
+  return {
+    title: truncateNodeLabelText(rawTitle, isJoin ? 24 : 84),
+    subtitle: truncateNodeLabelText(rawSubtitle, isJoin ? 24 : 108),
+    width: getAdaptiveNodeWidth(node, rawTitle, rawSubtitle),
+  };
 }
 
 function stripLeadingPrefix(text, prefix) {
@@ -120,6 +170,8 @@ function getNodeTitle(node) {
     return getToolCallTitle(node);
   case "tool_result":
     return getToolResultTitle(node);
+  case "join":
+    return "join";
   default:
     return normalizeText(node?.summary) || node?.id || "-";
   }
@@ -184,15 +236,21 @@ function buildTreeIndexes(graph) {
     .sort(compareNodes)
     .map(node => node.id);
 
-  return {nodeMap, childrenMap, roots};
+  return {nodeMap, childrenMap, roots, incomingCount};
 }
 
-function computeTreeLayout(graph) {
-  const {nodeMap, childrenMap, roots} = buildTreeIndexes(graph);
+function computeTreeLayout(graph, nodeDisplayByID) {
+  const {nodeMap, childrenMap, roots, incomingCount} = buildTreeIndexes(graph);
   const positions = new Map();
   const visited = new Set();
   const verticalGap = 160;
-  const horizontalGap = 320;
+  const widestNode = Object.values(nodeDisplayByID || {}).reduce((widest, display) => {
+    if (!display?.width) {
+      return widest;
+    }
+    return Math.max(widest, display.width);
+  }, 250);
+  const horizontalGap = Math.max(320, widestNode + 120);
   let cursor = 0;
 
   function placeNode(nodeId, depth, stack) {
@@ -222,7 +280,18 @@ function computeTreeLayout(graph) {
       return {top: y, bottom: y, center: y};
     }
 
-    const childBoxes = childIds.map(childId => placeNode(childId, depth + 1, stack));
+    const childBoxes = childIds.map((childId) => {
+      // A join-style child can have multiple incoming edges. If we always center
+      // every later parent on that already-placed child, sibling branches collapse
+      // onto the same row. Give repeated parents their own track while keeping the
+      // shared child anchored in place.
+      if ((incomingCount.get(childId) || 0) > 1 && positions.has(childId)) {
+        const y = cursor * verticalGap;
+        cursor += 1;
+        return {top: y, bottom: y, center: y};
+      }
+      return placeNode(childId, depth + 1, stack);
+    });
     const top = childBoxes[0].top;
     const bottom = childBoxes[childBoxes.length - 1].bottom;
     const center = childBoxes.length === 1 ? childBoxes[0].center : (top + bottom) / 2;
@@ -259,6 +328,8 @@ function getNodeSubtitle(node) {
       return normalizeText(node?.error) || `${normalizeText(node?.tool) || "tool"} failed`;
     }
     return `${normalizeText(node?.tool) || "tool"} ok`;
+  case "join":
+    return node?.timestamp || "-";
   default:
     return getOpenClawNodeTarget(node) || node?.timestamp || "-";
   }
@@ -272,6 +343,8 @@ function getNodeBackground(node) {
     return "#fff7ed";
   case "tool_result":
     return node?.ok === false ? "#fff5f5" : "#f3faf4";
+  case "join":
+    return "#f8fafc";
   case "final":
     return "#f5f3ff";
   default:
@@ -288,17 +361,23 @@ function getEdgeStyle(edge, nodeMap) {
     };
   }
 
-  if (targetNode?.originalParentId && targetNode.originalParentId !== targetNode.parentId) {
-    return {
-      stroke: "#0f766e",
-      strokeWidth: 2.5,
-      strokeDasharray: "6 4",
-    };
-  }
-
   return {
     stroke: "#94a3b8",
     strokeWidth: 2,
+  };
+}
+
+function getNodeStyle(node, color, width) {
+  const isJoin = node?.kind === "join";
+  return {
+    width: width ?? (isJoin ? 120 : 250),
+    minHeight: isJoin ? 56 : 76,
+    padding: isJoin ? "8px 12px" : "12px 14px",
+    borderRadius: isJoin ? 12 : 14,
+    border: node?.isAnchor ? `3px solid ${color}` : `1px solid ${color}`,
+    boxShadow: node?.isAnchor ? "0 8px 24px rgba(0, 0, 0, 0.12)" : "0 4px 14px rgba(0, 0, 0, 0.08)",
+    background: getNodeBackground(node),
+    color: "#1f2937",
   };
 }
 
@@ -306,7 +385,11 @@ export function buildOpenClawFlowElements(graph) {
   const sourceNodes = Array.isArray(graph?.nodes) ? graph.nodes : [];
   const sourceEdges = Array.isArray(graph?.edges) ? graph.edges : [];
   const nodeMap = Object.fromEntries(sourceNodes.map(node => [node.id, node]));
-  const positions = computeTreeLayout(graph);
+  const nodeDisplayByID = Object.fromEntries(sourceNodes.map((node) => [
+    node.id,
+    buildNodeDisplayTexts(node),
+  ]));
+  const positions = computeTreeLayout(graph, nodeDisplayByID);
 
   const flowNodes = sourceNodes
     .slice()
@@ -314,27 +397,23 @@ export function buildOpenClawFlowElements(graph) {
     .map((node) => {
       const color = getOpenClawNodeColor(node);
       const position = positions.get(node.id) || {x: 0, y: 0};
+      const nodeDisplay = nodeDisplayByID[node.id] || {
+        title: "-",
+        subtitle: "-",
+        width: node?.kind === "join" ? 120 : 250,
+      };
       return {
         id: node.id,
         position,
         data: {
-          title: getNodeTitle(node),
-          subtitle: getNodeSubtitle(node),
+          title: nodeDisplay.title,
+          subtitle: nodeDisplay.subtitle,
           rawNode: node,
           isAnchor: node.isAnchor,
         },
         draggable: false,
         selectable: true,
-        style: {
-          width: 250,
-          minHeight: 76,
-          padding: "12px 14px",
-          borderRadius: 14,
-          border: node.isAnchor ? `3px solid ${color}` : `1px solid ${color}`,
-          boxShadow: node.isAnchor ? "0 8px 24px rgba(0, 0, 0, 0.12)" : "0 4px 14px rgba(0, 0, 0, 0.08)",
-          background: getNodeBackground(node),
-          color: "#1f2937",
-        },
+        style: getNodeStyle(node, color, nodeDisplay.width),
       };
     });
 

--- a/web/src/OpenClawSessionGraphViewer.js
+++ b/web/src/OpenClawSessionGraphViewer.js
@@ -7,6 +7,7 @@ import {
   Row,
   Spin,
   Tag,
+  Tooltip,
   Typography
 } from "antd";
 import i18next from "i18next";
@@ -27,16 +28,122 @@ import {
 
 const {Text} = Typography;
 
-function OpenClawNodeLabel({title, subtitle}) {
+function getNodeStatusText(node) {
+  if (node?.kind !== "tool_result" || node?.ok === undefined || node?.ok === null) {
+    return "";
+  }
+
+  return node.ok
+    ? i18next.t("general:OK")
+    : i18next.t("entry:Failed", {defaultValue: "Failed"});
+}
+
+function OpenClawNodeHoverCard({node}) {
+  if (!node) {
+    return null;
+  }
+
+  const status = getNodeStatusText(node);
+  const target = getOpenClawNodeTarget(node);
+  const rows = [
+    {
+      key: "type",
+      label: i18next.t("general:Type"),
+      value: node.kind || "-",
+    },
+    {
+      key: "timestamp",
+      label: i18next.t("general:Timestamp"),
+      value: node.timestamp || "-",
+    },
+  ];
+
+  if (node.tool) {
+    rows.push({
+      key: "tool",
+      label: i18next.t("entry:Tool", {defaultValue: "Tool"}),
+      value: node.tool,
+    });
+  }
+
+  if (target) {
+    rows.push({
+      key: "target",
+      label: i18next.t("entry:Target", {defaultValue: "Target"}),
+      value: target,
+    });
+  }
+
+  if (status) {
+    rows.push({
+      key: "status",
+      label: i18next.t("general:Status"),
+      value: status,
+    });
+  }
+
+  const title = node.summary || i18next.t("entry:Session graph node", {defaultValue: "Session graph node"});
+
   return (
-    <div style={{display: "flex", flexDirection: "column", gap: "6px"}}>
-      <div style={{fontSize: 13, fontWeight: 600, lineHeight: 1.35}}>
-        {title || "-"}
-      </div>
-      <div style={{fontSize: 12, color: "#64748b", lineHeight: 1.35}}>
-        {subtitle || "-"}
+    <div style={{maxWidth: 420}}>
+      <div style={{fontWeight: 600, marginBottom: 8, wordBreak: "break-word"}}>{title}</div>
+      <div style={{display: "grid", rowGap: 6}}>
+        {rows.map((row) => (
+          <div key={row.key} style={{display: "grid", gridTemplateColumns: "92px minmax(0, 1fr)", columnGap: 8}}>
+            <span style={{color: "#94a3b8"}}>{row.label}</span>
+            <span style={{wordBreak: "break-word", overflowWrap: "anywhere"}}>{row.value}</span>
+          </div>
+        ))}
       </div>
     </div>
+  );
+}
+
+function OpenClawNodeLabel({title, subtitle, node}) {
+  const titleStyle = {
+    fontSize: 13,
+    fontWeight: 600,
+    lineHeight: 1.35,
+    whiteSpace: "normal",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    wordBreak: "break-word",
+    overflowWrap: "anywhere",
+    display: "-webkit-box",
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: "vertical",
+  };
+  const subtitleStyle = {
+    fontSize: 12,
+    color: "#64748b",
+    lineHeight: 1.35,
+    whiteSpace: "normal",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    wordBreak: "break-word",
+    overflowWrap: "anywhere",
+    display: "-webkit-box",
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: "vertical",
+  };
+
+  return (
+    <Tooltip
+      placement="top"
+      mouseEnterDelay={0.12}
+      overlayInnerStyle={{maxWidth: 460}}
+      title={<OpenClawNodeHoverCard node={node} />}
+      destroyTooltipOnHide
+    >
+      <div style={{display: "flex", flexDirection: "column", gap: "6px", width: "100%"}}>
+        <div style={titleStyle}>
+          {title || "-"}
+        </div>
+        <div style={subtitleStyle}>
+          {subtitle || "-"}
+        </div>
+      </div>
+    </Tooltip>
   );
 }
 
@@ -70,6 +177,7 @@ function OpenClawSessionGraphCanvas(props) {
             <OpenClawNodeLabel
               title={node.data.title}
               subtitle={node.data.subtitle}
+              node={node.data.rawNode}
             />
           ),
         },
@@ -90,9 +198,11 @@ function OpenClawSessionGraphCanvas(props) {
     }
 
     window.setTimeout(() => {
+      const anchorWidth = Number(anchorNode.style?.width) || 250;
+      const anchorHeight = Number(anchorNode.style?.minHeight) || 76;
       reactFlowInstance.setCenter(
-        anchorNode.position.x + 125,
-        anchorNode.position.y + 38,
+        anchorNode.position.x + anchorWidth / 2,
+        anchorNode.position.y + anchorHeight / 2,
         {zoom: 1.02, duration: 0}
       );
     }, 0);
@@ -149,8 +259,7 @@ class OpenClawSessionGraphViewer extends React.Component {
   componentDidUpdate(prevProps) {
     if (
       prevProps.entry?.owner !== this.props.entry?.owner ||
-      prevProps.entry?.name !== this.props.entry?.name ||
-      prevProps.provider !== this.props.provider
+      prevProps.entry?.name !== this.props.entry?.name
     ) {
       this.loadGraph();
     }

--- a/web/src/OpenClawSessionGraphViewer.js
+++ b/web/src/OpenClawSessionGraphViewer.js
@@ -259,7 +259,8 @@ class OpenClawSessionGraphViewer extends React.Component {
   componentDidUpdate(prevProps) {
     if (
       prevProps.entry?.owner !== this.props.entry?.owner ||
-      prevProps.entry?.name !== this.props.entry?.name
+      prevProps.entry?.name !== this.props.entry?.name ||
+      prevProps.provider !== this.props.provider
     ) {
       this.loadGraph();
     }


### PR DESCRIPTION
## Summary

This PR improves the OpenClaw session graph so it better reflects control flow and provides clearer graph viewer details.

## Changes

- introduce visible `join` nodes to represent result fan-in before the next assistant step or final node
- improve graph layout for DAG fan-in cases to avoid overlapping branches
- add richer hover details in the graph viewer