### PR TITLE
feat: add OpenClaw transcript storage and viewer

### DIFF
--- a/controllers/entry.go
+++ b/controllers/entry.go
@@ -107,6 +107,29 @@ func (c *ApiController) GetOpenClawSessionGraph() {
 	c.ResponseOk(graph)
 }
 
+// GetOpenClawSessionTranscript
+// @Title GetOpenClawSessionTranscript
+// @Tag Entry API
+// @Description get OpenClaw raw session transcript
+// @Param   id     query    string  true        "The id ( owner/name ) of the entry"
+// @Success 200 {object} object.OpenClawSessionTranscriptPreview The raw JSONL transcript preview
+// @router /get-openclaw-session-transcript [get]
+func (c *ApiController) GetOpenClawSessionTranscript() {
+	id := c.Ctx.Input.Query("id")
+
+	preview, err := object.GetOpenClawSessionTranscript(id, c.GetAcceptLanguage())
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	if preview == nil {
+		c.ResponseError("OpenClaw raw session transcript is not found")
+		return
+	}
+
+	c.ResponseOk(preview)
+}
+
 // UpdateEntry
 // @Title UpdateEntry
 // @Tag Entry API

--- a/object/openclaw_session_graph.go
+++ b/object/openclaw_session_graph.go
@@ -24,9 +24,10 @@ import (
 )
 
 type OpenClawSessionGraph struct {
-	Nodes []*OpenClawSessionGraphNode `json:"nodes"`
-	Edges []*OpenClawSessionGraphEdge `json:"edges"`
-	Stats OpenClawSessionGraphStats   `json:"stats"`
+	Nodes         []*OpenClawSessionGraphNode `json:"nodes"`
+	Edges         []*OpenClawSessionGraphEdge `json:"edges"`
+	Stats         OpenClawSessionGraphStats   `json:"stats"`
+	RawTranscript *OpenClawRawTranscriptRef   `json:"rawTranscript,omitempty"`
 }
 
 type OpenClawSessionGraphNode struct {
@@ -84,28 +85,12 @@ type openClawAssistantStepGroup struct {
 }
 
 func GetOpenClawSessionGraph(id string) (*OpenClawSessionGraph, error) {
-	entry, err := GetEntry(id)
-	if err != nil {
-		return nil, err
-	}
+	entry, _, anchorPayload, err := loadOpenClawSessionEntry(id)
 	if entry == nil {
-		return nil, nil
-	}
-	if strings.TrimSpace(entry.Type) != "session" {
-		return nil, fmt.Errorf("entry %s is not an OpenClaw session entry", id)
-	}
-
-	provider, err := GetProvider(util.GetId(entry.Owner, entry.Provider))
-	if err != nil {
 		return nil, err
 	}
-	if provider != nil && !isOpenClawLogProvider(provider) {
-		return nil, fmt.Errorf("entry %s is not an OpenClaw session entry", id)
-	}
-
-	anchorPayload, err := parseOpenClawSessionGraphPayload(entry)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse anchor entry %s: %w", entry.Name, err)
+		return nil, err
 	}
 
 	records, err := collectOpenClawSessionGraphRecords(entry, anchorPayload)
@@ -113,7 +98,15 @@ func GetOpenClawSessionGraph(id string) (*OpenClawSessionGraph, error) {
 		return nil, fmt.Errorf("failed to load OpenClaw session entries from database: %w", err)
 	}
 
-	return buildOpenClawSessionGraphFromEntries(anchorPayload, entry.Name, records), nil
+	graph := buildOpenClawSessionGraphFromEntries(anchorPayload, entry.Name, records)
+	rawTranscript, err := getOpenClawRawTranscriptRef(entry.Owner, entry.Provider, anchorPayload.SessionID)
+	if err != nil {
+		fmt.Printf("GetOpenClawSessionGraph: failed to load raw transcript ref for provider %s session %s: %v\n", entry.Provider, anchorPayload.SessionID, err)
+		return graph, nil
+	}
+	graph.RawTranscript = rawTranscript
+
+	return graph, nil
 }
 
 func parseOpenClawSessionGraphPayload(entry *Entry) (openClawBehaviorPayload, error) {

--- a/object/openclaw_transcript_storage.go
+++ b/object/openclaw_transcript_storage.go
@@ -1,0 +1,439 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/casdoor/casdoor/conf"
+	"github.com/casdoor/casdoor/util"
+)
+
+const (
+	openClawTranscriptResourceTag                = "openclawTranscript"
+	openClawSessionTranscriptPreviewLimit        = 2 * 1024 * 1024
+	openClawTranscriptDefaultStorageProviderName = "openclaw-transcript-storage"
+)
+
+type OpenClawRawTranscriptRef struct {
+	FileName string `json:"fileName,omitempty"`
+	FileSize int    `json:"fileSize,omitempty"`
+}
+
+type OpenClawSessionTranscriptPreview struct {
+	FileName   string `json:"fileName"`
+	FileSize   int    `json:"fileSize"`
+	LoadedSize int    `json:"loadedSize"`
+	Truncated  bool   `json:"truncated"`
+	Content    string `json:"content"`
+}
+
+func uploadOpenClawRawTranscript(logProvider *Provider, sessionID string, transcriptPath string, fileSize int64) error {
+	storageProvider, err := getOpenClawTranscriptStorageProvider(logProvider)
+	if err != nil {
+		return err
+	}
+	if storageProvider == nil {
+		return fmt.Errorf("no enabled Storage provider found")
+	}
+
+	resource, err := getOpenClawRawTranscriptResource(logProvider.Owner, logProvider.Name, sessionID)
+	if err != nil {
+		return err
+	}
+
+	objectKey := ""
+	if resource != nil {
+		objectKey = strings.TrimSpace(resource.Name)
+	}
+	if objectKey == "" {
+		fullFilePath := getOpenClawTranscriptStoragePath(logProvider.Owner, logProvider.Name, sessionID, util.GenerateUUID())
+		objectKey = getOpenClawTranscriptObjectKey(storageProvider, fullFilePath)
+	}
+	if strings.Contains(objectKey, "..") {
+		return fmt.Errorf("the objectKey: %s is not allowed", objectKey)
+	}
+
+	if err := putOpenClawRawTranscriptObject(storageProvider, objectKey, transcriptPath); err != nil {
+		return err
+	}
+
+	resource = buildOpenClawRawTranscriptResource(logProvider, storageProvider, sessionID, transcriptPath, fileSize, objectKey, resource)
+	_, err = AddOrUpdateResource(resource)
+	return err
+}
+
+func getOpenClawTranscriptStorageProvider(logProvider *Provider) (*Provider, error) {
+	if logProvider == nil {
+		return nil, fmt.Errorf("provider is nil")
+	}
+
+	providers, err := GetProviders(logProvider.Owner)
+	if err != nil {
+		return nil, err
+	}
+
+	storageProvider, err := selectOpenClawTranscriptStorageProvider(logProvider, providers)
+	if err != nil {
+		return nil, err
+	}
+	if storageProvider != nil {
+		return storageProvider, nil
+	}
+
+	return createOpenClawTranscriptDefaultStorageProvider(logProvider)
+}
+
+func selectOpenClawTranscriptStorageProvider(logProvider *Provider, providers []*Provider) (*Provider, error) {
+	selectedName := strings.TrimSpace(logProvider.ProviderUrl)
+	if selectedName != "" {
+		for _, provider := range providers {
+			if provider == nil || provider.Name != selectedName {
+				continue
+			}
+			if !isUsableOpenClawTranscriptStorageProviderForOwner(logProvider.Owner, provider) {
+				return nil, fmt.Errorf("selected provider %s is not an enabled Storage provider", selectedName)
+			}
+			return provider, nil
+		}
+
+		return nil, fmt.Errorf("selected Storage provider %s is not found", selectedName)
+	}
+
+	for _, provider := range providers {
+		if !isUsableOpenClawTranscriptStorageProviderForOwner(logProvider.Owner, provider) {
+			continue
+		}
+		return provider, nil
+	}
+
+	return nil, nil
+}
+
+func isUsableOpenClawTranscriptStorageProvider(provider *Provider) bool {
+	return provider != nil && provider.Category == "Storage" && !strings.EqualFold(strings.TrimSpace(provider.State), "Disabled")
+}
+
+func isUsableOpenClawTranscriptStorageProviderForOwner(owner string, provider *Provider) bool {
+	return isUsableOpenClawTranscriptStorageProvider(provider) && strings.TrimSpace(provider.Owner) == strings.TrimSpace(owner)
+}
+
+func createOpenClawTranscriptDefaultStorageProvider(logProvider *Provider) (*Provider, error) {
+	if logProvider == nil {
+		return nil, fmt.Errorf("provider is nil")
+	}
+
+	provider := &Provider{
+		Owner:       logProvider.Owner,
+		Name:        openClawTranscriptDefaultStorageProviderName,
+		CreatedTime: util.GetCurrentTime(),
+		DisplayName: "OpenClaw Transcript Storage",
+		Category:    "Storage",
+		Type:        ProviderTypeLocalFileSystem,
+		State:       "Enabled",
+		PathPrefix:  "openclaw-transcripts",
+		Domain:      getOpenClawDefaultStorageDomain(),
+	}
+
+	affected, err := AddProvider(provider)
+	if err != nil {
+		providers, getErr := GetProviders(logProvider.Owner)
+		if getErr != nil {
+			return nil, err
+		}
+
+		for _, existing := range providers {
+			if existing != nil && existing.Name == openClawTranscriptDefaultStorageProviderName && isUsableOpenClawTranscriptStorageProviderForOwner(logProvider.Owner, existing) {
+				return existing, nil
+			}
+		}
+
+		return nil, err
+	}
+	if !affected {
+		return nil, fmt.Errorf("failed to create default OpenClaw transcript Storage provider")
+	}
+
+	return provider, nil
+}
+
+func getOpenClawDefaultStorageDomain() string {
+	if origin := strings.TrimSpace(conf.GetConfigString("origin")); origin != "" {
+		return origin
+	}
+	return strings.TrimSpace(conf.GetConfigString("originFrontend"))
+}
+
+func getOpenClawTranscriptStoragePath(owner string, providerName string, sessionID string, nonce string) string {
+	return path.Join(
+		"openclaw",
+		sanitizeOpenClawStoragePathSegment(owner),
+		sanitizeOpenClawStoragePathSegment(providerName),
+		"sessions",
+		sanitizeOpenClawStoragePathSegment(nonce),
+		fmt.Sprintf("%s.jsonl", sanitizeOpenClawStoragePathSegment(sessionID)),
+	)
+}
+
+func getOpenClawTranscriptObjectKey(provider *Provider, fullFilePath string) string {
+	escapedPath := util.UrlJoin(provider.PathPrefix, fullFilePath)
+	objectKey := util.UrlJoin(util.GetUrlPath(provider.Domain), escapedPath)
+	if provider.Type == ProviderTypeLocalFileSystem {
+		objectKey = strings.TrimLeft(objectKey, "/")
+	}
+	if provider.Type == ProviderTypeTencentCloudCOS {
+		objectKey = escapePath(objectKey)
+	}
+	return objectKey
+}
+
+func getOpenClawTranscriptResourceParent(owner string, providerName string, sessionID string) string {
+	owner = strings.TrimSpace(owner)
+	providerName = strings.TrimSpace(providerName)
+	sessionID = strings.TrimSpace(sessionID)
+	if owner == "" || providerName == "" || sessionID == "" {
+		return ""
+	}
+
+	return path.Join("openclaw", util.GetMd5Hash(fmt.Sprintf("%s|%s|%s", owner, providerName, sessionID)))
+}
+
+func getOpenClawRawTranscriptResource(owner string, providerName string, sessionID string) (*Resource, error) {
+	owner = strings.TrimSpace(owner)
+	parent := getOpenClawTranscriptResourceParent(owner, providerName, sessionID)
+	if owner == "" || parent == "" {
+		return nil, nil
+	}
+
+	resource := Resource{}
+	existed, err := ormer.Engine.
+		Where("owner = ? and tag = ? and parent = ?", owner, openClawTranscriptResourceTag, parent).
+		Desc("created_time").
+		Get(&resource)
+	if err != nil {
+		return nil, err
+	}
+	if !existed {
+		return nil, nil
+	}
+
+	return &resource, nil
+}
+
+func getOpenClawRawTranscriptRef(owner string, providerName string, sessionID string) (*OpenClawRawTranscriptRef, error) {
+	resource, err := getOpenClawRawTranscriptResource(owner, providerName, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	return buildOpenClawRawTranscriptRef(resource), nil
+}
+
+func buildOpenClawRawTranscriptRef(resource *Resource) *OpenClawRawTranscriptRef {
+	if resource == nil {
+		return nil
+	}
+
+	return &OpenClawRawTranscriptRef{
+		FileName: resource.FileName,
+		FileSize: resource.FileSize,
+	}
+}
+
+func GetOpenClawSessionTranscript(id string, lang string) (*OpenClawSessionTranscriptPreview, error) {
+	entry, _, payload, err := loadOpenClawSessionEntry(id)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+
+	resource, err := getOpenClawRawTranscriptResource(entry.Owner, entry.Provider, payload.SessionID)
+	if err != nil {
+		return nil, err
+	}
+	if resource == nil {
+		return nil, nil
+	}
+
+	provider, err := getOpenClawTranscriptStorageProviderByName(resource.Owner, resource.Provider)
+	if err != nil {
+		return nil, err
+	}
+	if provider == nil || provider.Category != "Storage" {
+		return nil, fmt.Errorf("storage provider %s is not found", resource.Provider)
+	}
+
+	storageProvider, err := getStorageProvider(provider, lang)
+	if err != nil {
+		return nil, err
+	}
+
+	reader, err := storageProvider.GetStream(refineObjectKey(provider, resource.Name))
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	fileName := strings.TrimSpace(resource.FileName)
+	if fileName == "" {
+		fileName = fmt.Sprintf("%s.jsonl", payload.SessionID)
+	}
+
+	content, truncated, err := readOpenClawSessionTranscriptPreview(reader, openClawSessionTranscriptPreviewLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OpenClawSessionTranscriptPreview{
+		FileName:   filepath.Base(fileName),
+		FileSize:   resource.FileSize,
+		LoadedSize: len(content),
+		Truncated:  truncated,
+		Content:    string(content),
+	}, nil
+}
+
+func putOpenClawRawTranscriptObject(provider *Provider, objectKey string, transcriptPath string) error {
+	storageProvider, err := getStorageProvider(provider, "en")
+	if err != nil {
+		return err
+	}
+
+	file, err := os.Open(transcriptPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = storageProvider.Put(refineObjectKey(provider, objectKey), file)
+	return err
+}
+
+func buildOpenClawRawTranscriptResource(logProvider *Provider, storageProvider *Provider, sessionID string, transcriptPath string, fileSize int64, objectKey string, current *Resource) *Resource {
+	now := util.GetCurrentTime()
+	createdTime := now
+	if current != nil && strings.TrimSpace(current.CreatedTime) != "" {
+		createdTime = current.CreatedTime
+	}
+
+	return &Resource{
+		Owner:       logProvider.Owner,
+		Name:        objectKey,
+		CreatedTime: createdTime,
+		User:        "",
+		Provider:    storageProvider.Name,
+		Application: CasdoorApplication,
+		Tag:         openClawTranscriptResourceTag,
+		Parent:      getOpenClawTranscriptResourceParent(logProvider.Owner, logProvider.Name, sessionID),
+		FileName:    filepath.Base(transcriptPath),
+		FileType:    "text",
+		FileFormat:  filepath.Ext(transcriptPath),
+		FileSize:    int(fileSize),
+		Url:         "",
+		Description: "OpenClaw raw session transcript",
+	}
+}
+
+func getOpenClawTranscriptStorageProviderByName(owner string, name string) (*Provider, error) {
+	if strings.TrimSpace(owner) == "" || strings.TrimSpace(name) == "" {
+		return nil, nil
+	}
+
+	provider := Provider{Owner: owner, Name: name}
+	existed, err := ormer.Engine.Get(&provider)
+	if err != nil {
+		return nil, err
+	}
+	if !existed {
+		return nil, nil
+	}
+
+	return &provider, nil
+}
+
+func readOpenClawSessionTranscriptPreview(reader io.Reader, limit int) ([]byte, bool, error) {
+	if limit < 0 {
+		limit = 0
+	}
+
+	content, err := io.ReadAll(io.LimitReader(reader, int64(limit)+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if len(content) > limit {
+		return content[:limit], true, nil
+	}
+
+	return content, false, nil
+}
+
+func loadOpenClawSessionEntry(id string) (*Entry, *Provider, openClawBehaviorPayload, error) {
+	entry, err := GetEntry(id)
+	if err != nil {
+		return nil, nil, openClawBehaviorPayload{}, err
+	}
+	if entry == nil {
+		return nil, nil, openClawBehaviorPayload{}, nil
+	}
+	if strings.TrimSpace(entry.Type) != "session" {
+		return nil, nil, openClawBehaviorPayload{}, fmt.Errorf("entry %s is not an OpenClaw session entry", id)
+	}
+
+	provider, err := GetProvider(util.GetId(entry.Owner, entry.Provider))
+	if err != nil {
+		return nil, nil, openClawBehaviorPayload{}, err
+	}
+	if provider != nil && !isOpenClawLogProvider(provider) {
+		return nil, nil, openClawBehaviorPayload{}, fmt.Errorf("entry %s is not an OpenClaw session entry", id)
+	}
+
+	payload, err := parseOpenClawSessionGraphPayload(entry)
+	if err != nil {
+		return nil, nil, openClawBehaviorPayload{}, fmt.Errorf("failed to parse anchor entry %s: %w", entry.Name, err)
+	}
+
+	return entry, provider, payload, nil
+}
+
+func sanitizeOpenClawStoragePathSegment(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+
+	var builder strings.Builder
+	for _, ch := range value {
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '-' || ch == '_' || ch == '.' {
+			builder.WriteRune(ch)
+		} else {
+			builder.WriteByte('_')
+		}
+	}
+
+	sanitized := strings.Trim(builder.String(), ". ")
+	for strings.Contains(sanitized, "..") {
+		sanitized = strings.ReplaceAll(sanitized, "..", "_")
+	}
+	if sanitized == "" {
+		return "unknown"
+	}
+	return sanitized
+}

--- a/object/openclaw_transcript_sync.go
+++ b/object/openclaw_transcript_sync.go
@@ -230,6 +230,11 @@ func (w *openClawTranscriptSyncWorker) scanTranscriptDir() error {
 		if err := w.scanTranscriptFile(path); err != nil {
 			return err
 		}
+		sessionID := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+		if err := uploadOpenClawRawTranscript(w.provider, sessionID, path, nextState.Size); err != nil {
+			fmt.Printf("OpenClaw raw transcript storage failed for provider %s session %s: %v\n", w.provider.Name, sessionID, err)
+			continue
+		}
 		w.fileStates[path] = nextState
 	}
 

--- a/routers/router.go
+++ b/routers/router.go
@@ -149,6 +149,7 @@ func InitAPI() {
 	web.Router("/api/get-entries", &controllers.ApiController{}, "GET:GetEntries")
 	web.Router("/api/get-entry", &controllers.ApiController{}, "GET:GetEntry")
 	web.Router("/api/get-openclaw-session-graph", &controllers.ApiController{}, "GET:GetOpenClawSessionGraph")
+	web.Router("/api/get-openclaw-session-transcript", &controllers.ApiController{}, "GET:GetOpenClawSessionTranscript")
 	web.Router("/api/update-entry", &controllers.ApiController{}, "POST:UpdateEntry")
 	web.Router("/api/add-entry", &controllers.ApiController{}, "POST:AddEntry")
 	web.Router("/api/delete-entry", &controllers.ApiController{}, "POST:DeleteEntry")

--- a/web/src/ManagementPage.js
+++ b/web/src/ManagementPage.js
@@ -117,6 +117,7 @@ import ServerStorePage from "./ServerStorePage";
 import ServerEditPage from "./ServerEditPage";
 import EntryListPage from "./EntryListPage";
 import EntryEditPage from "./EntryEditPage";
+import OpenClawSessionTranscriptPage from "./OpenClawSessionTranscriptPage";
 import SiteListPage from "./SiteListPage";
 import SiteEditPage from "./SiteEditPage";
 import RuleListPage from "./RuleListPage";
@@ -542,6 +543,7 @@ function ManagementPage(props) {
         <Route exact path="/server-store" render={(props) => renderLoginIfNotLoggedIn(<ServerStorePage account={account} {...props} />)} />
         <Route exact path="/servers/:organizationName/:serverName" render={(props) => renderLoginIfNotLoggedIn(<ServerEditPage account={account} {...props} />)} />
         <Route exact path="/entries" render={(props) => renderLoginIfNotLoggedIn(<EntryListPage account={account} {...props} />)} />
+        <Route exact path="/entries/:organizationName/:entryName/transcript" render={(props) => renderLoginIfNotLoggedIn(<OpenClawSessionTranscriptPage account={account} {...props} />)} />
         <Route exact path="/entries/:organizationName/:entryName" render={(props) => renderLoginIfNotLoggedIn(<EntryEditPage account={account} {...props} />)} />
         <Route exact path="/sites" render={(props) => renderLoginIfNotLoggedIn(<SiteListPage account={account} {...props} />)} />
         <Route exact path="/sites/:organizationName/:siteName" render={(props) => renderLoginIfNotLoggedIn(<SiteEditPage account={account} {...props} />)} />

--- a/web/src/OpenClawSessionGraphViewer.js
+++ b/web/src/OpenClawSessionGraphViewer.js
@@ -10,7 +10,7 @@ import {
   Tooltip,
   Typography
 } from "antd";
-import {FullscreenExitOutlined, FullscreenOutlined} from "@ant-design/icons";
+import {FileTextOutlined, FullscreenExitOutlined, FullscreenOutlined} from "@ant-design/icons";
 import i18next from "i18next";
 import Loading from "./common/Loading";
 import ReactFlow, {
@@ -483,17 +483,40 @@ class OpenClawSessionGraphViewer extends React.Component {
 
     return (
       <div
-        style={{display: "flex", flexWrap: "wrap", gap: 8, marginBottom: 12}}
+        style={{display: "flex", flexWrap: "wrap", gap: 8, marginBottom: 12, alignItems: "center"}}
       >
-        <Tag color="default">{i18next.t("site:Nodes")}: {stats.totalNodes}</Tag>
-        <Tag color="blue">{i18next.t("entry:Tasks")}: {stats.taskCount}</Tag>
-        <Tag color="orange">{i18next.t("entry:Tool calls")}: {stats.toolCallCount}</Tag>
-        <Tag color="green">{i18next.t("entry:Results")}: {stats.toolResultCount}</Tag>
-        <Tag color="purple">{i18next.t("entry:Finals")}: {stats.finalCount}</Tag>
-        {stats.failedCount > 0 ? (
-          <Tag color="red">{i18next.t("webhook:Failed")}: {stats.failedCount}</Tag>
-        ) : null}
+        <div style={{display: "flex", flexWrap: "wrap", gap: 8, flex: 1, minWidth: 0}}>
+          <Tag color="default">{i18next.t("site:Nodes")}: {stats.totalNodes}</Tag>
+          <Tag color="blue">{i18next.t("entry:Tasks")}: {stats.taskCount}</Tag>
+          <Tag color="orange">{i18next.t("entry:Tool calls")}: {stats.toolCallCount}</Tag>
+          <Tag color="green">{i18next.t("entry:Results")}: {stats.toolResultCount}</Tag>
+          <Tag color="purple">{i18next.t("entry:Finals")}: {stats.finalCount}</Tag>
+          {stats.failedCount > 0 ? (
+            <Tag color="red">{i18next.t("webhook:Failed")}: {stats.failedCount}</Tag>
+          ) : null}
+        </div>
+        {this.renderRawTranscriptButton()}
       </div>
+    );
+  }
+
+  renderRawTranscriptButton() {
+    if (!this.state.graph?.rawTranscript || !this.props.entry?.owner || !this.props.entry?.name) {
+      return null;
+    }
+
+    return (
+      <Tooltip title={i18next.t("entry:Raw JSONL")}>
+        <Button
+          size="small"
+          icon={<FileTextOutlined />}
+          onClick={() => {
+            window.location.href = `/entries/${this.props.entry.owner}/${encodeURIComponent(this.props.entry.name)}/transcript`;
+          }}
+        >
+          {i18next.t("entry:Raw JSONL")}
+        </Button>
+      </Tooltip>
     );
   }
 

--- a/web/src/OpenClawSessionTranscriptPage.js
+++ b/web/src/OpenClawSessionTranscriptPage.js
@@ -1,0 +1,150 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from "react";
+import {Alert, Button, Card, Descriptions} from "antd";
+import {ArrowLeftOutlined} from "@ant-design/icons";
+import i18next from "i18next";
+import * as EntryBackend from "./backend/EntryBackend";
+import * as Setting from "./Setting";
+import Loading from "./common/Loading";
+import {Editor} from "./common/Editor";
+
+class OpenClawSessionTranscriptPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      owner: props.match.params.organizationName,
+      entryName: props.match.params.entryName,
+      loading: false,
+      error: "",
+      transcript: null,
+    };
+  }
+
+  componentDidMount() {
+    this.loadTranscript();
+  }
+
+  componentDidUpdate(prevProps) {
+    const owner = this.props.match.params.organizationName;
+    const entryName = this.props.match.params.entryName;
+    if (owner !== prevProps.match.params.organizationName || entryName !== prevProps.match.params.entryName) {
+      this.setState({
+        owner,
+        entryName,
+        transcript: null,
+      }, () => this.loadTranscript());
+    }
+  }
+
+  loadTranscript() {
+    this.setState({loading: true, error: ""});
+    EntryBackend.getOpenClawSessionTranscript(this.state.owner, this.state.entryName)
+      .then((res) => {
+        if (res.status === "ok" && res.data) {
+          this.setState({
+            loading: false,
+            error: "",
+            transcript: res.data,
+          });
+        } else {
+          this.setState({
+            loading: false,
+            error: `${i18next.t("general:Failed to load")}: ${res.msg}`,
+            transcript: null,
+          });
+        }
+      })
+      .catch((error) => {
+        this.setState({
+          loading: false,
+          error: `${i18next.t("general:Failed to load")}: ${error?.message || String(error)}`,
+          transcript: null,
+        });
+      });
+  }
+
+  getEntryPath() {
+    return `/entries/${this.state.owner}/${encodeURIComponent(this.state.entryName)}`;
+  }
+
+  renderContent() {
+    if (this.state.loading) {
+      return <Loading type="page" tip={i18next.t("login:Loading")} />;
+    }
+
+    if (this.state.error) {
+      return <Alert type="warning" showIcon message={this.state.error} />;
+    }
+
+    const transcript = this.state.transcript;
+    if (!transcript) {
+      return null;
+    }
+
+    return (
+      <div style={{display: "grid", gap: 12}}>
+        <Descriptions bordered size="small" column={Setting.isMobile() ? 1 : 3}>
+          <Descriptions.Item label={i18next.t("resource:File name")}>
+            {transcript.fileName || "-"}
+          </Descriptions.Item>
+          <Descriptions.Item label={i18next.t("resource:File size")}>
+            {Setting.getFriendlyFileSize(transcript.fileSize || 0)}
+          </Descriptions.Item>
+          <Descriptions.Item label={i18next.t("entry:Loaded size")}>
+            {Setting.getFriendlyFileSize(transcript.loadedSize || 0)}
+          </Descriptions.Item>
+        </Descriptions>
+        {transcript.truncated ? (
+          <Alert
+            type="warning"
+            showIcon
+            message={i18next.t("entry:Transcript truncated")}
+          />
+        ) : null}
+        <Editor
+          value={transcript.content || ""}
+          readOnly
+          fillWidth
+          dark
+          height="calc(100vh - 300px)"
+          minHeight="360px"
+        />
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <Card
+        size="small"
+        title={i18next.t("entry:Raw JSONL")}
+        extra={
+          <Button
+            icon={<ArrowLeftOutlined />}
+            onClick={() => this.props.history.push(this.getEntryPath())}
+          >
+            {i18next.t("entry:Back to session")}
+          </Button>
+        }
+        style={Setting.isMobile() ? {margin: "5px"} : {}}
+      >
+        {this.renderContent()}
+      </Card>
+    );
+  }
+}
+
+export default OpenClawSessionTranscriptPage;

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -102,6 +102,7 @@ class ProviderEditPage extends React.Component {
       providerName: props.match.params.providerName,
       owner: props.organizationName !== undefined ? props.organizationName : props.match.params.organizationName,
       provider: null,
+      providers: [],
       certs: [],
       organizations: [],
       mode: props.location.mode !== undefined ? props.location.mode : "edit",
@@ -116,6 +117,7 @@ class ProviderEditPage extends React.Component {
   UNSAFE_componentWillMount() {
     this.getOrganizations();
     this.getProvider();
+    this.getProviders(this.state.owner);
     this.getCerts(this.state.owner);
   }
 
@@ -179,6 +181,17 @@ class ProviderEditPage extends React.Component {
     }
   }
 
+  getProviders(owner) {
+    ProviderBackend.getProviders(owner)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.setState({
+            providers: res.data || [],
+          });
+        }
+      });
+  }
+
   getCerts(owner) {
     CertBackend.getCerts(owner)
       .then((res) => {
@@ -204,6 +217,10 @@ class ProviderEditPage extends React.Component {
     if (key === "owner" && provider["owner"] !== value) {
       // the provider change the owner, reset the cert
       provider["cert"] = "";
+      if (provider["category"] === "Log" && provider["type"] === "Agent" && provider["subType"] === "OpenClaw") {
+        provider["providerUrl"] = "";
+      }
+      this.getProviders(value);
       this.getCerts(value);
     }
 
@@ -1089,7 +1106,8 @@ class ProviderEditPage extends React.Component {
             this.updateProviderField.bind(this)
           ) : this.state.provider.category === "Log" ? renderLogProviderFields(
             this.state.provider,
-            this.updateProviderField.bind(this)
+            this.updateProviderField.bind(this),
+            this.state.providers
           ) : this.state.provider.category === "Scan" ? renderScanProviderFields(
             this.state.provider,
             this.updateProviderField.bind(this),

--- a/web/src/backend/EntryBackend.js
+++ b/web/src/backend/EntryBackend.js
@@ -35,6 +35,17 @@ export function getOpenClawSessionGraph(owner, name) {
   }).then(res => res.json());
 }
 
+export function getOpenClawSessionTranscriptUrl(owner, name) {
+  return `${Setting.ServerUrl}/api/get-openclaw-session-transcript?id=${owner}/${encodeURIComponent(name)}`;
+}
+
+export function getOpenClawSessionTranscript(owner, name) {
+  return fetch(getOpenClawSessionTranscriptUrl(owner, name), {
+    method: "GET",
+    credentials: "include",
+  }).then(res => res.json());
+}
+
 export function updateEntry(owner, name, entry) {
   const newEntry = Setting.deepCopy(entry);
   return fetch(`${Setting.ServerUrl}/api/update-entry?id=${owner}/${encodeURIComponent(name)}`, {

--- a/web/src/provider/LogProviderFields.js
+++ b/web/src/provider/LogProviderFields.js
@@ -19,7 +19,17 @@ import i18next from "i18next";
 
 const {Option} = Select;
 
-export function renderLogProviderFields(provider, updateProviderField) {
+function getStorageProviderOptions(providers, owner) {
+  return (providers || []).filter(provider =>
+    provider.category === "Storage" &&
+    (!owner || provider.owner === owner) &&
+    (typeof provider.state !== "string" || provider.state.toLowerCase() !== "disabled")
+  );
+}
+
+export function renderLogProviderFields(provider, updateProviderField, providers = []) {
+  const storageProviders = getStorageProviderOptions(providers, provider.owner);
+
   return (
     <React.Fragment>
       {provider.type === "Agent" && provider.subType === "OpenClaw" ? (
@@ -52,6 +62,23 @@ export function renderLogProviderFields(provider, updateProviderField) {
               <Input value={provider.endpoint} onChange={e => {
                 updateProviderField("endpoint", e.target.value);
               }} />
+            </Col>
+          </Row>
+          <Row style={{marginTop: "20px"}} >
+            <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+              {i18next.t("provider:Storage provider")} :
+            </Col>
+            <Col span={22} >
+              <Select virtual={false} style={{width: "100%"}} value={provider.providerUrl || ""} onChange={value => {
+                updateProviderField("providerUrl", value);
+              }}>
+                <Option value="" />
+                {storageProviders.map(storageProvider => (
+                  <Option key={storageProvider.name} value={storageProvider.name}>
+                    {storageProvider.displayName || storageProvider.name}
+                  </Option>
+                ))}
+              </Select>
             </Col>
           </Row>
         </React.Fragment>


### PR DESCRIPTION
## Summary

This PR adds Raw JSONL support for OpenClaw session graph entries.

OpenClaw transcript sync now stores the original `.jsonl` session transcript in a Storage provider and exposes a lightweight `rawTranscript` reference from the existing session graph API. The frontend shows a Raw JSONL entry point from the session graph and opens an internal read-only transcript viewer.

It also allows OpenClaw Log providers to choose which Storage provider should be used for transcript storage. If none is selected, the backend uses the first available enabled Storage provider, or creates a local filesystem fallback provider automatically.

## Changes

- Store changed OpenClaw `.jsonl` transcripts through Casdoor Storage provider.
- Create/update a `Resource` record for each stored transcript.
- Add `rawTranscript` metadata to the OpenClaw session graph response.
- Add `/api/get-openclaw-session-transcript` preview API.
- Preview only the first 2 MiB of transcript content to avoid freezing the browser on large JSONL/base64 sessions.
- Add an internal OpenClaw transcript viewer page.
- Add a Raw JSONL button on the OpenClaw session graph toolbar.
- Add Storage provider selection to OpenClaw Log provider settings via existing `providerUrl`.
- Auto-create a local filesystem Storage provider fallback when no usable Storage provider exists.