### PR TITLE
feat: enhance OpenClaw session graph text capture and tool call/result linking

### DIFF
--- a/object/openclaw_session_graph.go
+++ b/object/openclaw_session_graph.go
@@ -44,6 +44,7 @@ type OpenClawSessionGraphNode struct {
 	Path             string `json:"path,omitempty"`
 	OK               *bool  `json:"ok,omitempty"`
 	Error            string `json:"error,omitempty"`
+	Detail           string `json:"detail,omitempty"`
 	Text             string `json:"text,omitempty"`
 	IsAnchor         bool   `json:"isAnchor"`
 }
@@ -143,6 +144,7 @@ func parseOpenClawSessionGraphPayload(entry *Entry) (openClawBehaviorPayload, er
 	payload.Path = strings.TrimSpace(payload.Path)
 	payload.Error = strings.TrimSpace(payload.Error)
 	payload.AssistantText = strings.TrimSpace(payload.AssistantText)
+	payload.Detail = strings.TrimSpace(payload.Detail)
 	payload.Text = strings.TrimSpace(payload.Text)
 	payload.Timestamp = strings.TrimSpace(firstNonEmpty(payload.Timestamp, entry.CreatedTime))
 
@@ -265,6 +267,7 @@ func buildOpenClawSessionGraphFromEntries(anchorPayload openClawBehaviorPayload,
 				Query:      payload.Query,
 				URL:        payload.URL,
 				Path:       payload.Path,
+				Detail:     payload.Detail,
 				Text:       payload.Text,
 			})
 			storedNode := builder.nodes[nodeID]
@@ -362,6 +365,7 @@ func buildOpenClawSessionGraphFromEntries(anchorPayload openClawBehaviorPayload,
 			Path:             payload.Path,
 			OK:               cloneBoolPointer(payload.OK),
 			Error:            payload.Error,
+			Detail:           payload.Detail,
 			Text:             payload.Text,
 		})
 		appendGraphNodeEntryName(nodeIDsByEntryName, record.Entry, payload.EntryID)
@@ -658,6 +662,7 @@ func (b *openClawSessionGraphBuilder) addNode(node *OpenClawSessionGraphNode) {
 	cloned.URL = strings.TrimSpace(cloned.URL)
 	cloned.Path = strings.TrimSpace(cloned.Path)
 	cloned.Error = strings.TrimSpace(cloned.Error)
+	cloned.Detail = strings.TrimSpace(cloned.Detail)
 	cloned.Text = strings.TrimSpace(cloned.Text)
 	cloned.OK = cloneBoolPointer(cloned.OK)
 	b.nodes[cloned.ID] = &cloned
@@ -748,6 +753,7 @@ func mergeOpenClawGraphNode(current, next *OpenClawSessionGraphNode) {
 	current.URL = firstNonEmpty(current.URL, next.URL)
 	current.Path = firstNonEmpty(current.Path, next.Path)
 	current.Error = firstNonEmpty(current.Error, next.Error)
+	current.Detail = firstNonEmpty(current.Detail, next.Detail)
 	current.Text = firstNonEmpty(current.Text, next.Text)
 	current.OK = mergeBoolPointers(current.OK, next.OK)
 	current.IsAnchor = current.IsAnchor || next.IsAnchor

--- a/object/openclaw_session_graph.go
+++ b/object/openclaw_session_graph.go
@@ -44,7 +44,6 @@ type OpenClawSessionGraphNode struct {
 	Path             string `json:"path,omitempty"`
 	OK               *bool  `json:"ok,omitempty"`
 	Error            string `json:"error,omitempty"`
-	Detail           string `json:"detail,omitempty"`
 	Text             string `json:"text,omitempty"`
 	IsAnchor         bool   `json:"isAnchor"`
 }
@@ -144,7 +143,6 @@ func parseOpenClawSessionGraphPayload(entry *Entry) (openClawBehaviorPayload, er
 	payload.Path = strings.TrimSpace(payload.Path)
 	payload.Error = strings.TrimSpace(payload.Error)
 	payload.AssistantText = strings.TrimSpace(payload.AssistantText)
-	payload.Detail = strings.TrimSpace(payload.Detail)
 	payload.Text = strings.TrimSpace(payload.Text)
 	payload.Timestamp = strings.TrimSpace(firstNonEmpty(payload.Timestamp, entry.CreatedTime))
 
@@ -267,7 +265,6 @@ func buildOpenClawSessionGraphFromEntries(anchorPayload openClawBehaviorPayload,
 				Query:      payload.Query,
 				URL:        payload.URL,
 				Path:       payload.Path,
-				Detail:     payload.Detail,
 				Text:       payload.Text,
 			})
 			storedNode := builder.nodes[nodeID]
@@ -365,7 +362,6 @@ func buildOpenClawSessionGraphFromEntries(anchorPayload openClawBehaviorPayload,
 			Path:             payload.Path,
 			OK:               cloneBoolPointer(payload.OK),
 			Error:            payload.Error,
-			Detail:           payload.Detail,
 			Text:             payload.Text,
 		})
 		appendGraphNodeEntryName(nodeIDsByEntryName, record.Entry, payload.EntryID)
@@ -662,7 +658,6 @@ func (b *openClawSessionGraphBuilder) addNode(node *OpenClawSessionGraphNode) {
 	cloned.URL = strings.TrimSpace(cloned.URL)
 	cloned.Path = strings.TrimSpace(cloned.Path)
 	cloned.Error = strings.TrimSpace(cloned.Error)
-	cloned.Detail = strings.TrimSpace(cloned.Detail)
 	cloned.Text = strings.TrimSpace(cloned.Text)
 	cloned.OK = cloneBoolPointer(cloned.OK)
 	b.nodes[cloned.ID] = &cloned
@@ -753,7 +748,6 @@ func mergeOpenClawGraphNode(current, next *OpenClawSessionGraphNode) {
 	current.URL = firstNonEmpty(current.URL, next.URL)
 	current.Path = firstNonEmpty(current.Path, next.Path)
 	current.Error = firstNonEmpty(current.Error, next.Error)
-	current.Detail = firstNonEmpty(current.Detail, next.Detail)
 	current.Text = firstNonEmpty(current.Text, next.Text)
 	current.OK = mergeBoolPointers(current.OK, next.OK)
 	current.IsAnchor = current.IsAnchor || next.IsAnchor

--- a/object/openclaw_transcript_sync.go
+++ b/object/openclaw_transcript_sync.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"runtime"
 	"strings"
@@ -17,6 +18,18 @@ import (
 )
 
 const openClawTranscriptSyncInterval = 10 * time.Second
+
+const (
+	openClawTranscriptSummaryMax          = 100
+	openClawTranscriptTaskTextMax         = 2000
+	openClawTranscriptAssistantTextMax    = 2000
+	openClawTranscriptFinalTextMax        = 2000
+	openClawTranscriptToolCommandMax      = 500
+	openClawTranscriptToolCallDetailMax   = 16 * 1024
+	openClawTranscriptToolResultTextMax   = 64 * 1024
+	openClawTranscriptToolResultDetailMax = 16 * 1024
+	openClawTranscriptErrorTextMax        = 500
+)
 
 var (
 	openClawTranscriptWorkers   = map[string]*openClawTranscriptSyncWorker{}
@@ -39,22 +52,22 @@ type openClawTranscriptFileState struct {
 }
 
 type openClawTranscriptEntry struct {
-	Type      string                 `json:"type"`
-	ID        string                 `json:"id"`
-	ParentID  string                 `json:"parentId"`
-	Timestamp string                 `json:"timestamp"`
-	Message   *openClawMessage       `json:"message"`
-	Details   map[string]interface{} `json:"details"`
+	Type      string           `json:"type"`
+	ID        string           `json:"id"`
+	ParentID  string           `json:"parentId"`
+	Timestamp string           `json:"timestamp"`
+	Message   *openClawMessage `json:"message"`
 }
 
 type openClawMessage struct {
-	Role       string          `json:"role"`
-	Content    json.RawMessage `json:"content"`
-	StopReason string          `json:"stopReason"`
-	ToolCallID string          `json:"toolCallId"`
-	ToolName   string          `json:"toolName"`
-	IsError    bool            `json:"isError"`
-	Timestamp  int64           `json:"timestamp"`
+	Role       string                 `json:"role"`
+	Content    json.RawMessage        `json:"content"`
+	StopReason string                 `json:"stopReason"`
+	ToolCallID string                 `json:"toolCallId"`
+	ToolName   string                 `json:"toolName"`
+	IsError    bool                   `json:"isError"`
+	Timestamp  int64                  `json:"timestamp"`
+	Details    map[string]interface{} `json:"details"`
 }
 
 type openClawContentItem struct {
@@ -80,6 +93,7 @@ type openClawBehaviorPayload struct {
 	OK            *bool  `json:"ok,omitempty"`
 	Error         string `json:"error,omitempty"`
 	AssistantText string `json:"assistantText,omitempty"`
+	Detail        string `json:"detail,omitempty"`
 	Text          string `json:"text,omitempty"`
 }
 
@@ -431,17 +445,17 @@ func buildOpenClawTranscriptEntries(provider *Provider, sessionID string, entry 
 		}
 
 		return []*Entry{newOpenClawTranscriptEntry(provider, sessionID, "task", entry.ID, openClawBehaviorPayload{
-			Summary:   truncateText(fmt.Sprintf("task: %s", text), 100),
+			Summary:   truncateText(fmt.Sprintf("task: %s", text), openClawTranscriptSummaryMax),
 			Kind:      "task",
 			SessionID: sessionID,
 			EntryID:   entry.ID,
 			ParentID:  entry.ParentID,
 			Timestamp: normalizeOpenClawTimestamp(entry.Timestamp, message.Timestamp),
-			Text:      truncateText(text, 2000),
+			Text:      truncateText(text, openClawTranscriptTaskTextMax),
 		})}
 	case "assistant":
 		items := parseContentItems(message.Content)
-		assistantText := truncateText(extractMessageText(message.Content), 2000)
+		assistantText := truncateText(extractMessageText(message.Content), openClawTranscriptAssistantTextMax)
 		toolEntries := []*Entry{}
 		storedAssistantText := false
 		for _, item := range items {
@@ -451,7 +465,7 @@ func buildOpenClawTranscriptEntries(provider *Provider, sessionID string, entry 
 			context := extractOpenClawToolContext(item)
 			toolContexts[item.ID] = context
 			payload := openClawBehaviorPayload{
-				Summary:    truncateText(buildToolCallSummary(context), 100),
+				Summary:    truncateText(buildToolCallSummary(context), openClawTranscriptSummaryMax),
 				Kind:       "tool_call",
 				SessionID:  sessionID,
 				EntryID:    entry.ID,
@@ -462,7 +476,8 @@ func buildOpenClawTranscriptEntries(provider *Provider, sessionID string, entry 
 				Query:      context.Query,
 				URL:        context.URL,
 				Path:       context.Path,
-				Text:       truncateText(context.Command, 500),
+				Detail:     marshalOpenClawJSON(item.Arguments, openClawTranscriptToolCallDetailMax),
+				Text:       truncateText(context.Command, openClawTranscriptToolCommandMax),
 			}
 			if !storedAssistantText {
 				// Avoid duplicating the same assistant text on every tool-call row.
@@ -484,13 +499,13 @@ func buildOpenClawTranscriptEntries(provider *Provider, sessionID string, entry 
 			return nil
 		}
 		return []*Entry{newOpenClawTranscriptEntry(provider, sessionID, "final", entry.ID, openClawBehaviorPayload{
-			Summary:   truncateText(fmt.Sprintf("final: %s", text), 100),
+			Summary:   truncateText(fmt.Sprintf("final: %s", text), openClawTranscriptSummaryMax),
 			Kind:      "final",
 			SessionID: sessionID,
 			EntryID:   entry.ID,
 			ParentID:  entry.ParentID,
 			Timestamp: normalizeOpenClawTimestamp(entry.Timestamp, message.Timestamp),
-			Text:      truncateText(text, 2000),
+			Text:      truncateText(text, openClawTranscriptFinalTextMax),
 		})}
 	case "toolResult":
 		payload, ok := buildToolResultPayload(sessionID, entry, toolContexts[message.ToolCallID])
@@ -510,14 +525,15 @@ func buildToolResultPayload(sessionID string, entry openClawTranscriptEntry, too
 	}
 
 	okValue, errorText := resolveToolResultStatus(entry)
-	text := summarizeToolResultText(extractMessageText(message.Content), okValue)
+	rawText := extractMessageText(message.Content)
+	summaryText := summarizeToolResultText(rawText, okValue)
 	toolName := firstNonEmpty(toolContext.Tool, message.ToolName)
-	if toolName == "" && text == "" && errorText == "" {
+	if toolName == "" && rawText == "" && errorText == "" {
 		return openClawBehaviorPayload{}, false
 	}
 
 	return openClawBehaviorPayload{
-		Summary:    truncateText(buildToolResultSummary(toolName, toolContext, okValue, errorText, text), 100),
+		Summary:    truncateText(buildToolResultSummary(toolName, toolContext, okValue, errorText, summaryText), openClawTranscriptSummaryMax),
 		Kind:       "tool_result",
 		SessionID:  sessionID,
 		EntryID:    entry.ID,
@@ -527,10 +543,11 @@ func buildToolResultPayload(sessionID string, entry openClawTranscriptEntry, too
 		Tool:       toolName,
 		Query:      toolContext.Query,
 		URL:        toolContext.URL,
-		Path:       firstNonEmpty(toolContext.Path, extractWriteSuccessPath(text)),
+		Path:       firstNonEmpty(toolContext.Path, extractWriteSuccessPath(rawText)),
 		OK:         &okValue,
-		Error:      truncateText(errorText, 500),
-		Text:       truncateText(text, 2000),
+		Error:      truncateText(errorText, openClawTranscriptErrorTextMax),
+		Detail:     marshalOpenClawJSON(message.Details, openClawTranscriptToolResultDetailMax),
+		Text:       truncateText(rawText, openClawTranscriptToolResultTextMax),
 	}, true
 }
 
@@ -547,11 +564,29 @@ func newOpenClawTranscriptEntry(provider *Provider, sessionID string, entryKind 
 		Name:        fmt.Sprintf("oc_%s", util.GetMd5Hash(nameSource)),
 		CreatedTime: createdTime,
 		UpdatedTime: createdTime,
-		DisplayName: truncateText(payload.Summary, 100),
+		DisplayName: truncateText(payload.Summary, openClawTranscriptSummaryMax),
 		Provider:    provider.Name,
 		Type:        "session",
 		Message:     string(body),
 	}
+}
+
+func marshalOpenClawJSON(value interface{}, max int) string {
+	if isEmptyOpenClawJSONValue(value) {
+		return ""
+	}
+
+	body, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return ""
+	}
+
+	text := strings.TrimSpace(string(body))
+	if text == "" || text == "null" || text == "{}" || text == "[]" {
+		return ""
+	}
+
+	return truncateText(text, max)
 }
 
 func addOpenClawTranscriptEntry(entry *Entry) error {
@@ -662,14 +697,23 @@ func buildToolCallSummary(context openClawToolContext) string {
 }
 
 func resolveToolResultStatus(entry openClawTranscriptEntry) (bool, string) {
-	if entry.Message != nil && entry.Message.IsError {
-		return false, stringifyOpenClawArg(entry.Details["error"])
-	}
-	if status, ok := entry.Details["status"].(string); ok && strings.EqualFold(status, "error") {
-		return false, stringifyOpenClawArg(entry.Details["error"])
+	message := entry.Message
+	details := map[string]interface{}(nil)
+	if message != nil {
+		details = message.Details
 	}
 
-	text := strings.TrimSpace(extractMessageText(entry.Message.Content))
+	if message != nil && message.IsError {
+		return false, stringifyOpenClawArg(details["error"])
+	}
+	if status, ok := details["status"].(string); ok && strings.EqualFold(status, "error") {
+		return false, stringifyOpenClawArg(details["error"])
+	}
+
+	text := ""
+	if message != nil {
+		text = strings.TrimSpace(extractMessageText(message.Content))
+	}
 	if strings.HasPrefix(text, "{") {
 		var payload map[string]interface{}
 		if err := json.Unmarshal([]byte(text), &payload); err == nil {
@@ -679,7 +723,28 @@ func resolveToolResultStatus(entry openClawTranscriptEntry) (bool, string) {
 		}
 	}
 
-	return true, stringifyOpenClawArg(entry.Details["error"])
+	return true, stringifyOpenClawArg(details["error"])
+}
+
+func isEmptyOpenClawJSONValue(value interface{}) bool {
+	if value == nil {
+		return true
+	}
+
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Interface, reflect.Pointer:
+		if rv.IsNil() {
+			return true
+		}
+		return isEmptyOpenClawJSONValue(rv.Elem().Interface())
+	case reflect.Map, reflect.Slice:
+		return rv.IsNil() || rv.Len() == 0
+	case reflect.Array, reflect.String:
+		return rv.Len() == 0
+	}
+
+	return false
 }
 
 func summarizeToolResultText(text string, okValue bool) string {

--- a/object/openclaw_transcript_sync.go
+++ b/object/openclaw_transcript_sync.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"runtime"
 	"strings"
@@ -20,15 +19,13 @@ import (
 const openClawTranscriptSyncInterval = 10 * time.Second
 
 const (
-	openClawTranscriptSummaryMax          = 100
-	openClawTranscriptTaskTextMax         = 2000
-	openClawTranscriptAssistantTextMax    = 2000
-	openClawTranscriptFinalTextMax        = 2000
-	openClawTranscriptToolCommandMax      = 500
-	openClawTranscriptToolCallDetailMax   = 16 * 1024
-	openClawTranscriptToolResultTextMax   = 64 * 1024
-	openClawTranscriptToolResultDetailMax = 16 * 1024
-	openClawTranscriptErrorTextMax        = 500
+	openClawTranscriptSummaryMax        = 100
+	openClawTranscriptTaskTextMax       = 2000
+	openClawTranscriptAssistantTextMax  = 2000
+	openClawTranscriptFinalTextMax      = 2000
+	openClawTranscriptToolCommandMax    = 500
+	openClawTranscriptToolResultTextMax = 64 * 1024
+	openClawTranscriptErrorTextMax      = 500
 )
 
 var (
@@ -52,11 +49,12 @@ type openClawTranscriptFileState struct {
 }
 
 type openClawTranscriptEntry struct {
-	Type      string           `json:"type"`
-	ID        string           `json:"id"`
-	ParentID  string           `json:"parentId"`
-	Timestamp string           `json:"timestamp"`
-	Message   *openClawMessage `json:"message"`
+	Type      string                 `json:"type"`
+	ID        string                 `json:"id"`
+	ParentID  string                 `json:"parentId"`
+	Timestamp string                 `json:"timestamp"`
+	Message   *openClawMessage       `json:"message"`
+	Details   map[string]interface{} `json:"details"`
 }
 
 type openClawMessage struct {
@@ -93,7 +91,6 @@ type openClawBehaviorPayload struct {
 	OK            *bool  `json:"ok,omitempty"`
 	Error         string `json:"error,omitempty"`
 	AssistantText string `json:"assistantText,omitempty"`
-	Detail        string `json:"detail,omitempty"`
 	Text          string `json:"text,omitempty"`
 }
 
@@ -476,7 +473,6 @@ func buildOpenClawTranscriptEntries(provider *Provider, sessionID string, entry 
 				Query:      context.Query,
 				URL:        context.URL,
 				Path:       context.Path,
-				Detail:     marshalOpenClawJSON(item.Arguments, openClawTranscriptToolCallDetailMax),
 				Text:       truncateText(context.Command, openClawTranscriptToolCommandMax),
 			}
 			if !storedAssistantText {
@@ -546,7 +542,6 @@ func buildToolResultPayload(sessionID string, entry openClawTranscriptEntry, too
 		Path:       firstNonEmpty(toolContext.Path, extractWriteSuccessPath(rawText)),
 		OK:         &okValue,
 		Error:      truncateText(errorText, openClawTranscriptErrorTextMax),
-		Detail:     marshalOpenClawJSON(message.Details, openClawTranscriptToolResultDetailMax),
 		Text:       truncateText(rawText, openClawTranscriptToolResultTextMax),
 	}, true
 }
@@ -569,24 +564,6 @@ func newOpenClawTranscriptEntry(provider *Provider, sessionID string, entryKind 
 		Type:        "session",
 		Message:     string(body),
 	}
-}
-
-func marshalOpenClawJSON(value interface{}, max int) string {
-	if isEmptyOpenClawJSONValue(value) {
-		return ""
-	}
-
-	body, err := json.MarshalIndent(value, "", "  ")
-	if err != nil {
-		return ""
-	}
-
-	text := strings.TrimSpace(string(body))
-	if text == "" || text == "null" || text == "{}" || text == "[]" {
-		return ""
-	}
-
-	return truncateText(text, max)
 }
 
 func addOpenClawTranscriptEntry(entry *Entry) error {
@@ -698,10 +675,7 @@ func buildToolCallSummary(context openClawToolContext) string {
 
 func resolveToolResultStatus(entry openClawTranscriptEntry) (bool, string) {
 	message := entry.Message
-	details := map[string]interface{}(nil)
-	if message != nil {
-		details = message.Details
-	}
+	details := mergeOpenClawTranscriptDetails(entry.Details, message)
 
 	if message != nil && message.IsError {
 		return false, stringifyOpenClawArg(details["error"])
@@ -726,25 +700,22 @@ func resolveToolResultStatus(entry openClawTranscriptEntry) (bool, string) {
 	return true, stringifyOpenClawArg(details["error"])
 }
 
-func isEmptyOpenClawJSONValue(value interface{}) bool {
-	if value == nil {
-		return true
+func mergeOpenClawTranscriptDetails(entryDetails map[string]interface{}, message *openClawMessage) map[string]interface{} {
+	if message == nil || len(message.Details) == 0 {
+		return entryDetails
+	}
+	if len(entryDetails) == 0 {
+		return message.Details
 	}
 
-	rv := reflect.ValueOf(value)
-	switch rv.Kind() {
-	case reflect.Interface, reflect.Pointer:
-		if rv.IsNil() {
-			return true
-		}
-		return isEmptyOpenClawJSONValue(rv.Elem().Interface())
-	case reflect.Map, reflect.Slice:
-		return rv.IsNil() || rv.Len() == 0
-	case reflect.Array, reflect.String:
-		return rv.Len() == 0
+	details := map[string]interface{}{}
+	for key, value := range entryDetails {
+		details[key] = value
 	}
-
-	return false
+	for key, value := range message.Details {
+		details[key] = value
+	}
+	return details
 }
 
 func summarizeToolResultText(text string, okValue bool) string {

--- a/web/src/OpenClawSessionGraphViewer.js
+++ b/web/src/OpenClawSessionGraphViewer.js
@@ -126,7 +126,7 @@ function OpenClawNodeHoverCard({node}) {
   if (node.tool) {
     rows.push({
       key: "tool",
-      label: i18next.t("entry:Tool"),
+      label: i18next.t("general:Tool"),
       value: node.tool,
     });
   }
@@ -497,13 +497,13 @@ class OpenClawSessionGraphViewer extends React.Component {
     );
   }
 
-  renderNodeText(value) {
+  renderNodeText(value, style = {}) {
     if (!value) {
       return "-";
     }
 
     return (
-      <div style={{whiteSpace: "pre-wrap", wordBreak: "break-word"}}>
+      <div style={{whiteSpace: "pre-wrap", wordBreak: "break-word", overflowWrap: "anywhere", maxWidth: "100%", ...style}}>
         {value}
       </div>
     );
@@ -564,20 +564,25 @@ class OpenClawSessionGraphViewer extends React.Component {
     const isCurrentNode = normalizeNodeKey(node?.id) === normalizeNodeKey(currentNode?.id);
     const target = getOpenClawNodeTarget(node);
     const displayTarget = target && target !== node?.tool ? target : "";
+    const panelMaxHeight = Setting.isMobile() ? 360 : 420;
 
     return (
       <div
         style={{
           display: "grid",
+          gridTemplateRows: "auto minmax(0, 1fr)",
           gap: 10,
-          height: "100%",
+          maxHeight: panelMaxHeight,
+          minHeight: 0,
+          minWidth: 0,
           padding: 12,
           border: "1px solid #dbe3ef",
           borderRadius: 12,
           background: "#fafcff",
+          overflow: "hidden",
         }}
       >
-        <div style={{display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12}}>
+        <div style={{display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12, minWidth: 0}}>
           <div style={{display: "flex", alignItems: "center", gap: 8, minWidth: 0, flexWrap: "wrap"}}>
             <Text strong>{title}</Text>
             {node ? getStatusTag(node) : null}
@@ -585,6 +590,7 @@ class OpenClawSessionGraphViewer extends React.Component {
           {node && !isCurrentNode ? (
             <Button
               size="small"
+              style={{flex: "none"}}
               onClick={() => this.setState({selectedNode: node})}
             >
               {i18next.t("entry:Open linked node")}
@@ -592,37 +598,31 @@ class OpenClawSessionGraphViewer extends React.Component {
           ) : null}
         </div>
         {node ? (
-          <div style={{display: "grid", rowGap: 8}}>
-            <div>
+          <div style={{display: "grid", rowGap: 8, minHeight: 0, minWidth: 0, overflowY: "auto", overflowX: "hidden", paddingRight: 4}}>
+            <div style={{minWidth: 0}}>
               <Text type="secondary">{i18next.t("entry:Summary")}: </Text>
-              <Text style={{wordBreak: "break-word"}}>{node.summary || "-"}</Text>
+              <Text style={{wordBreak: "break-word", overflowWrap: "anywhere"}}>{node.summary || "-"}</Text>
             </div>
-            <div>
+            <div style={{minWidth: 0}}>
               <Text type="secondary">{i18next.t("general:Tool")}: </Text>
               <Text>{node.tool || "-"}</Text>
             </div>
             {displayTarget ? (
-              <div>
+              <div style={{minWidth: 0}}>
                 <Text type="secondary">{i18next.t("entry:Target")}: </Text>
-                <Text style={{wordBreak: "break-word"}}>{displayTarget}</Text>
+                <Text style={{wordBreak: "break-word", overflowWrap: "anywhere"}}>{displayTarget}</Text>
               </div>
             ) : null}
             {node.error ? (
-              <div>
+              <div style={{minWidth: 0}}>
                 <Text type="secondary">{i18next.t("general:Error")}: </Text>
                 {this.renderNodeText(node.error)}
               </div>
             ) : null}
             {node.text ? (
-              <div>
+              <div style={{minWidth: 0}}>
                 <Text type="secondary">{i18next.t("entry:Text")}: </Text>
                 {this.renderNodeText(node.text)}
-              </div>
-            ) : null}
-            {node.detail ? (
-              <div>
-                <Text type="secondary">{i18next.t("entry:Detail")}: </Text>
-                {this.renderNodeText(node.detail)}
               </div>
             ) : null}
           </div>
@@ -645,6 +645,7 @@ class OpenClawSessionGraphViewer extends React.Component {
           display: "grid",
           gridTemplateColumns: Setting.isMobile() ? "1fr" : "repeat(2, minmax(0, 1fr))",
           gap: 12,
+          minWidth: 0,
         }}
       >
         {this.renderToolPairPanel(i18next.t("entry:Call"), callNode, node)}
@@ -707,11 +708,6 @@ class OpenClawSessionGraphViewer extends React.Component {
             {toolPair ? (
               <Descriptions.Item label={i18next.t("entry:Call / Result")}>
                 {toolPair}
-              </Descriptions.Item>
-            ) : null}
-            {node.detail ? (
-              <Descriptions.Item label={i18next.t("entry:Detail")}>
-                {this.renderNodeText(node.detail)}
               </Descriptions.Item>
             ) : null}
             <Descriptions.Item label={i18next.t("entry:Query")}>

--- a/web/src/OpenClawSessionGraphViewer.js
+++ b/web/src/OpenClawSessionGraphViewer.js
@@ -31,6 +31,68 @@ import {
 
 const {Text} = Typography;
 
+function normalizeNodeKey(value) {
+  return `${value ?? ""}`.trim();
+}
+
+function isToolCallNode(node) {
+  return node?.kind === "tool_call";
+}
+
+function isToolResultNode(node) {
+  return node?.kind === "tool_result";
+}
+
+function findLinkedToolCallNode(nodes, toolResultNode) {
+  if (!isToolResultNode(toolResultNode)) {
+    return null;
+  }
+
+  const parentId = normalizeNodeKey(toolResultNode.parentId);
+  if (parentId) {
+    const directParent = nodes.find((candidate) => {
+      return isToolCallNode(candidate) && normalizeNodeKey(candidate.id) === parentId;
+    });
+    if (directParent) {
+      return directParent;
+    }
+  }
+
+  const toolCallId = normalizeNodeKey(toolResultNode.toolCallId);
+  if (!toolCallId) {
+    return null;
+  }
+
+  return nodes.find((candidate) => {
+    return isToolCallNode(candidate) && normalizeNodeKey(candidate.toolCallId) === toolCallId;
+  }) || null;
+}
+
+function findLinkedToolResultNode(nodes, toolCallNode) {
+  if (!isToolCallNode(toolCallNode)) {
+    return null;
+  }
+
+  const toolCallId = normalizeNodeKey(toolCallNode.toolCallId);
+  if (toolCallId) {
+    const byToolCallId = nodes.find((candidate) => {
+      return isToolResultNode(candidate) && normalizeNodeKey(candidate.toolCallId) === toolCallId;
+    });
+    if (byToolCallId) {
+      return byToolCallId;
+    }
+  }
+
+  const nodeId = normalizeNodeKey(toolCallNode.id);
+  if (!nodeId) {
+    return null;
+  }
+
+  return nodes.find((candidate) => {
+    return isToolResultNode(candidate) && normalizeNodeKey(candidate.parentId) === nodeId;
+  }) || null;
+}
+
 function getNodeStatusText(node) {
   if (node?.kind !== "tool_result" || node?.ok === undefined || node?.ok === null) {
     return "";
@@ -447,8 +509,153 @@ class OpenClawSessionGraphViewer extends React.Component {
     );
   }
 
+  getLinkedNodes(node) {
+    const nodes = Array.isArray(this.state.graph?.nodes) ? this.state.graph.nodes : [];
+    if (!node || nodes.length === 0) {
+      return {
+        linkedToolCallNode: null,
+        linkedToolResultNode: null,
+      };
+    }
+
+    if (isToolCallNode(node)) {
+      return {
+        linkedToolCallNode: null,
+        linkedToolResultNode: findLinkedToolResultNode(nodes, node),
+      };
+    }
+
+    if (isToolResultNode(node)) {
+      return {
+        linkedToolCallNode: findLinkedToolCallNode(nodes, node),
+        linkedToolResultNode: null,
+      };
+    }
+
+    return {
+      linkedToolCallNode: null,
+      linkedToolResultNode: null,
+    };
+  }
+
+  getToolPairNodes(node) {
+    const {linkedToolCallNode, linkedToolResultNode} = this.getLinkedNodes(node);
+    if (isToolCallNode(node)) {
+      return {
+        callNode: node,
+        resultNode: linkedToolResultNode,
+      };
+    }
+
+    if (isToolResultNode(node)) {
+      return {
+        callNode: linkedToolCallNode,
+        resultNode: node,
+      };
+    }
+
+    return {
+      callNode: null,
+      resultNode: null,
+    };
+  }
+
+  renderToolPairPanel(title, node, currentNode) {
+    const isCurrentNode = normalizeNodeKey(node?.id) === normalizeNodeKey(currentNode?.id);
+    const target = getOpenClawNodeTarget(node);
+    const displayTarget = target && target !== node?.tool ? target : "";
+
+    return (
+      <div
+        style={{
+          display: "grid",
+          gap: 10,
+          height: "100%",
+          padding: 12,
+          border: "1px solid #dbe3ef",
+          borderRadius: 12,
+          background: "#fafcff",
+        }}
+      >
+        <div style={{display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12}}>
+          <div style={{display: "flex", alignItems: "center", gap: 8, minWidth: 0, flexWrap: "wrap"}}>
+            <Text strong>{title}</Text>
+            {node ? getStatusTag(node) : null}
+          </div>
+          {node && !isCurrentNode ? (
+            <Button
+              size="small"
+              onClick={() => this.setState({selectedNode: node})}
+            >
+              {i18next.t("entry:Open linked node")}
+            </Button>
+          ) : null}
+        </div>
+        {node ? (
+          <div style={{display: "grid", rowGap: 8}}>
+            <div>
+              <Text type="secondary">{i18next.t("entry:Summary")}: </Text>
+              <Text style={{wordBreak: "break-word"}}>{node.summary || "-"}</Text>
+            </div>
+            <div>
+              <Text type="secondary">{i18next.t("general:Tool")}: </Text>
+              <Text>{node.tool || "-"}</Text>
+            </div>
+            {displayTarget ? (
+              <div>
+                <Text type="secondary">{i18next.t("entry:Target")}: </Text>
+                <Text style={{wordBreak: "break-word"}}>{displayTarget}</Text>
+              </div>
+            ) : null}
+            {node.error ? (
+              <div>
+                <Text type="secondary">{i18next.t("general:Error")}: </Text>
+                {this.renderNodeText(node.error)}
+              </div>
+            ) : null}
+            {node.text ? (
+              <div>
+                <Text type="secondary">{i18next.t("entry:Text")}: </Text>
+                {this.renderNodeText(node.text)}
+              </div>
+            ) : null}
+            {node.detail ? (
+              <div>
+                <Text type="secondary">{i18next.t("entry:Detail")}: </Text>
+                {this.renderNodeText(node.detail)}
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <Text type="secondary">-</Text>
+        )}
+      </div>
+    );
+  }
+
+  renderToolPair(node) {
+    const {callNode, resultNode} = this.getToolPairNodes(node);
+    if (!callNode && !resultNode) {
+      return null;
+    }
+
+    return (
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: Setting.isMobile() ? "1fr" : "repeat(2, minmax(0, 1fr))",
+          gap: 12,
+        }}
+      >
+        {this.renderToolPairPanel(i18next.t("entry:Call"), callNode, node)}
+        {this.renderToolPairPanel(i18next.t("entry:Result"), resultNode, node)}
+      </div>
+    );
+  }
+
   renderNodeDrawer() {
     const node = this.state.selectedNode;
+    const toolPair = this.renderToolPair(node);
 
     return (
       <Drawer
@@ -497,6 +704,11 @@ class OpenClawSessionGraphViewer extends React.Component {
             <Descriptions.Item label={i18next.t("general:Tool")}>
               {node.tool || "-"}
             </Descriptions.Item>
+            {toolPair ? (
+              <Descriptions.Item label={i18next.t("entry:Call / Result")}>
+                {toolPair}
+              </Descriptions.Item>
+            ) : null}
             {node.detail ? (
               <Descriptions.Item label={i18next.t("entry:Detail")}>
                 {this.renderNodeText(node.detail)}

--- a/web/src/OpenClawSessionGraphViewer.js
+++ b/web/src/OpenClawSessionGraphViewer.js
@@ -497,6 +497,11 @@ class OpenClawSessionGraphViewer extends React.Component {
             <Descriptions.Item label={i18next.t("general:Tool")}>
               {node.tool || "-"}
             </Descriptions.Item>
+            {node.detail ? (
+              <Descriptions.Item label={i18next.t("entry:Detail")}>
+                {this.renderNodeText(node.detail)}
+              </Descriptions.Item>
+            ) : null}
             <Descriptions.Item label={i18next.t("entry:Query")}>
               {this.renderNodeText(node.query)}
             </Descriptions.Item>


### PR DESCRIPTION
## Summary

This PR improves the OpenClaw session graph so it captures more useful session behavior from transcript files and makes tool execution easier to inspect in the UI.

Compared with `master`, the transcript sync now extracts richer `text` and metadata from OpenClaw sessions, including tool call commands, tool result bodies, error text, paths, URLs, queries, and status. The session graph drawer also adds a linked Call / Result view so users can inspect a tool call and its matching result side by side.

## Changes

- Enhanced OpenClaw transcript scanning for session graph entries.
- Captures more useful `text` for tasks, assistant finals, tool calls, and tool results.
- Adds a Call / Result linked panel in the session graph drawer.
