### PR TITLE
feat: make CORS `Access-Control-Allow-Headers` configurable

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -18,6 +18,7 @@ logPostOnly = true
 isUsernameLowered = false
 origin =
 originFrontend =
+corsAllowHeaders =
 staticBaseUrl = "https://cdn.casbin.org"
 isDemoMode = false
 batchSize = 100

--- a/routers/cors_filter.go
+++ b/routers/cors_filter.go
@@ -29,12 +29,28 @@ const (
 	headerAllowMethods     = "Access-Control-Allow-Methods"
 	headerAllowHeaders     = "Access-Control-Allow-Headers"
 	headerAllowCredentials = "Access-Control-Allow-Credentials"
+
+	defaultCorsAllowHeaders = "Content-Type, Authorization"
 )
+
+// getCorsAllowHeaders returns the value to advertise in the
+// Access-Control-Allow-Headers response header. The list is read from the
+// optional "corsAllowHeaders" key in app.conf so deployments can permit
+// additional non-safelisted headers (e.g. X-Requested-With sent by Swagger
+// UI, X-CSRF-Token, X-Trace-Id) without forking. Empty / missing config
+// preserves the historical default.
+func getCorsAllowHeaders() string {
+	configured := conf.GetConfigString("corsAllowHeaders")
+	if configured == "" {
+		return defaultCorsAllowHeaders
+	}
+	return configured
+}
 
 func setCorsHeaders(ctx *context.Context, origin string) {
 	ctx.Output.Header(headerAllowOrigin, origin)
 	ctx.Output.Header(headerAllowMethods, "POST, GET, OPTIONS, DELETE")
-	ctx.Output.Header(headerAllowHeaders, "Content-Type, Authorization")
+	ctx.Output.Header(headerAllowHeaders, getCorsAllowHeaders())
 	ctx.Output.Header(headerAllowCredentials, "true")
 
 	if ctx.Input.Method() == "OPTIONS" {


### PR DESCRIPTION
## What

Adds an optional `corsAllowHeaders` key to `app.conf`. When set, its value replaces the previously hardcoded `Content-Type, Authorization` advertised in `Access-Control-Allow-Headers`. When unset, the original default is preserved — existing deployments behave identically.

## Why

Several common HTTP clients add headers that browsers treat as non-CORS-safelisted, triggering preflight `OPTIONS` requests. Casdoor's response currently lists only `Content-Type, Authorization`, so the browser rejects the actual request. Today operators have to either fork or wrap Casdoor behind a reverse proxy that rewrites the headers.

Concrete cases reported:

- **Swagger UI (FastAPI / Spring Boot)** adds `X-Requested-With: XMLHttpRequest` to every fetch. The OIDC `authorization_code` token POST fails with:
  ```
  Access to fetch at 'http://localhost:8001/api/login/oauth/access_token'
  has been blocked by CORS policy: Request header field x-requested-with
  is not allowed by Access-Control-Allow-Headers in preflight response.
  ```
  Full repro and context in #5508.
- **CSRF-protected frontends** want to forward `X-CSRF-Token`.
- **Observability stacks** want `X-Trace-Id` / `X-Request-Id` echoed through.
- **#3691** documents a community nginx workaround that adds a much wider header set.

## How

`routers/cors_filter.go` gets a tiny helper that reads `corsAllowHeaders` from config and falls back to the historical default:

```go
const defaultCorsAllowHeaders = \"Content-Type, Authorization\"

func getCorsAllowHeaders() string {
    configured := conf.GetConfigString(\"corsAllowHeaders\")
    if configured == \"\" {
        return defaultCorsAllowHeaders
    }
    return configured
}
```

`setCorsHeaders` calls it instead of using the literal. `conf/app.conf` gets an empty `corsAllowHeaders =` placeholder so operators discover the option.

## Backward compatibility

Drop-in. Without `corsAllowHeaders` in `app.conf`, Casdoor emits exactly the same `Access-Control-Allow-Headers` value as before this change.

## Example usage

Operators wanting to allow Swagger UI's OIDC flow plus CSRF tokens add:

\`\`\`ini
corsAllowHeaders = \"Content-Type, Authorization, X-Requested-With, X-CSRF-Token\"
\`\`\`

## Notes

- No new dependencies.
- Same pattern could later expose `corsAllowMethods` and `corsAllowCredentials`; happy to follow up in a separate PR if maintainers want those too.
- No new tests — \`routers/\` package currently ships without unit tests; adding test harness for one helper felt out of scope. Manual verification: \`go build ./routers/...\` and \`go vet ./routers/...\` pass.

Closes #5508