### PR TITLE
fix: fix error handling in NewGoogleChatProvider

### DIFF
--- a/notification/google_chat.go
+++ b/notification/google_chat.go
@@ -29,6 +29,10 @@ func NewGoogleChatProvider(credentials string) (*notify.Notify, error) {
 	withSpacesScope := option.WithScopes("https://www.googleapis.com/auth/chat.spaces")
 
 	listSvc, err := chat.NewService(context.Background(), withCred, withSpacesScope)
+	if err != nil {
+		return nil, err
+	}
+
 	spaces, err := listSvc.Spaces.List().Do()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes a dropped `err` variable in the `notification` package.
