### PR TITLE
fix: restrict Swagger static path to `dev` runmode

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,7 +88,9 @@ func main() {
 	// web.SetStaticPath("/static", "web/build/static")
 
 	web.BConfig.WebConfig.DirectoryIndex = true
-	web.SetStaticPath("/swagger", "swagger")
+	if web.BConfig.RunMode == "dev" {
+		web.SetStaticPath("/swagger", "swagger")
+	}
 	web.SetStaticPath("/files", "files")
 	// https://studygolang.com/articles/2303
 	web.InsertFilter("*", web.BeforeStatic, routers.RequestBodyFilter)


### PR DESCRIPTION
## Summary

Swagger UI and the OpenAPI spec (`/swagger/index.html`, `/swagger/swagger.json`) are served unconditionally in all environments. [`main.go:91`](https://github.com/casdoor/casdoor/blob/fc03a30e/main.go#L91) registers the static path with no environment check, exposing the full API surface (234 endpoints) in production.

## Changes

### `main.go`

Wrapped `web.SetStaticPath("/swagger", "swagger")` with a runmode check:

```go
if web.BConfig.RunMode == "dev" {
    web.SetStaticPath("/swagger", "swagger")
}
```

Beego reads `runmode` from [`conf/app.conf:3`](https://github.com/casdoor/casdoor/blob/fc03a30e/conf/app.conf#L3) (default: `dev`). When `runmode != "dev"`, the static path is never registered — Beego returns 404 for `/swagger/*`. The `swagger/` directory still exists on disk but is not served.

### Frontend impact

None. No frontend code references the swagger path.

## Verification

- `go build ./...` — passes
- Swagger annotations in [`routers/router.go:16-23`](https://github.com/casdoor/casdoor/blob/fc03a30e/routers/router.go#L16-L23) are build-time only (used by `bee` to generate `swagger.json`) — no runtime impact

## Compatibility

No breaking changes. Default `runmode` is `dev`, so swagger is still served unless explicitly set to `prod`. Production deployments should set `runmode = prod` in `app.conf`.