### PR TITLE
fix: specify department_id_type for Lark syncer department APIs

### DIFF
--- a/object/syncer_lark.go
+++ b/object/syncer_lark.go
@@ -117,7 +117,7 @@ type LarkDeptListResp struct {
 	Msg  string `json:"msg"`
 	Data struct {
 		Items []struct {
-			DepartmentId string `json:"department_id"`
+			OpenDepartmentId string `json:"open_department_id"`
 		} `json:"items"`
 		HasMore   bool   `json:"has_more"`
 		PageToken string `json:"page_token"`
@@ -175,10 +175,10 @@ func (p *LarkSyncerProvider) getLarkAccessToken() (string, error) {
 	return tokenResp.TenantAccessToken, nil
 }
 
-// getLarkDepartments gets all department IDs from Lark API
+// getLarkDepartments gets all open department IDs from Lark API
 func (p *LarkSyncerProvider) getLarkDepartments(accessToken string) ([]string, error) {
 	domain := p.getLarkDomain()
-	allDeptIds := []string{"0"} // Start with root department
+	allOpenDeptIds := []string{"0"} // Start with root department
 	pageToken := ""
 
 	for {
@@ -204,7 +204,7 @@ func (p *LarkSyncerProvider) getLarkDepartments(accessToken string) ([]string, e
 		}
 
 		for _, dept := range deptResp.Data.Items {
-			allDeptIds = append(allDeptIds, dept.DepartmentId)
+			allOpenDeptIds = append(allOpenDeptIds, dept.OpenDepartmentId)
 		}
 
 		if !deptResp.Data.HasMore {
@@ -213,7 +213,7 @@ func (p *LarkSyncerProvider) getLarkDepartments(accessToken string) ([]string, e
 		pageToken = deptResp.Data.PageToken
 	}
 
-	return allDeptIds, nil
+	return allOpenDeptIds, nil
 }
 
 // getLarkUsersFromDept gets users from a specific department


### PR DESCRIPTION
  Closes #5496.
  Alternative to #5498.

  Lark international APIs use `open_department_id` for department IDs by default.
  The Lark syncer was parsing `department_id` from the department list response,
  which can cause mismatches when those department IDs are later used in
  `find_by_department` requests.

  PR #5498 fixes the issue by explicitly setting `department_id_type=department_id`
  for the Lark department APIs. This PR fixes the same issue from the response side:
  it keeps the existing requests unchanged and updates the syncer to read
  `open_department_id` from the department list response instead.

  This approach is preferable because it aligns the syncer with Lark's default API
  behavior and keeps the fix smaller and more consistent with the current implementation.