### PR TITLE
fix: prevent connection reset in K8s liveness/readiness probes

### DIFF
--- a/routers/static_filter.go
+++ b/routers/static_filter.go
@@ -214,13 +214,16 @@ func StaticFilter(ctx *context.Context) {
 func serveFileWithReplace(w http.ResponseWriter, r *http.Request, name string, organizationThemeCookie *OrganizationThemeCookie) {
 	f, err := os.Open(filepath.Clean(name))
 	if err != nil {
-		panic(err)
+		// Log error and return 404 instead of panicking to avoid connection reset
+		http.Error(w, "File not found", http.StatusNotFound)
+		return
 	}
 	defer f.Close()
 
 	d, err := f.Stat()
 	if err != nil {
-		panic(err)
+		http.Error(w, "File stat error", http.StatusInternalServerError)
+		return
 	}
 
 	oldContent := util.ReadStringFromPath(name)

--- a/util/process.go
+++ b/util/process.go
@@ -81,6 +81,13 @@ func StopOldInstance(port int) error {
 		return nil
 	}
 
+	// Don't kill ourselves - this can happen in containerized environments
+	// where the server runs as PID 1 and the port is already bound
+	currentPid := os.Getpid()
+	if pid == currentPid {
+		return nil
+	}
+
 	process, err := os.FindProcess(pid)
 	if err != nil {
 		return err


### PR DESCRIPTION
fixes #5396 
## Problem

  When deploying Casdoor via Helm with SQLite configuration, the Pod continuously restarts with liveness/readiness probe failures:

  Liveness probe failed: Get "http://10.100.1.88:8000/": read tcp 10.100.1.1:54002->10.100.1.88:8000: read: connection reset by peer
  Readiness probe failed: Get "http://10.100.1.88:8000/": http: server closed idle connection

  ## Root Cause

  1. **`StopOldInstance` lacks self-protection**: The function doesn't check if the PID it's about to kill is the current process. In containerized environments where Casdoor runs as PID 1, this could cause unexpected behavior.

  2. **`serveFileWithReplace` uses panic on file errors**: When file operations fail, the function panics instead of returning a proper HTTP error response, which can cause connection resets.

  ## Solution

  1. Add self-PID check in `StopOldInstance` to prevent killing the current process.
  2. Replace `panic(err)` with `http.Error()` in `serveFileWithReplace` for graceful error handling.