### PR TITLE
fix: global admin exit impersonation fails for cross-org users

### DIFF
--- a/routers/authz_filter.go
+++ b/routers/authz_filter.go
@@ -294,7 +294,7 @@ func getExtraInfo(ctx *context.Context, urlPath string) map[string]interface{} {
 	return extra
 }
 
-func getImpersonateUser(ctx *context.Context, subOwner, subName, username string) (string, string, string) {
+func getImpersonateUser(ctx *context.Context, subOwner, subName, username, urlPath string) (string, string, string) {
 	impersonateUser, ok := ctx.Input.Session("impersonateUser").(string)
 	impersonateUserCookie := ctx.GetCookie("impersonateUser")
 	if ok && impersonateUser != "" && impersonateUserCookie != "" {
@@ -309,8 +309,11 @@ func getImpersonateUser(ctx *context.Context, subOwner, subName, username string
 				panic(err)
 			}
 
-			if user.IsAdmin && impUserOwner == user.Owner {
+			if user.IsAdmin && (impUserOwner == user.Owner || user.IsGlobalAdmin()) {
 				ctx.Input.SetData("impersonating", true)
+				if urlPath == "/api/exit-impersonate-user" {
+					return subOwner, subName, username
+				}
 				return impUserOwner, impUserName, impersonateUser
 			}
 		}
@@ -323,14 +326,14 @@ func ApiFilter(ctx *context.Context) {
 	subOwner, subName := getSubject(ctx)
 	// stash current user info into request context for controllers
 	username := ""
+	urlPath := getUrlPath(ctx)
 	if !(subOwner == "anonymous" && subName == "anonymous") {
 		username = fmt.Sprintf("%s/%s", subOwner, subName)
-		subOwner, subName, username = getImpersonateUser(ctx, subOwner, subName, username)
+		subOwner, subName, username = getImpersonateUser(ctx, subOwner, subName, username, urlPath)
 	}
 	ctx.Input.SetData("currentUserId", username)
 
 	method := ctx.Request.Method
-	urlPath := getUrlPath(ctx)
 	extraInfo := getExtraInfo(ctx, urlPath)
 
 	objOwner, objName := "", ""


### PR DESCRIPTION
## Summary

Fixes two issues that prevent global admins from exiting impersonation when the impersonated user belongs to a different organization.

## Changes

### 1. Allow global admins to exit cross-org impersonation

The exit condition in `getImpersonateUser` now checks `user.IsGlobalAdmin()` in addition to `impUserOwner == user.Owner`. This allows global admins (`built-in/*`) to exit impersonation regardless of the impersonated user's organization.

### 2. Use real admin identity for authz on exit endpoint

When calling `/api/exit-impersonate-user`, the authz filter now uses the real admin's identity as the request subject instead of the impersonated user's identity. The `"impersonating"` flag is still set so the controller can verify the impersonation state.

### Implementation

- `getImpersonateUser` accepts a `urlPath` parameter
- For `/api/exit-impersonate-user`, returns the original (admin) subject identity while still setting `"impersonating": true`
- `ApiFilter` computes `urlPath` earlier and passes it through

## Affected files

- `routers/authz_filter.go`

## Before / After

| Scenario | Before | After |
|---|---|---|
| Global admin exits impersonation (same org) | ✅ Allow | ✅ Allow |
| Global admin exits impersonation (cross-org) | ❌ Deny | ✅ Allow |
| Org admin exits impersonation (same org) | ✅ Allow | ✅ Allow |
| Authz subject for exit endpoint | Impersonated user | Real admin |