### PR TITLE
fix: show user group membership from group side

### DIFF
--- a/object/group.go
+++ b/object/group.go
@@ -315,9 +315,12 @@ func GetGroupUserCount(groupId string, field, value string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	names, err := userEnforcer.GetUserNamesByGroupName(groupId)
+	names, err := getGroupUserNames(groupId)
 	if err != nil {
 		return 0, err
+	}
+	if len(names) == 0 {
+		return 0, nil
 	}
 
 	if field == "" && value == "" {
@@ -339,9 +342,12 @@ func GetPaginationGroupUsers(groupId string, offset, limit int, field, value, so
 	if err != nil {
 		return nil, err
 	}
-	names, err := userEnforcer.GetUserNamesByGroupName(groupId)
+	names, err := getGroupUserNames(groupId)
 	if err != nil {
 		return nil, err
+	}
+	if len(names) == 0 {
+		return users, nil
 	}
 
 	tableNamePrefix := conf.GetConfigString("tableNamePrefix")
@@ -383,9 +389,12 @@ func GetGroupUsers(groupId string) ([]*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	names, err := userEnforcer.GetUserNamesByGroupName(groupId)
+	names, err := getGroupUserNames(groupId)
 	if err != nil {
 		return nil, err
+	}
+	if len(names) == 0 {
+		return users, nil
 	}
 	err = ormer.Engine.Where("owner = ?", owner).In("name", names).Find(&users)
 	if err != nil {
@@ -405,8 +414,7 @@ func ExtendGroupWithUsers(group *Group) error {
 	}
 
 	groupId := group.GetId()
-	userIds := []string{}
-	userIds, err := userEnforcer.GetAllUsersByGroup(groupId)
+	userIds, err := getGroupUserIds(groupId)
 	if err != nil {
 		return err
 	}
@@ -417,7 +425,7 @@ func ExtendGroupWithUsers(group *Group) error {
 
 func ExtendGroupsWithUsers(groups []*Group) error {
 	for _, group := range groups {
-		users, err := userEnforcer.GetAllUsersByGroup(group.GetId())
+		users, err := getGroupUserIds(group.GetId())
 		if err != nil {
 			return err
 		}
@@ -425,6 +433,68 @@ func ExtendGroupsWithUsers(groups []*Group) error {
 		group.Users = users
 	}
 	return nil
+}
+
+func getGroupUserNames(groupId string) ([]string, error) {
+	userIds, err := getGroupUserIds(groupId)
+	if err != nil {
+		return nil, err
+	}
+
+	owner, _, err := util.GetOwnerAndNameFromIdWithError(groupId)
+	if err != nil {
+		return nil, err
+	}
+
+	names := []string{}
+	for _, userId := range userIds {
+		userOwner, name := util.GetOwnerAndNameFromIdNoCheck(userId)
+		if userOwner == owner {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+func getGroupUserIds(groupId string) ([]string, error) {
+	owner, _, err := util.GetOwnerAndNameFromIdWithError(groupId)
+	if err != nil {
+		return nil, err
+	}
+
+	userIdMap := map[string]bool{}
+	userIds := []string{}
+	addUserId := func(userId string) {
+		if userId == "" || userIdMap[userId] {
+			return
+		}
+		userIdMap[userId] = true
+		userIds = append(userIds, userId)
+	}
+
+	enforcerUserIds, err := userEnforcer.GetAllUsersByGroup(groupId)
+	if err != nil {
+		return nil, err
+	}
+	for _, userId := range enforcerUserIds {
+		addUserId(userId)
+	}
+
+	users := []*User{}
+	err = ormer.Engine.Cols("owner", "name", "groups").
+		Where("owner = ?", owner).
+		And(builder.Like{"`groups`", groupId}).
+		Find(&users)
+	if err != nil {
+		return nil, err
+	}
+	for _, user := range users {
+		if util.InSlice(user.Groups, groupId) {
+			addUserId(user.GetId())
+		}
+	}
+
+	return userIds, nil
 }
 
 func GroupChangeTrigger(oldName, newName string) error {

--- a/object/group_test.go
+++ b/object/group_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/casbin/casbin/v2"
+	"github.com/casbin/casbin/v2/model"
+	xormadapter "github.com/casdoor/xorm-adapter/v3"
+)
+
+func initGroupUserTestStore(t *testing.T) {
+	t.Helper()
+
+	oldOrmer := ormer
+	oldUserEnforcer := userEnforcer
+
+	testOrmer, err := NewAdapter("sqlite3", filepath.Join(t.TempDir(), "casdoor-test.db"), "")
+	if err != nil {
+		t.Fatalf("NewAdapter() error = %v", err)
+	}
+	ormer = testOrmer
+	t.Cleanup(func() {
+		runtime.SetFinalizer(testOrmer, nil)
+		ormer.close()
+		ormer = oldOrmer
+		userEnforcer = oldUserEnforcer
+	})
+
+	if err = ormer.Engine.Sync2(new(User), new(Group)); err != nil {
+		t.Fatalf("Sync2() error = %v", err)
+	}
+
+	m, err := model.NewModelFromString(`
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
+`)
+	if err != nil {
+		t.Fatalf("NewModelFromString() error = %v", err)
+	}
+
+	adapter, err := xormadapter.NewAdapterByEngineWithTableName(ormer.Engine, "casbin_user_rule", "")
+	if err != nil {
+		t.Fatalf("NewAdapterByEngineWithTableName() error = %v", err)
+	}
+	enforcer, err := casbin.NewEnforcer(m, adapter)
+	if err != nil {
+		t.Fatalf("NewEnforcer() error = %v", err)
+	}
+	userEnforcer = NewUserGroupEnforcer(enforcer)
+}
+
+func TestGetGroupUsersIncludesUsersAssignedByUserGroups(t *testing.T) {
+	initGroupUserTestStore(t)
+
+	groupId := "test/group1"
+	user := &User{
+		Owner:  "test",
+		Name:   "alice",
+		Groups: []string{groupId},
+	}
+	group := &Group{
+		Owner:       "test",
+		Name:        "group1",
+		DisplayName: "Group 1",
+	}
+
+	if _, err := ormer.Engine.Insert(group, user); err != nil {
+		t.Fatalf("Insert() error = %v", err)
+	}
+
+	users, err := GetGroupUsers(groupId)
+	if err != nil {
+		t.Fatalf("GetGroupUsers() error = %v", err)
+	}
+
+	if len(users) != 1 || users[0].GetId() != user.GetId() {
+		t.Fatalf("GetGroupUsers(%q) = %#v, want user %q from User.Groups", groupId, users, user.GetId())
+	}
+}
+
+func TestExtendGroupWithUsersIncludesUsersAssignedByUserGroups(t *testing.T) {
+	initGroupUserTestStore(t)
+
+	group := &Group{
+		Owner:       "test",
+		Name:        "group1",
+		DisplayName: "Group 1",
+	}
+	user := &User{
+		Owner:  "test",
+		Name:   "alice",
+		Groups: []string{group.GetId()},
+	}
+
+	if _, err := ormer.Engine.Insert(group, user); err != nil {
+		t.Fatalf("Insert() error = %v", err)
+	}
+
+	if err := ExtendGroupWithUsers(group); err != nil {
+		t.Fatalf("ExtendGroupWithUsers() error = %v", err)
+	}
+
+	if len(group.Users) != 1 || group.Users[0] != user.GetId() {
+		t.Fatalf("ExtendGroupWithUsers() set group.Users = %#v, want [%q]", group.Users, user.GetId())
+	}
+}


### PR DESCRIPTION
## What

Fixes #5467.

This PR makes the user-group relationship visible from the Group side even when the relationship exists in `User.Groups` but is missing from the Casbin user-group policy table.

## How to Reproduce

1. Assign a user to a group from the User edit page.
2. Open the same user page.
3. Confirm the assigned group is displayed correctly in the user's Groups field.
4. Open the corresponding Group page or Group list.
5. The assigned user may not be displayed under that group.

This makes the relationship appear one-way in the UI:

- User -> Groups works
- Group -> Users does not always work

## Root Cause

The User page reads group membership from the `User.Groups` field.

The Group page reads users through the Casbin user-group enforcer. If `User.Groups` and the Casbin policy table are out of sync, the Group page cannot find users that are still visible from the User page.

## Solution

Group-side membership lookup now merges both relationship sources:

- users returned by the Casbin user-group enforcer
- users whose `User.Groups` field contains the target group

The merged result is de-duplicated and used by:

- `GetGroupUsers()`
- `GetGroupUserCount()`
- `GetPaginationGroupUsers()`
- `ExtendGroupWithUsers()`
- `ExtendGroupsWithUsers()`

## Tests

Added regression tests covering users assigned through `User.Groups` without a corresponding Casbin policy.

```bash
go test ./object -run "Test(GetGroupUsersIncludesUsersAssignedByUserGroups|ExtendGroupWithUsersIncludesUsersAssignedByUserGroups)" -count=1