### PR TITLE
feat: add missing `@Param` annotations to undocumented handlers

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -610,6 +610,7 @@ func (c *ApiController) SsoLogout() {
 // @Title GetAccount
 // @Tag Account API
 // @Description get the details of the current account
+// @Param   managedAccounts query string false "Whether to include managed accounts"
 // @Success 200 {object} controllers.Response The Response object
 // @router /get-account [get]
 func (c *ApiController) GetAccount() {
@@ -739,6 +740,9 @@ func (c *ApiController) GetUserinfo2() {
 // GetCaptcha ...
 // @Tag Login API
 // @Title GetCaptcha
+// @Description Get captcha provider information for an application
+// @Param   applicationId     query string true  "The application id (owner/name)"
+// @Param   isCurrentProvider query string false "Whether to get the current provider"
 // @router /get-captcha [get]
 // @Success 200 {object} object.Userinfo The Response object
 func (c *ApiController) GetCaptcha() {

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -1305,6 +1305,10 @@ func (c *ApiController) HandleSamlLogin() {
 // HandleOfficialAccountEvent ...
 // @Tag System API
 // @Title HandleOfficialAccountEvent
+// @Description Handle WeChat Official Account webhook event
+// @Param   signature query string false "WeChat signature"
+// @Param   timestamp query string false "WeChat timestamp"
+// @Param   nonce     query string false "WeChat nonce"
 // @router /webhook [POST]
 // @Success 200 {object} controllers.Response The Response object
 func (c *ApiController) HandleOfficialAccountEvent() {
@@ -1455,7 +1459,9 @@ func (c *ApiController) GetCaptchaStatus() {
 // Callback
 // @Title Callback
 // @Tag Callback API
-// @Description Get Login Error Counts
+// @Description Handle OAuth callback redirect
+// @Param   code  query string false "OAuth authorization code"
+// @Param   state query string false "OAuth state parameter"
 // @router /Callback [post]
 // @Success 200 {object} object.Userinfo The Response object
 func (c *ApiController) Callback() {
@@ -1470,6 +1476,8 @@ func (c *ApiController) Callback() {
 // @Title DeviceAuth
 // @Tag Device Authorization Endpoint
 // @Description Endpoint for the device authorization flow
+// @Param   client_id query string true  "The OAuth2 client ID"
+// @Param   scope     query string false "The requested scope"
 // @router /device-auth [post]
 // @Success 200 {object} object.DeviceAuthResponse The Response object
 func (c *ApiController) DeviceAuth() {
@@ -1564,6 +1572,8 @@ func (c *ApiController) DeviceAuth() {
 // @Title CancelDeviceAuth
 // @Tag Device Authorization Endpoint
 // @Description cancel a pending device authorization flow
+// @Param   userCode    query string true "The user code to cancel"
+// @Param   cancelToken query string true "The cancellation token"
 // @router /cancel-device-auth [post]
 func (c *ApiController) CancelDeviceAuth() {
 	userCode := c.Ctx.Input.Query("userCode")
@@ -1594,6 +1604,7 @@ func (c *ApiController) CancelDeviceAuth() {
 // @Title DeviceAuthComplete
 // @Tag Device Authorization Endpoint
 // @Description Complete device authorization by establishing a browser session after token issuance
+// @Param   deviceCode query string true "The device code to complete"
 // @router /device-auth-complete [post]
 func (c *ApiController) DeviceAuthComplete() {
 	deviceCode := c.Ctx.Input.Query("deviceCode")

--- a/controllers/casbin_cli_api.go
+++ b/controllers/casbin_cli_api.go
@@ -163,6 +163,8 @@ func processArgsToTempFiles(args []string) ([]string, []string, error) {
 // @Title RunCasbinCommand
 // @Tag Enforcer API
 // @Description Call Casbin CLI commands
+// @Param   language query string false "The CLI language (default: go)"
+// @Param   args     query string true  "The CLI command arguments"
 // @Success 200 {object} controllers.Response The Response object
 // @router /run-casbin-command [get]
 func (c *ApiController) RunCasbinCommand() {

--- a/controllers/get-dashboard.go
+++ b/controllers/get-dashboard.go
@@ -20,6 +20,7 @@ import "github.com/casdoor/casdoor/object"
 // @Title GetDashboard
 // @Tag System API
 // @Description get information of dashboard
+// @Param   owner query string true "The owner (organization) name"
 // @Success 200 {object} controllers.Response The Response object
 // @router /get-dashboard [get]
 func (c *ApiController) GetDashboard() {
@@ -38,6 +39,7 @@ func (c *ApiController) GetDashboard() {
 // @Title GetDashboardProviderDistribution
 // @Tag System API
 // @Description get provider type distribution for dashboard
+// @Param   owner query string true "The owner (organization) name"
 // @Success 200 {object} controllers.Response The Response object
 // @router /get-dashboard-providers [get]
 func (c *ApiController) GetDashboardProviderDistribution() {
@@ -56,6 +58,7 @@ func (c *ApiController) GetDashboardProviderDistribution() {
 // @Title GetDashboardMfaCoverage
 // @Tag System API
 // @Description get MFA adoption coverage stats for dashboard
+// @Param   owner query string true "The owner (organization) name"
 // @Success 200 {object} controllers.Response The Response object
 // @router /get-dashboard-mfa [get]
 func (c *ApiController) GetDashboardMfaCoverage() {
@@ -74,6 +77,7 @@ func (c *ApiController) GetDashboardMfaCoverage() {
 // @Title GetDashboardLoginHeatmap
 // @Tag System API
 // @Description get system activity heatmap data for dashboard
+// @Param   owner query string true "The owner (organization) name"
 // @Success 200 {object} controllers.Response The Response object
 // @router /get-dashboard-heatmap [get]
 func (c *ApiController) GetDashboardLoginHeatmap() {

--- a/controllers/link.go
+++ b/controllers/link.go
@@ -29,6 +29,8 @@ type LinkForm struct {
 // Unlink ...
 // @Tag Login API
 // @Title Unlink
+// @Description Unlink a third-party provider from user account
+// @Param   body body controllers.LinkForm true "Unlink request"
 // @router /unlink [post]
 // @Success 200 {object} object.Userinfo The Response object
 func (c *ApiController) Unlink() {

--- a/controllers/native_sso.go
+++ b/controllers/native_sso.go
@@ -27,6 +27,8 @@ import (
 // @Title NativeSsoComplete
 // @Tag Native SSO
 // @Description Complete OAuth authorization after Native SSO token exchange
+// @Param   clientId     query string true  "The OAuth2 client ID"
+// @Param   responseType query string false "The response type (default: login)"
 // @router /native-sso-complete [post]
 func (c *ApiController) NativeSsoComplete() {
 	var request struct {

--- a/controllers/prometheus.go
+++ b/controllers/prometheus.go
@@ -44,6 +44,8 @@ func (c *ApiController) GetPrometheusInfo() {
 // @Tag System API
 // @Description get Prometheus metrics. Accessible either by an admin session or by
 // a valid Key (created at /keys) supplied via ?accessKey=...&accessSecret=... query params.
+// @Param   accessKey    query string false "The access key for authentication"
+// @Param   accessSecret query string false "The access secret for authentication"
 // @Success 200 {string} Prometheus metrics in text format
 // @router /metrics [get]
 func (c *ApiController) GetMetrics() {

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -679,6 +679,8 @@ func (c *ApiController) SetPassword() {
 
 // CheckUserPassword
 // @Title CheckUserPassword
+// @Description Check if user password is correct
+// @Param   body body object.User true "User object with password to check"
 // @router /check-user-password [post]
 // @Tag User API
 // @Success 200 {object} object.Userinfo The Response object

--- a/controllers/verification.go
+++ b/controllers/verification.go
@@ -134,6 +134,16 @@ func (c *ApiController) GetVerification() {
 // SendVerificationCode ...
 // @Title SendVerificationCode
 // @Tag Verification API
+// @Description Send verification code to email or phone
+// @Param   dest          formData string true  "The destination email or phone number"
+// @Param   type          formData string true  "The verification type (email/phone)"
+// @Param   countryCode   formData string false "The country code for phone verification"
+// @Param   applicationId formData string true  "The application id (owner/name)"
+// @Param   method        formData string true  "The verification method (signup/login/forget/reset/mfaSetup/mfaAuth)"
+// @Param   checkUser     formData string false "The username to check"
+// @Param   captchaType   formData string true  "The captcha provider type"
+// @Param   clientSecret  formData string false "The captcha client secret"
+// @Param   captchaToken  formData string false "The captcha verification token"
 // @router /send-verification-code [post]
 // @Success 200 {object} object.Userinfo The Response object
 func (c *ApiController) SendVerificationCode() {
@@ -401,6 +411,11 @@ func (c *ApiController) SendVerificationCode() {
 // VerifyCaptcha ...
 // @Title VerifyCaptcha
 // @Tag Verification API
+// @Description Verify a captcha token
+// @Param   captchaType   formData string true "The captcha provider type"
+// @Param   captchaToken  formData string true "The captcha verification token"
+// @Param   clientSecret  formData string true "The captcha client secret"
+// @Param   applicationId formData string true "The application id (owner/name)"
 // @router /verify-captcha [post]
 // @Success 200 {object} object.Userinfo The Response object
 func (c *ApiController) VerifyCaptcha() {
@@ -444,6 +459,10 @@ func (c *ApiController) VerifyCaptcha() {
 // ResetEmailOrPhone ...
 // @Tag Account API
 // @Title ResetEmailOrPhone
+// @Description Reset user email or phone with verification code
+// @Param   type formData string true "The destination type (email/phone)"
+// @Param   dest formData string true "The new email or phone number"
+// @Param   code formData string true "The verification code"
 // @router /reset-email-or-phone [post]
 // @Success 200 {object} object.Userinfo The Response object
 func (c *ApiController) ResetEmailOrPhone() {
@@ -552,6 +571,8 @@ func (c *ApiController) ResetEmailOrPhone() {
 // VerifyCode
 // @Tag Verification API
 // @Title VerifyCode
+// @Description Verify a verification code
+// @Param   body body form.AuthForm true "Verification request"
 // @router /verify-code [post]
 // @Success 200 {object} object.Userinfo The Response object
 func (c *ApiController) VerifyCode() {


### PR DESCRIPTION
## Summary

Add `@Param` annotations to 20 handler functions that parse request parameters but have zero parameter documentation in Swagger.

These endpoints currently appear in the generated Swagger spec with no parameters — API clients, security testing tools, and SDK generators have no way to know what to send.

| Category | Count | Examples |
|----------|-------|---------|
| POST handlers parsing body/form | 12 | `SendVerificationCode`, `VerifyCaptcha`, `VerifyCode`, `Unlink` |
| GET handlers reading query params | 8 | `GetCaptcha`, `GetDashboard`, `GetMetrics` |

## Changes

Only comment additions. Zero behavioral changes. Zero code changes.

### `controllers/verification.go`
- `SendVerificationCode`: added 9 `@Param formData` annotations matching `VerificationForm` struct fields parsed via `c.ParseForm()`
- `VerifyCaptcha`: added 4 `@Param formData` annotations for the fields checked by `CheckParameter(VerifyCaptcha, ...)`
- `ResetEmailOrPhone`: added 3 `@Param formData` annotations matching `c.Ctx.Request.Form.Get()` calls
- `VerifyCode`: added 1 `@Param body` annotation for `form.AuthForm` JSON body via `json.Unmarshal`

### `controllers/auth.go`
- `HandleOfficialAccountEvent`: added 3 `@Param query` for WeChat webhook params (`signature`, `timestamp`, `nonce`)
- `Callback`: added 2 `@Param query` for OAuth `code`/`state`, fixed `@Description` from "Get Login Error Counts" to "Handle OAuth callback redirect"
- `DeviceAuth`: added 2 `@Param query` for `client_id`/`scope`
- `CancelDeviceAuth`: added 2 `@Param query` for `userCode`/`cancelToken`
- `DeviceAuthComplete`: added 1 `@Param query` for `deviceCode`

### `controllers/link.go`
- `Unlink`: added 1 `@Param body` for `controllers.LinkForm` JSON body

### `controllers/user.go`
- `CheckUserPassword`: added 1 `@Param body` for `object.User` JSON body

### `controllers/native_sso.go`
- `NativeSsoComplete`: added 2 `@Param query` for `clientId` and `responseType` (JSON body contains `accessToken` but is an anonymous struct — not representable as a Swagger schema reference)

### `controllers/account.go`
- `GetCaptcha`: added 2 `@Param query` for `applicationId`/`isCurrentProvider`
- `GetAccount`: added 1 `@Param query` for `managedAccounts`

### `controllers/get-dashboard.go`
- `GetDashboard`, `GetDashboardProviderDistribution`, `GetDashboardMfaCoverage`, `GetDashboardLoginHeatmap`: added `@Param owner query` to each

### `controllers/prometheus.go`
- `GetMetrics`: added 2 `@Param query` for `accessKey`/`accessSecret`

### `controllers/casbin_cli_api.go`
- `RunCasbinCommand`: added 2 `@Param query` for `language`/`args`

## Verification

- `go build ./...` passes
- `bee generate docs` produces correct swagger output — all 20 endpoints now show their parameters (were 0 params before)
- Every `@Param` location matches the handler's actual parsing method (`formData` for `ParseForm`/`Form.Get`, `query` for `Input.Query`, `body` for `json.Unmarshal`)
- No behavioral changes — only comment additions
