### PR TITLE
feat: implement groups in permissions

### DIFF
--- a/object/check.go
+++ b/object/check.go
@@ -491,9 +491,10 @@ func CheckApiPermission(userId string, organization string, path string, method 
 		}
 
 		userHit := permission.isUserHit(userId)
+		groupHit := permission.isGroupHit(userId)
 		roleHit := permission.isRoleHit(userId)
 
-		if !userHit && !roleHit {
+		if !userHit && !groupHit && !roleHit {
 			if permission.Effect == "Allow" {
 				allowPermissionCount += 1
 			} else {
@@ -510,6 +511,22 @@ func CheckApiPermission(userId string, organization string, path string, method 
 		var isAllowed bool
 
 		if userHit {
+			isAllowed, err = enforcer.Enforce(userId, path, method)
+			if err != nil {
+				return false, err
+			}
+
+			if isAllowed {
+				if permission.Effect == "Allow" {
+					allowCount += 1
+				}
+			} else {
+				if permission.Effect == "Deny" {
+					denyCount += 1
+				}
+			}
+		}
+		if groupHit {
 			isAllowed, err = enforcer.Enforce(userId, path, method)
 			if err != nil {
 				return false, err
@@ -607,9 +624,10 @@ func CheckLoginPermission(userId string, application *Application) (bool, error)
 		}
 
 		userHit := permission.isUserHit(userId)
+		groupHit := permission.isGroupHit(userId)
 		roleHit := permission.isRoleHit(userId)
 
-		if !userHit && !roleHit {
+		if !userHit && !groupHit && !roleHit {
 			if permission.Effect == "Allow" {
 				allowPermissionCount += 1
 			} else {
@@ -626,6 +644,22 @@ func CheckLoginPermission(userId string, application *Application) (bool, error)
 		var isAllowed bool
 
 		if userHit {
+			isAllowed, err = enforcer.Enforce(userId, application.Name, "Read")
+			if err != nil {
+				return false, err
+			}
+
+			if isAllowed {
+				if permission.Effect == "Allow" {
+					allowCount += 1
+				}
+			} else {
+				if permission.Effect == "Deny" {
+					denyCount += 1
+				}
+			}
+		}
+		if groupHit {
 			isAllowed, err = enforcer.Enforce(userId, application.Name, "Read")
 			if err != nil {
 				return false, err

--- a/object/permission.go
+++ b/object/permission.go
@@ -306,6 +306,23 @@ func getPermissionsByUser(userId string) ([]*Permission, error) {
 	return res, nil
 }
 
+func getPermissionsByGroup(groupId string) ([]*Permission, error) {
+	permissions := []*Permission{}
+	err := ormer.Engine.Where("groups like ?", "%"+groupId+"\"%").Find(&permissions)
+	if err != nil {
+		return permissions, err
+	}
+
+	res := []*Permission{}
+	for _, permission := range permissions {
+		if util.InSlice(permission.Groups, groupId) {
+			res = append(res, permission)
+		}
+	}
+
+	return res, nil
+}
+
 func GetPermissionsByRole(roleId string) ([]*Permission, error) {
 	permissions := []*Permission{}
 	err := ormer.Engine.Where("roles like ?", "%"+roleId+"\"%").Find(&permissions)
@@ -353,6 +370,31 @@ func getPermissionsAndRolesByUser(userId string) ([]*Permission, []*Role, error)
 
 		if _, ok := existedPerms[perm.Name]; !ok {
 			existedPerms[perm.Name] = struct{}{}
+		}
+	}
+
+	user, err := GetUser(userId)
+	if err != nil {
+		return nil, nil, err
+	}
+	if user != nil {
+		groupIds := append([]string{}, user.Groups...)
+		if len(user.Groups) > 0 {
+			groupIds = append(groupIds, "*", util.GetId(user.Owner, "*"))
+		}
+
+		for _, groupId := range groupIds {
+			perms, err := getPermissionsByGroup(groupId)
+			if err != nil {
+				return nil, nil, err
+			}
+			for _, perm := range perms {
+				perm.Users = nil
+				if _, ok := existedPerms[perm.Name]; !ok {
+					existedPerms[perm.Name] = struct{}{}
+					permissions = append(permissions, perm)
+				}
+			}
 		}
 	}
 
@@ -454,6 +496,24 @@ func (p *Permission) isUserHit(name string) bool {
 			continue
 		}
 		if userOrg == targetOrg && (userName == "*" || userName == targetName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Permission) isGroupHit(userId string) bool {
+	user, err := GetUser(userId)
+	if err != nil || user == nil {
+		return false
+	}
+
+	for _, group := range p.Groups {
+		if group == "*" || group == util.GetId(p.Owner, "*") {
+			return len(user.Groups) > 0
+		}
+
+		if util.InSlice(user.Groups, group) {
 			return true
 		}
 	}

--- a/object/permission_enforcer.go
+++ b/object/permission_enforcer.go
@@ -127,22 +127,39 @@ func getPolicies(permission *Permission) [][]string {
 	permissionId := permission.GetId()
 	domainExist := len(permission.Domains) > 0
 
-	usersAndRoles := append(permission.Users, permission.Roles...)
-	for _, userOrRole := range usersAndRoles {
+	subjects := make([]string, 0, len(permission.Users)+len(permission.Groups)+len(permission.Roles))
+	subjects = append(subjects, permission.Users...)
+	for _, group := range permission.Groups {
+		subjects = append(subjects, getPermissionGroupSubject(permission.Owner, group))
+	}
+	subjects = append(subjects, permission.Roles...)
+
+	for _, subject := range subjects {
 		for _, resource := range permission.Resources {
 			for _, action := range permission.Actions {
 				if domainExist {
 					for _, domain := range permission.Domains {
-						policies = append(policies, []string{userOrRole, domain, resource, action, strings.ToLower(permission.Effect), permissionId})
+						policies = append(policies, []string{subject, domain, resource, action, strings.ToLower(permission.Effect), permissionId})
 					}
 				} else {
-					policies = append(policies, []string{userOrRole, resource, action, strings.ToLower(permission.Effect), "", permissionId})
+					policies = append(policies, []string{subject, resource, action, strings.ToLower(permission.Effect), "", permissionId})
 				}
 			}
 		}
 	}
 
 	return policies
+}
+
+func getPermissionGroupId(permissionOwner string, groupId string) string {
+	if groupId == "*" {
+		return util.GetId(permissionOwner, "*")
+	}
+	return groupId
+}
+
+func getPermissionGroupSubject(permissionOwner string, groupId string) string {
+	return GetGroupWithPrefix(getPermissionGroupId(permissionOwner, groupId))
 }
 
 type permissionRoleResolver struct {
@@ -220,6 +237,81 @@ func (r *permissionRoleResolver) getRolesInRole(permissionOwner string, roleId s
 	return roles, nil
 }
 
+type permissionGroupResolver struct {
+	groupsByOwner map[string][]*Group
+	usersByGroup  map[string][]string
+}
+
+func newPermissionGroupResolver() *permissionGroupResolver {
+	return &permissionGroupResolver{
+		groupsByOwner: map[string][]*Group{},
+		usersByGroup:  map[string][]string{},
+	}
+}
+
+func (r *permissionGroupResolver) getGroups(owner string) ([]*Group, error) {
+	if groups, ok := r.groupsByOwner[owner]; ok {
+		return groups, nil
+	}
+
+	groups, err := GetGroups(owner)
+	if err != nil {
+		return nil, err
+	}
+
+	r.groupsByOwner[owner] = groups
+	return groups, nil
+}
+
+func (r *permissionGroupResolver) getUsersInGroup(permissionOwner string, groupId string) ([]string, error) {
+	groupId = getPermissionGroupId(permissionOwner, groupId)
+	if users, ok := r.usersByGroup[groupId]; ok {
+		return users, nil
+	}
+
+	groupOwner, groupName, err := util.GetOwnerAndNameFromIdWithError(groupId)
+	if err != nil {
+		return nil, err
+	}
+
+	if groupName == "*" {
+		groups, err := r.getGroups(groupOwner)
+		if err != nil {
+			return nil, err
+		}
+
+		usersByID := map[string]struct{}{}
+		for _, group := range groups {
+			groupUsers, err := r.getUsersInGroup(groupOwner, group.GetId())
+			if err != nil {
+				return nil, err
+			}
+			for _, user := range groupUsers {
+				usersByID[user] = struct{}{}
+			}
+		}
+
+		users := make([]string, 0, len(usersByID))
+		for user := range usersByID {
+			users = append(users, user)
+		}
+		r.usersByGroup[groupId] = users
+		return users, nil
+	}
+
+	if userEnforcer == nil {
+		return []string{}, nil
+	}
+
+	users, err := userEnforcer.GetAllUsersByGroup(groupId)
+	if err != nil {
+		return nil, err
+	}
+
+	r.usersByGroup[groupId] = users
+	return users, nil
+}
+
 func getPermissionEnforcerTargets(permission *Permission, permissionIDs ...string) ([]*Permission, error) {
 	if len(permissionIDs) == 0 {
 		return []*Permission{permission}, nil
@@ -266,9 +358,28 @@ func getRuntimeGroupingPolicies(permissions []*Permission) ([][]string, error) {
 	var groupingPolicies [][]string
 	visitedPolicies := map[string]struct{}{}
 	roleResolver := newPermissionRoleResolver()
+	groupResolver := newPermissionGroupResolver()
 
 	for _, permission := range permissions {
 		domainExist := len(permission.Domains) > 0
+		for _, groupId := range permission.Groups {
+			groupSubject := getPermissionGroupSubject(permission.Owner, groupId)
+			users, err := groupResolver.getUsersInGroup(permission.Owner, groupId)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, user := range users {
+				if domainExist {
+					for _, domain := range permission.Domains {
+						appendRuntimeGroupingPolicy(&groupingPolicies, visitedPolicies, newRuntimeGroupingPolicy(user, groupSubject, domain))
+					}
+				} else {
+					appendRuntimeGroupingPolicy(&groupingPolicies, visitedPolicies, newRuntimeGroupingPolicy(user, groupSubject, ""))
+				}
+			}
+		}
+
 		for _, roleId := range permission.Roles {
 			visited := map[string]struct{}{}
 			rolesInRole, err := roleResolver.getRolesInRole(permission.Owner, roleId, visited)
@@ -285,6 +396,31 @@ func getRuntimeGroupingPolicies(permissions []*Permission) ([][]string, error) {
 						}
 					} else {
 						appendRuntimeGroupingPolicy(&groupingPolicies, visitedPolicies, newRuntimeGroupingPolicy(subUser, currentRoleID, ""))
+					}
+				}
+
+				for _, subGroup := range role.Groups {
+					groupSubject := getPermissionGroupSubject(role.Owner, subGroup)
+					if domainExist {
+						for _, domain := range permission.Domains {
+							appendRuntimeGroupingPolicy(&groupingPolicies, visitedPolicies, newRuntimeGroupingPolicy(groupSubject, currentRoleID, domain))
+						}
+					} else {
+						appendRuntimeGroupingPolicy(&groupingPolicies, visitedPolicies, newRuntimeGroupingPolicy(groupSubject, currentRoleID, ""))
+					}
+
+					users, err := groupResolver.getUsersInGroup(role.Owner, subGroup)
+					if err != nil {
+						return nil, err
+					}
+					for _, user := range users {
+						if domainExist {
+							for _, domain := range permission.Domains {
+								appendRuntimeGroupingPolicy(&groupingPolicies, visitedPolicies, newRuntimeGroupingPolicy(user, groupSubject, domain))
+							}
+						} else {
+							appendRuntimeGroupingPolicy(&groupingPolicies, visitedPolicies, newRuntimeGroupingPolicy(user, groupSubject, ""))
+						}
 					}
 				}
 

--- a/object/permission_enforcer_test.go
+++ b/object/permission_enforcer_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetPoliciesIncludesGroups(t *testing.T) {
+	permission := &Permission{
+		Owner:     "org",
+		Name:      "perm",
+		Users:     []string{"org/alice"},
+		Groups:    []string{"org/dev"},
+		Roles:     []string{"org/admin"},
+		Resources: []string{"data1"},
+		Actions:   []string{"read"},
+		Effect:    "Allow",
+	}
+
+	got := getPolicies(permission)
+	want := [][]string{
+		{"org/alice", "data1", "read", "allow", "", "org/perm"},
+		{"group:org/dev", "data1", "read", "allow", "", "org/perm"},
+		{"org/admin", "data1", "read", "allow", "", "org/perm"},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("getPolicies() = %#v, want %#v", got, want)
+	}
+}
+
+func TestGetPoliciesIncludesGroupsWithDomains(t *testing.T) {
+	permission := &Permission{
+		Owner:     "org",
+		Name:      "perm",
+		Groups:    []string{"org/dev"},
+		Domains:   []string{"domain1"},
+		Resources: []string{"data1"},
+		Actions:   []string{"read"},
+		Effect:    "Deny",
+	}
+
+	got := getPolicies(permission)
+	want := [][]string{
+		{"group:org/dev", "domain1", "data1", "read", "deny", "org/perm"},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("getPolicies() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
This pull request adds comprehensive support for group-based permissions throughout the permission system. The changes ensure that permissions can be assigned to groups, checked against group membership, and enforced accordingly. Additionally, new tests verify that group-based permissions are correctly included in policy generation.

**Group-based permission support:**

* Added logic to check if a user is part of a group when evaluating permissions in both `CheckApiPermission` and `CheckLoginPermission`, and updated enforcement logic to handle group-based permissions. [[1]](diffhunk://#diff-8cd443ab0f47d0d05db201355fb82a567f9dce59f45203b2e386ab9a56d15a63R494-R497) [[2]](diffhunk://#diff-8cd443ab0f47d0d05db201355fb82a567f9dce59f45203b2e386ab9a56d15a63R529-R544) [[3]](diffhunk://#diff-8cd443ab0f47d0d05db201355fb82a567f9dce59f45203b2e386ab9a56d15a63R627-R630) [[4]](diffhunk://#diff-8cd443ab0f47d0d05db201355fb82a567f9dce59f45203b2e386ab9a56d15a63R662-R677)
* Implemented `isGroupHit` method for the `Permission` type to determine if a user belongs to a group relevant to a permission.
* Extended permission retrieval to include group-based permissions for users, and added `getPermissionsByGroup` for fetching permissions by group. [[1]](diffhunk://#diff-362ebe545d78185fe03fa15029e71219956e19b8d85e4790c91f098d9ac3284dR309-R325) [[2]](diffhunk://#diff-362ebe545d78185fe03fa15029e71219956e19b8d85e4790c91f098d9ac3284dR376-R400)

**Policy and enforcer enhancements:**

* Updated `getPolicies` to include group subjects, and added helpers for group subject formatting and ID resolution. [[1]](diffhunk://#diff-c349c7a43a617dd8e3534cdfcd7a338529521722f0b7a0f6fd1c59597f9bd049L130-R145) [[2]](diffhunk://#diff-c349c7a43a617dd8e3534cdfcd7a338529521722f0b7a0f6fd1c59597f9bd049R154-R164)
* Introduced `permissionGroupResolver` to efficiently resolve groups and users for permissions, and extended `getRuntimeGroupingPolicies` to generate grouping policies for groups and nested group-role relationships. [[1]](diffhunk://#diff-c349c7a43a617dd8e3534cdfcd7a338529521722f0b7a0f6fd1c59597f9bd049R240-R314) [[2]](diffhunk://#diff-c349c7a43a617dd8e3534cdfcd7a338529521722f0b7a0f6fd1c59597f9bd049R361-R382) [[3]](diffhunk://#diff-c349c7a43a617dd8e3534cdfcd7a338529521722f0b7a0f6fd1c59597f9bd049R402-R426)

**Testing:**

* Added tests to ensure that group-based permissions are correctly included in generated policies, both with and without domains.

fix #5524