### PR TITLE
fix: use exclusive C14N for SAML assertion signatures

### DIFF
--- a/object/saml_idp.go
+++ b/object/saml_idp.go
@@ -161,7 +161,9 @@ func NewSamlSigningContext(application *Application, randomKeyStore *X509Key) *d
 		ctx.Hash = crypto.SHA512
 	}
 
-	ctx.Canonicalizer = dsig.MakeC14N10ExclusiveCanonicalizerWithPrefixList("")
+	if application.EnableSamlC14n10 {
+		ctx.Canonicalizer = dsig.MakeC14N10ExclusiveCanonicalizerWithPrefixList("")
+	}
 
 	return ctx
 }

--- a/object/saml_idp.go
+++ b/object/saml_idp.go
@@ -151,6 +151,21 @@ func NewSamlResponse(application *Application, user *User, host string, certific
 	return samlResponse, nil
 }
 
+func NewSamlSigningContext(application *Application, randomKeyStore *X509Key) *dsig.SigningContext {
+	ctx := dsig.NewDefaultSigningContext(randomKeyStore)
+	if application.SamlHashAlgorithm == "" || application.SamlHashAlgorithm == "SHA1" {
+		ctx.Hash = crypto.SHA1
+	} else if application.SamlHashAlgorithm == "SHA256" {
+		ctx.Hash = crypto.SHA256
+	} else if application.SamlHashAlgorithm == "SHA512" {
+		ctx.Hash = crypto.SHA512
+	}
+
+	ctx.Canonicalizer = dsig.MakeC14N10ExclusiveCanonicalizerWithPrefixList("")
+
+	return ctx
+}
+
 type X509Key struct {
 	X509Certificate string
 	PrivateKey      string
@@ -375,18 +390,7 @@ func GetSamlResponse(application *Application, user *User, samlRequest string, h
 		PrivateKey:      cert.PrivateKey,
 		X509Certificate: certificate,
 	}
-	ctx := dsig.NewDefaultSigningContext(randomKeyStore)
-	if application.SamlHashAlgorithm == "" || application.SamlHashAlgorithm == "SHA1" {
-		ctx.Hash = crypto.SHA1
-	} else if application.SamlHashAlgorithm == "SHA256" {
-		ctx.Hash = crypto.SHA256
-	} else if application.SamlHashAlgorithm == "SHA512" {
-		ctx.Hash = crypto.SHA512
-	}
-
-	if application.EnableSamlC14n10 {
-		ctx.Canonicalizer = dsig.MakeC14N10ExclusiveCanonicalizerWithPrefixList("xs")
-	}
+	ctx := NewSamlSigningContext(application, randomKeyStore)
 
 	// signedXML, err := ctx.SignEnvelopedLimix(samlResponse)
 	// if err != nil {

--- a/object/saml_idp_test.go
+++ b/object/saml_idp_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"testing"
+
+	"github.com/beevik/etree"
+	"github.com/stretchr/testify/require"
+)
+
+func testSamlSigningKeyStore(t *testing.T) *X509Key {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	return &X509Key{
+		PrivateKey:      string(privateKeyPEM),
+		X509Certificate: base64.StdEncoding.EncodeToString([]byte("test-certificate")),
+	}
+}
+
+func TestNewSamlSigningContextUsesExclusiveCanonicalization(t *testing.T) {
+	keyStore := testSamlSigningKeyStore(t)
+
+	tests := []struct {
+		name             string
+		enableSamlC14n10 bool
+	}{
+		{name: "disabled", enableSamlC14n10: false},
+		{name: "enabled", enableSamlC14n10: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := NewSamlSigningContext(&Application{EnableSamlC14n10: tt.enableSamlC14n10}, keyStore)
+
+			signedElement := etree.NewElement("Assertion")
+			signedElement.CreateAttr("ID", "_test")
+			signedElement.CreateElement("Issuer").SetText("https://example.com")
+
+			signature, err := ctx.ConstructSignature(signedElement, true)
+			require.NoError(t, err)
+
+			doc := etree.NewDocument()
+			doc.SetRoot(signature)
+
+			signatureXML, err := doc.WriteToBytes()
+			require.NoError(t, err)
+
+			xml := string(signatureXML)
+			require.Contains(t, xml, "http://www.w3.org/2001/10/xml-exc-c14n#")
+			require.NotContains(t, xml, "http://www.w3.org/2006/12/xml-c14n11")
+			require.NotContains(t, xml, "InclusiveNamespaces")
+			require.NotContains(t, xml, "PrefixList=\"xs\"")
+		})
+	}
+}

--- a/object/saml_idp_test.go
+++ b/object/saml_idp_test.go
@@ -47,11 +47,31 @@ func TestNewSamlSigningContextUsesExclusiveCanonicalization(t *testing.T) {
 	keyStore := testSamlSigningKeyStore(t)
 
 	tests := []struct {
-		name             string
-		enableSamlC14n10 bool
+		name              string
+		enableSamlC14n10  bool
+		expectedAlgorithm string
+		unexpected        []string
 	}{
-		{name: "disabled", enableSamlC14n10: false},
-		{name: "enabled", enableSamlC14n10: true},
+		{
+			name:              "disabled uses c14n11",
+			enableSamlC14n10:  false,
+			expectedAlgorithm: "http://www.w3.org/2006/12/xml-c14n11",
+			unexpected: []string{
+				"http://www.w3.org/2001/10/xml-exc-c14n#",
+				"InclusiveNamespaces",
+				"PrefixList=\"xs\"",
+			},
+		},
+		{
+			name:              "enabled uses exclusive c14n10",
+			enableSamlC14n10:  true,
+			expectedAlgorithm: "http://www.w3.org/2001/10/xml-exc-c14n#",
+			unexpected: []string{
+				"http://www.w3.org/2006/12/xml-c14n11",
+				"InclusiveNamespaces",
+				"PrefixList=\"xs\"",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -72,10 +92,10 @@ func TestNewSamlSigningContextUsesExclusiveCanonicalization(t *testing.T) {
 			require.NoError(t, err)
 
 			xml := string(signatureXML)
-			require.Contains(t, xml, "http://www.w3.org/2001/10/xml-exc-c14n#")
-			require.NotContains(t, xml, "http://www.w3.org/2006/12/xml-c14n11")
-			require.NotContains(t, xml, "InclusiveNamespaces")
-			require.NotContains(t, xml, "PrefixList=\"xs\"")
+			require.Contains(t, xml, tt.expectedAlgorithm)
+			for _, unexpected := range tt.unexpected {
+				require.NotContains(t, xml, unexpected)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes #5433.

Summary
- Keep the `EnableSamlC14n10` toggle in place.
- Restore the `EnableSamlC14n10=true` branch to the known-good v2.285.0 behavior: exclusive C14N using `dsig.MakeC14N10ExclusiveCanonicalizerWithPrefixList("")`.
- Preserve the `EnableSamlC14n10=false` path by continuing to use goxmldsig's direct `SigningContext` default, which is C14N11.
- Add a regression test that verifies both branches explicitly: disabled emits C14N11, enabled emits exclusive C14N, and the enabled branch does not emit `InclusiveNamespaces` or `PrefixList="xs"`.

Why
- The regression reported in #5433 is specifically in the enabled branch: newer releases changed the exclusive C14N branch shape from the v2.285.0 implementation to an incompatible variant.
- Preserving the flag avoids changing existing configuration semantics while still restoring the working exclusive-C14N path for users who enable it.

Validation
- Ran a standalone probe against the production helper and confirmed:
  - `EnableSamlC14n10=false` emits `http://www.w3.org/2006/12/xml-c14n11`
  - `EnableSamlC14n10=true` emits `http://www.w3.org/2001/10/xml-exc-c14n#`
  - the enabled branch does not emit `InclusiveNamespaces` or `PrefixList="xs"`
- Confirmed the edited files have no local compile errors.

Notes
- This PR branch is pushed from a fork because the upstream repository does not grant direct push access to this account.