### PR TITLE
fix: normalize response in `GetEmailAndPhone` to prevent user enumeration

### DIFF
--- a/controllers/user.go
+++ b/controllers/user.go
@@ -468,33 +468,39 @@ func (c *ApiController) GetEmailAndPhone() {
 		return
 	}
 
+	type EmailAndPhoneResp struct {
+		Name  string `json:"name"`
+		Email string `json:"email"`
+		Phone string `json:"phone"`
+	}
+
 	user, err := object.GetUserByFields(organization, username)
 	if err != nil {
-		c.ResponseError(err.Error())
+		c.ResponseOk(&EmailAndPhoneResp{Name: username})
 		return
 	}
 
 	if user == nil {
-		c.ResponseError(fmt.Sprintf(c.T("general:The user: %s doesn't exist"), util.GetId(organization, username)))
+		c.ResponseOk(&EmailAndPhoneResp{Name: username})
 		return
 	}
 
-	respUser := object.User{Name: user.Name}
+	resp := &EmailAndPhoneResp{Name: user.Name}
 	var contentType string
 	switch username {
 	case user.Email:
 		contentType = "email"
-		respUser.Email = user.Email
+		resp.Email = user.Email
 	case user.Phone:
 		contentType = "phone"
-		respUser.Phone = user.Phone
+		resp.Phone = user.Phone
 	case user.Name:
 		contentType = "username"
-		respUser.Email = util.GetMaskedEmail(user.Email)
-		respUser.Phone = util.GetMaskedPhone(user.Phone)
+		resp.Email = util.GetMaskedEmail(user.Email)
+		resp.Phone = util.GetMaskedPhone(user.Phone)
 	}
 
-	c.ResponseOk(respUser, contentType)
+	c.ResponseOk(resp, contentType)
 }
 
 // SetPassword


### PR DESCRIPTION

## Summary

`GET /api/get-email-and-phone` is public (needed for password recovery). It currently returns the full `object.User` struct (~3900 bytes) for valid users and a short error string (~155 bytes) for invalid ones — making user enumeration trivial by response size alone. The error message also explicitly says "The user X doesn't exist".

## Changes

### `controllers/user.go` — [`GetEmailAndPhone()`](https://github.com/casdoor/casdoor/blob/fc03a30e/controllers/user.go#L461)

- **Minimal response struct** — replaced `object.User{Name: ...}` (150+ zero-value JSON fields) with a 3-field struct: `name`, `email`, `phone`
- **Uniform response for missing users** — changed from `ResponseError("The user X doesn't exist")` to `ResponseOk(&EmailAndPhoneResp{Name: username})` with empty email/phone

Both cases now return `status: "ok"` with the same struct shape and similar size.

### Frontend impact — [`web/src/auth/ForgetPage.js`](https://github.com/casdoor/casdoor/blob/fc03a30e/web/src/auth/ForgetPage.js#L86-L131)

No frontend changes needed. ForgetPage reads only `res.data.name`, `res.data.email`, `res.data.phone`, and `res.data2` — all present in the new response. For missing users, the `!phone && !email` guard at [line 96](https://github.com/casdoor/casdoor/blob/fc03a30e/web/src/auth/ForgetPage.js#L96) shows "No verification method" — a generic message that doesn't confirm account existence.

## Verification

- `go build ./...` — passes
- Confirmed ForgetPage reads no other fields from the response (no `countryCode`, no other `User` fields)
- Tested forgot password flow locally with Playwright — existing user shows masked phone/email correctly

## Compatibility

UX change: non-existent users see "No verification method" instead of "The user X doesn't exist". This is intentional — eliminates the enumeration vector. API consumers that relied on `status: "error"` to detect missing users should use `GET /api/get-user` (authenticated) instead.
