### PR TITLE
fix: remove `localhost` and `127.0.0.1` from hardcoded CORS allowlist

### DIFF
--- a/util/validation.go
+++ b/util/validation.go
@@ -127,6 +127,6 @@ func IsValidOrigin(origin string) (bool, error) {
 		originHostOnly = fmt.Sprintf("%s://%s", urlObj.Scheme, urlObj.Hostname())
 	}
 
-	res := originHostOnly == "http://localhost" || originHostOnly == "https://localhost" || originHostOnly == "http://127.0.0.1" || originHostOnly == "http://casdoor-authenticator" || strings.HasSuffix(originHostOnly, ".chromiumapp.org")
+	res := originHostOnly == "http://casdoor-authenticator" || strings.HasSuffix(originHostOnly, ".chromiumapp.org")
 	return res, nil
 }


### PR DESCRIPTION
## Summary

[`util/validation.go:130`](https://github.com/casdoor/casdoor/blob/fc03a30e/util/validation.go#L130) unconditionally trusts `http://localhost`, `https://localhost`, and `http://127.0.0.1` as valid origins. The CORS filter at [`cors_filter.go:55-63`](https://github.com/casdoor/casdoor/blob/fc03a30e/routers/cors_filter.go#L55-L63) checks this **before** any other validation — if it passes, the origin is reflected with `Access-Control-Allow-Credentials: true`. In production, any process on a user's localhost can make authenticated cross-origin requests to the Casdoor API.

## Changes

### `util/validation.go` — [`IsValidOrigin()`](https://github.com/casdoor/casdoor/blob/fc03a30e/util/validation.go#L116)

Removed `http://localhost`, `https://localhost`, and `http://127.0.0.1` from the hardcoded allowlist. Kept `http://casdoor-authenticator` and `*.chromiumapp.org` (browser extension — legitimate non-dev use case).

### Why dev environments still work

`IsValidOrigin()` is used in 3 places. In all three, removing localhost is safe because subsequent checks handle it:

1. **CORS filter** ([`cors_filter.go:86-105`](https://github.com/casdoor/casdoor/blob/fc03a30e/routers/cors_filter.go#L86-L105)) — falls through to hostname matching (`originHostname == host`, [line 89](https://github.com/casdoor/casdoor/blob/fc03a30e/routers/cors_filter.go#L89)) and intranet check (`IsHostIntranet`, [line 91](https://github.com/casdoor/casdoor/blob/fc03a30e/routers/cors_filter.go#L91)). Dev servers on localhost pass both.
2. **OAuth redirect URI** ([`application_util.go:368`](https://github.com/casdoor/casdoor/blob/fc03a30e/object/application_util.go#L368)) — falls through to the app's configured `RedirectUris` list at [line 376](https://github.com/casdoor/casdoor/blob/fc03a30e/object/application_util.go#L376).
3. **Application origin** ([`application_util.go:515`](https://github.com/casdoor/casdoor/blob/fc03a30e/object/application_util.go#L515)) — same fallthrough to configured redirect URIs.

### Frontend impact

None. The frontend uses relative URLs in production (same-origin, no CORS). In dev, the craco proxy handles API requests — the backend never sees a cross-origin localhost request.

## Verification

- `go build ./...` — passes
- Confirmed frontend `ServerUrl` is empty string (relative paths) in [`web/src/Setting.js`](https://github.com/casdoor/casdoor/blob/fc03a30e/web/src/Setting.js)
- Confirmed dev proxy in `craco.config.js` uses `changeOrigin: true`

## Compatibility

No breaking changes for production. Dev environments work via hostname matching and intranet checks. Deployments that explicitly need localhost CORS can set `origin = http://localhost:PORT` in `app.conf` or add localhost to the app's redirect URIs.
