### PR TITLE
feat: add captcha validation to signup

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/beego/beego/v2/core/logs"
+	"github.com/casdoor/casdoor/captcha"
 	"github.com/casdoor/casdoor/form"
 	"github.com/casdoor/casdoor/object"
 	"github.com/casdoor/casdoor/util"
@@ -120,6 +121,34 @@ func (c *ApiController) Signup() {
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
+	}
+
+	var enableCaptcha bool
+	if enableCaptcha, err = object.CheckToEnableCaptcha(application, authForm.Organization, authForm.Username, clientIp); err != nil {
+		c.ResponseError(err.Error())
+		return
+	} else if enableCaptcha {
+		captchaProvider, err := object.GetCaptchaProviderByApplication(util.GetId(application.Owner, application.Name), "false", c.GetAcceptLanguage())
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
+
+		if captchaProvider.Type != "Default" {
+			authForm.ClientSecret = captchaProvider.ClientSecret
+		}
+
+		var isHuman bool
+		isHuman, err = captcha.VerifyCaptchaByCaptchaType(authForm.CaptchaType, authForm.CaptchaToken, captchaProvider.ClientId, authForm.ClientSecret, captchaProvider.ClientId2)
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
+
+		if !isHuman {
+			c.ResponseError(c.T("verification:Turing test failed."))
+			return
+		}
 	}
 
 	msg := object.CheckUserSignup(application, organization, &authForm, c.GetAcceptLanguage())

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -30,6 +30,7 @@ import {withRouter} from "react-router-dom";
 import {CountryCodeSelect} from "../common/select/CountryCodeSelect";
 import * as PasswordChecker from "../common/PasswordChecker";
 import * as InvitationBackend from "../backend/InvitationBackend";
+import {CaptchaModal} from "../common/modal/CaptchaModal";
 
 const formItemLayout = {
   labelCol: {
@@ -124,6 +125,8 @@ class SignupPage extends React.Component {
       region: "",
       isTermsOfUseVisible: false,
       termsOfUseContent: "",
+      openCaptchaModal: false,
+      captchaValues: undefined,
     };
 
     this.form = React.createRef();
@@ -259,6 +262,57 @@ class SignupPage extends React.Component {
     return languagesItem?.rule;
   }
 
+  checkCaptchaStatus(values) {
+    AuthBackend.getCaptchaStatus(values)
+      .then((res) => {
+        if (res.status === "ok") {
+          if (res.data) {
+            this.setState({
+              openCaptchaModal: true,
+              values: values,
+            });
+            return null;
+          }
+        }
+        this.submitSignup(values);
+      });
+  }
+
+  renderCaptchaModal(application) {
+    if (Setting.getCaptchaRule(application) === Setting.CaptchaRule.Never) {
+      return null;
+    }
+    const captchaProviderItems = Setting.getCaptchaProviderItems(application);
+    const captchaRule = Setting.getCaptchaRule(application);
+    let provider = null;
+
+    const ruleProviders = captchaProviderItems.filter(providerItem => providerItem.rule === captchaRule);
+    if (ruleProviders.length > 0) {
+      provider = ruleProviders[0].provider;
+    }
+
+    if (!provider) {
+      return null;
+    }
+
+    return <CaptchaModal
+      owner={provider.owner}
+      name={provider.name}
+      visible={this.state.openCaptchaModal}
+      onOk={(captchaType, captchaToken, clientSecret) => {
+        const values = this.state.values;
+        values["captchaType"] = captchaType;
+        values["captchaToken"] = captchaToken;
+        values["clientSecret"] = clientSecret;
+
+        this.submitSignup(values);
+        this.setState({openCaptchaModal: false});
+      }}
+      onCancel={() => this.setState({openCaptchaModal: false})}
+      isCurrentProvider={true}
+    />;
+  }
+
   onFinish(values) {
     const application = this.getApplicationObj();
 
@@ -285,6 +339,24 @@ class SignupPage extends React.Component {
     const params = new URLSearchParams(window.location.search);
     values.plan = params.get("plan");
     values.pricing = params.get("pricing");
+
+    const captchaRule = Setting.getCaptchaRule(application);
+    if (captchaRule === Setting.CaptchaRule.Always) {
+      this.setState({
+        openCaptchaModal: true,
+        values: values,
+      });
+      return;
+    } else if (captchaRule === Setting.CaptchaRule.Dynamic || captchaRule === Setting.CaptchaRule.InternetOnly) {
+      this.checkCaptchaStatus(values);
+      return;
+    }
+
+    this.submitSignup(values);
+  }
+
+  submitSignup(values) {
+    const application = this.getApplicationObj();
 
     // Get OAuth parameters if present
     const oAuthParams = Util.getOAuthGetParameters();
@@ -1022,6 +1094,9 @@ class SignupPage extends React.Component {
               />
               {
                 this.renderForm(application)
+              }
+              {
+                this.renderCaptchaModal(application)
               }
             </div>
           </div>


### PR DESCRIPTION
## Summary

The `Signup()` handler never verifies CAPTCHA server-side, and `SignupPage.js` never renders a CAPTCHA challenge. An attacker can call `POST /api/signup` directly, bypassing CAPTCHA even when a provider is configured. `Login()` already has full CAPTCHA validation — this PR brings signup to parity.

## Changes

### Backend — `controllers/account.go`

Added the same CAPTCHA validation block from [`Login()`](https://github.com/casdoor/casdoor/blob/fc03a30e/controllers/auth.go#L710-L735) to [`Signup()`](https://github.com/casdoor/casdoor/blob/fc03a30e/controllers/account.go#L84), after application/organization lookup and before `CheckUserSignup()`:

1. `object.CheckToEnableCaptcha()` — check if CAPTCHA is required
2. `object.GetCaptchaProviderByApplication()` — fetch the configured provider
3. `captcha.VerifyCaptchaByCaptchaType()` — verify the token

If CAPTCHA is not enabled on the application, the block is a no-op.

### Frontend — `web/src/auth/SignupPage.js`

Added `CaptchaModal` support mirroring [`LoginPage.js:1171-1221`](https://github.com/casdoor/casdoor/blob/fc03a30e/web/src/auth/LoginPage.js#L1171-L1221):

- `onFinish()` checks `getCaptchaRule()` before submitting — opens modal for Always / Dynamic / Internet-Only rules
- `renderCaptchaModal()` renders `CaptchaModal` with the same provider selection logic as LoginPage
- `submitSignup()` extracted as the actual API call, invoked directly or after CAPTCHA completion

Uses existing helpers: `Setting.getCaptchaRule()`, `Setting.getCaptchaProviderItems()`, `AuthBackend.getCaptchaStatus()`.

## Verification

### Local test environment setup

1. Start MySQL:
   ```bash
   docker run -d --name casdoor-mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=123456 mysql:8.0.25
   ```

2. Place the following `init_data.json` in the project root (creates a test org, test app with Cloudflare Turnstile CAPTCHA, and rule `Always`):

   <details>
   <summary><code>init_data.json</code></summary>

   ```json
   {
     "organizations": [
       {
         "owner": "admin",
         "name": "test-org",
         "displayName": "Test Organization",
         "passwordType": "bcrypt",
         "passwordOptions": ["AtLeast6"],
         "countryCodes": ["US"],
         "languages": ["en"],
         "initScore": 2000,
         "enableSoftDeletion": false,
         "isProfilePublic": true,
         "accountItems": [
           {"name": "Organization", "visible": true, "viewRule": "Public", "modifyRule": "Admin"},
           {"name": "ID", "visible": true, "viewRule": "Public", "modifyRule": "Immutable"},
           {"name": "Name", "visible": true, "viewRule": "Public", "modifyRule": "Admin"},
           {"name": "Display name", "visible": true, "viewRule": "Public", "modifyRule": "Self"},
           {"name": "Password", "visible": true, "viewRule": "Self", "modifyRule": "Self"}
         ]
       }
     ],
     "applications": [
       {
         "owner": "admin",
         "name": "test-app",
         "displayName": "Test App",
         "organization": "test-org",
         "cert": "cert-built-in",
         "enablePassword": true,
         "clientId": "test-client-id",
         "clientSecret": "test-client-secret",
         "enableCaptcha": true,
         "enableSignUp": true,
         "providers": [
           {
             "owner": "",
             "name": "provider_captcha_cloudflare",
             "canSignUp": false,
             "canSignIn": false,
             "canUnlink": false,
             "prompted": false,
             "alertType": "None",
             "rule": "Always",
             "provider": {
               "owner": "admin",
               "name": "provider_captcha_cloudflare"
             }
           }
         ],
         "signupItems": [
           {"name": "ID", "visible": false, "required": true, "prompted": false, "rule": "Random"},
           {"name": "Username", "visible": true, "required": true, "prompted": false, "rule": "None"},
           {"name": "Display name", "visible": true, "required": true, "prompted": false, "rule": "None"},
           {"name": "Password", "visible": true, "required": true, "prompted": false, "rule": "None"},
           {"name": "Confirm password", "visible": true, "required": true, "prompted": false, "rule": "None"},
           {"name": "Agreement", "visible": true, "required": true, "prompted": false, "rule": "None"}
         ]
       }
     ],
     "users": [],
     "providers": [
       {
         "owner": "admin",
         "name": "provider_captcha_cloudflare",
         "displayName": "Cloudflare captcha",
         "category": "Captcha",
         "type": "Cloudflare Turnstile",
         "subType": "",
         "method": "Normal",
         "clientId": "3x00000000000000000000FF",
         "clientSecret": "1x0000000000000000000000000000000AA"
       }
     ],
     "certs": [],
     "ldaps": [],
     "models": [],
     "permissions": [],
     "payments": [],
     "products": [],
     "resources": [],
     "roles": [],
     "syncers": [],
     "tokens": [],
     "webhooks": [],
     "groups": [],
     "adapters": [],
     "enforcers": [],
     "plans": [],
     "pricings": []
   }
   ```

   </details>

   The `clientId` / `clientSecret` are [Cloudflare Turnstile test keys](https://developers.cloudflare.com/turnstile/troubleshooting/testing/). They work on any domain including `localhost`.

   | Sitekey | Behavior |
   |---|---|
   | `1x00000000000000000000AA` | Always passes (visible widget) |
   | `2x00000000000000000000AB` | Always fails (visible widget) |
   | `3x00000000000000000000FF` | Forces interactive challenge (visible widget) |

   The `init_data.json` above uses `3x00000000000000000000FF` so the CAPTCHA modal renders a real interactive challenge. The secret key `1x0000000000000000000000000000000AA` always passes server-side validation.

3. Build and start the backend:
   ```bash
   go build -o casdoor-server .
   ./casdoor-server --createDatabase=true
   ```

4. Start the frontend dev server:
   ```bash
   cd web && BROWSER=none PORT=7001 yarn start
   ```

5. Open `http://localhost:7001/signup/test-app`.

### Test 1: Backend rejects signup without CAPTCHA token

```bash
curl -s 'http://localhost:8000/api/signup' \
  -X POST \
  -H 'Content-Type: text/plain;charset=UTF-8' \
  --data-raw '{"application":"test-app","organization":"test-org","username":"test-user-nocaptcha","name":"Test","password":"123123","confirm":"123123","agreement":true}'
```

**Expected response** (CAPTCHA required, no token provided):
```json
{
  "status": "error",
  "msg": "invalid captcha provider: ",
  ...
}
```

Before this PR, the same request returns `{"status": "ok", ...}` — signup succeeds without any CAPTCHA check.

### Test 2: Backend accepts signup with valid CAPTCHA token

```bash
curl -s 'http://localhost:8000/api/signup' \
  -X POST \
  -H 'Content-Type: text/plain;charset=UTF-8' \
  --data-raw '{"application":"test-app","organization":"test-org","username":"test-user-01","name":"Test User 01","password":"123123","confirm":"123123","agreement":true,"captchaType":"Cloudflare Turnstile","captchaToken":"XXXX.DUMMY.TOKEN.XXXX","clientSecret":"***"}'
```

**Expected response** (valid CAPTCHA token, signup succeeds):
```json
{
  "status": "ok",
  "msg": "",
  "data": "test-org/test-user-01",
  ...
}
```

### Test 3: Frontend shows CAPTCHA modal on signup

1. Navigate to `http://localhost:7001/signup/test-app`
2. Fill in Username, Display name, Password, Confirm, check Agreement
3. Click **Sign Up**
4. A CAPTCHA modal appears with the Cloudflare Turnstile widget

<!-- Screenshot: signup form filled -->
<img width="2559" height="1261" alt="Signup form filled" src="https://github.com/user-attachments/assets/28ed6be6-08d2-4fe2-8af0-4d34e5c1d041" />

<!-- Screenshot: CAPTCHA modal -->
<img width="604" height="691" alt="CAPTCHA modal on signup" src="https://github.com/user-attachments/assets/fc39e344-68ff-42bf-9d65-ece9607f8007" />

### Other checks

- `go build ./...` — passes
- `yarn build` (craco) — passes
- ESLint via husky pre-commit — passes
- Login page CAPTCHA flow — unaffected, works as before

## Compatibility

No breaking changes. Without a CAPTCHA provider configured, behavior is identical to before.
