### PR TITLE
fix: prevent arbitrary file write via path traversal in LocalFileSystemProvider

### DIFF
--- a/object/provider.go
+++ b/object/provider.go
@@ -237,6 +237,10 @@ func UpdateProvider(id string, provider *Provider) (bool, error) {
 		}
 	}
 
+	if strings.Contains(provider.PathPrefix, "..") {
+		return false, fmt.Errorf("the pathPrefix: %s is not allowed", provider.PathPrefix)
+	}
+
 	if err := fillOpenClawProviderDefaults(provider); err != nil {
 		return false, err
 	}
@@ -284,6 +288,10 @@ func AddProvider(provider *Provider) (bool, error) {
 		if err != nil {
 			return false, err
 		}
+	}
+
+	if strings.Contains(provider.PathPrefix, "..") {
+		return false, fmt.Errorf("the pathPrefix: %s is not allowed", provider.PathPrefix)
 	}
 
 	if err := fillOpenClawProviderDefaults(provider); err != nil {

--- a/storage/local_file_system.go
+++ b/storage/local_file_system.go
@@ -44,8 +44,15 @@ func NewLocalFileSystemStorageProvider() *LocalFileSystemProvider {
 func (sp LocalFileSystemProvider) GetFullPath(path string) string {
 	fullPath := path
 	if !strings.HasPrefix(path, sp.BaseDir) {
-		fullPath, _ = filepath.Abs(filepath.Join(sp.BaseDir, path))
+		fullPath = filepath.Join(sp.BaseDir, path)
 	}
+
+	fullPath = filepath.Clean(fullPath)
+	rel, err := filepath.Rel(sp.BaseDir, fullPath)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return sp.BaseDir
+	}
+
 	return fullPath
 }
 


### PR DESCRIPTION
### Description
This PR addresses an arbitrary file write vulnerability (Path Traversal) in the `Local File System` storage provider. An authenticated administrator could manipulate the `pathPrefix` or upload paths to write files outside the intended storage directory (`files/`).

### Changes
- **Object Layer**: Added validation in `AddProvider` and `UpdateProvider` to reject `pathPrefix` containing `..` sequences.
- **Storage Layer**: Hardened `LocalFileSystemProvider.GetFullPath` using `filepath.Rel` to ensure the resolved path is always contained within the `BaseDir` (sandbox).

### Security Impact
Prevents arbitrary file write on file system, which could lead to Remote Code Execution (RCE) or Denial of Service (DoS) by overwriting critical system/database files (e.g `casdoor.db`).
