### PR TITLE
fix: send backchannel logout before expiring tokens in sso-logout

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -544,6 +544,10 @@ func (c *ApiController) SsoLogout() {
 		return
 	}
 
+	// Send OIDC Back-Channel Logout notifications BEFORE expiring tokens,
+	// because SendBackchannelLogout calls GetActiveTokensByUser (expires_in > 0).
+	object.SendBackchannelLogout(owner, username, currentSessionId, c.Ctx.Request.Host)
+
 	if logoutAllSessions {
 		// Logout from all sessions: expire all tokens and delete all sessions
 		_, err = object.ExpireTokenByUser(owner, username)
@@ -595,9 +599,6 @@ func (c *ApiController) SsoLogout() {
 			return
 		}
 	}
-
-	// Send OIDC Back-Channel Logout notifications (https://openid.net/specs/openid-connect-backchannel-1_0.html)
-	object.SendBackchannelLogout(owner, username, currentSessionId, c.Ctx.Request.Host)
 
 	// Propagate logout to external Custom OAuth2 providers
 	object.InvokeCustomProviderLogout(ssoApplication, ssoSessionToken)


### PR DESCRIPTION
SendBackchannelLogout internally calls GetActiveTokensByUser which filters by expires_in > 0. When called after ExpireTokenByUser, all tokens already have expires_in=0, so the backchannel notification silently does nothing.

Move the call before ExpireTokenByUser so that active tokens are still discoverable when building the logout notification list.