### PR TITLE
fix: normalize response in `GetEmailAndPhone` to prevent user enumeration

### DIFF
--- a/controllers/user.go
+++ b/controllers/user.go
@@ -468,33 +468,39 @@ func (c *ApiController) GetEmailAndPhone() {
 		return
 	}
 
+	type EmailAndPhoneResp struct {
+		Name  string `json:"name"`
+		Email string `json:"email"`
+		Phone string `json:"phone"`
+	}
+
 	user, err := object.GetUserByFields(organization, username)
 	if err != nil {
-		c.ResponseError(err.Error())
+		c.ResponseOk(&EmailAndPhoneResp{Name: username})
 		return
 	}
 
 	if user == nil {
-		c.ResponseError(fmt.Sprintf(c.T("general:The user: %s doesn't exist"), util.GetId(organization, username)))
+		c.ResponseOk(&EmailAndPhoneResp{Name: username})
 		return
 	}
 
-	respUser := object.User{Name: user.Name}
+	resp := &EmailAndPhoneResp{Name: user.Name}
 	var contentType string
 	switch username {
 	case user.Email:
 		contentType = "email"
-		respUser.Email = user.Email
+		resp.Email = user.Email
 	case user.Phone:
 		contentType = "phone"
-		respUser.Phone = user.Phone
+		resp.Phone = user.Phone
 	case user.Name:
 		contentType = "username"
-		respUser.Email = util.GetMaskedEmail(user.Email)
-		respUser.Phone = util.GetMaskedPhone(user.Phone)
+		resp.Email = util.GetMaskedEmail(user.Email)
+		resp.Phone = util.GetMaskedPhone(user.Phone)
 	}
 
-	c.ResponseOk(respUser, contentType)
+	c.ResponseOk(resp, contentType)
 }
 
 // SetPassword


### PR DESCRIPTION
**Previous PR:** [#5464](https://github.com/casdoor/casdoor/pull/5464) (closed — maintainer suggested `enableErrorMask`, see rebuttal below)

## Summary

`GET /api/get-email-and-phone` is a public endpoint used by the forgot-password flow. It currently leaks whether a username exists via two independent side channels:

1. **Response size** — valid user: ~3,900 bytes (full `object.User` struct with 150+ zero-value JSON fields), invalid user: ~155 bytes (short error string). An attacker can enumerate usernames by comparing `Content-Length` alone.
2. **Response status** — valid user: `"status": "ok"`, invalid user: `"status": "error"` with message `"The user X doesn't exist"`.

**CWE-203** (Observable Discrepancy) / **OWASP OTG-IDENT-004** (Account Enumeration)

### Why `enableErrorMask` does not fix this

In [#5464](https://github.com/casdoor/casdoor/pull/5464), the maintainer suggested setting `enableErrorMask = true` in `app.conf`. This only changes the error **message text** (from `"The user X doesn't exist"` to a generic string). It does **not** change:

- The response **structure** — valid users still return the full `object.User` struct (~3,900 bytes), invalid users still return a short error (~155 bytes)
- The response **status field** — valid users get `"status": "ok"`, invalid users get `"status": "error"`

An attacker ignores the message text entirely and checks response size or status field. `enableErrorMask` is ineffective against this vector.

`enableErrorMask2` would block the endpoint entirely, but that breaks the forgot-password flow for all users.

## Changes

### `controllers/user.go` — `GetEmailAndPhone()`

- **Minimal response struct** — replaced `object.User{Name: ...}` (150+ zero-value JSON fields) with a 3-field struct: `name`, `email`, `phone`
- **Uniform response for missing users** — changed from `ResponseError("The user X doesn't exist")` to `ResponseOk(&EmailAndPhoneResp{Name: username})` with empty email/phone

Both valid and invalid usernames now return `status: "ok"` with the same struct shape and similar byte size.

### Frontend impact

None. `ForgetPage.js` reads only `res.data.name`, `res.data.email`, `res.data.phone`, and `res.data2` — all present in the new response. For missing users, the existing `!phone && !email` guard shows "No verification method" — a generic message that does not confirm whether the account exists.

## Verification

- `go build ./...` — passes
- ForgetPage reads no other fields from the response
- Forgot-password flow works correctly for existing users (masked phone/email displayed)
