### PR TITLE
feat: respect ?columns= query param in update-application

### DIFF
--- a/controllers/application.go
+++ b/controllers/application.go
@@ -17,6 +17,7 @@ package controllers
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/beego/beego/v2/core/utils/pagination"
 	"github.com/casdoor/casdoor/object"
@@ -224,6 +225,7 @@ func (c *ApiController) GetOrganizationApplications() {
 // @router /update-application [post]
 func (c *ApiController) UpdateApplication() {
 	id := c.Ctx.Input.Query("id")
+	columnsStr := c.Ctx.Input.Query("columns")
 
 	var application object.Application
 	err := json.Unmarshal(c.Ctx.Input.RequestBody, &application)
@@ -237,7 +239,14 @@ func (c *ApiController) UpdateApplication() {
 		return
 	}
 
-	c.Data["json"] = wrapActionResponse(object.UpdateApplication(id, &application, c.IsGlobalAdmin(), c.GetAcceptLanguage()))
+	columns := []string{}
+	if columnsStr != "" {
+		for _, col := range strings.Split(columnsStr, ",") {
+			columns = append(columns, util.CamelToSnakeCase(col))
+		}
+	}
+
+	c.Data["json"] = wrapActionResponse(object.UpdateApplication(id, &application, c.IsGlobalAdmin(), c.GetAcceptLanguage(), columns))
 	c.ServeJSON()
 }
 

--- a/controllers/resource.go
+++ b/controllers/resource.go
@@ -366,7 +366,7 @@ func (c *ApiController) UploadResource() {
 		}
 
 		applicationObj.TermsOfUse = fileUrl
-		_, err = object.UpdateApplication(applicationId, applicationObj, true, c.GetAcceptLanguage())
+		_, err = object.UpdateApplication(applicationId, applicationObj, true, c.GetAcceptLanguage(), nil)
 		if err != nil {
 			c.ResponseError(err.Error())
 			return

--- a/mcpself/application.go
+++ b/mcpself/application.go
@@ -84,7 +84,7 @@ func (c *McpController) handleUpdateApplicationTool(id interface{}, args UpdateA
 		return
 	}
 
-	affected, err := object.UpdateApplication(args.Id, &args.Application, c.IsGlobalAdmin(), c.GetAcceptLanguage())
+	affected, err := object.UpdateApplication(args.Id, &args.Application, c.IsGlobalAdmin(), c.GetAcceptLanguage(), nil)
 	if err != nil {
 		c.SendToolErrorResult(id, err.Error())
 		return

--- a/object/application.go
+++ b/object/application.go
@@ -389,7 +389,7 @@ func GetApplication(id string) (*Application, error) {
 	return getApplication(owner, name)
 }
 
-func UpdateApplication(id string, application *Application, isGlobalAdmin bool, lang string) (bool, error) {
+func UpdateApplication(id string, application *Application, isGlobalAdmin bool, lang string, columns []string) (bool, error) {
 	owner, name, err := util.GetOwnerAndNameFromIdWithError(id)
 	if err != nil {
 		return false, err
@@ -441,7 +441,12 @@ func UpdateApplication(id string, application *Application, isGlobalAdmin bool, 
 		providerItem.Provider = nil
 	}
 
-	session := ormer.Engine.ID(core.PK{owner, name}).Where("organization = ?", oldApplication.Organization).AllCols()
+	session := ormer.Engine.ID(core.PK{owner, name}).Where("organization = ?", oldApplication.Organization)
+	if len(columns) > 0 {
+		session = session.Cols(columns...)
+	} else {
+		session = session.AllCols()
+	}
 	if application.ClientSecret == "***" {
 		session.Omit("client_secret")
 	}


### PR DESCRIPTION
## Problem

`POST /api/update-application` uses `AllCols()` which writes **every** column regardless of which fields the request body contains. Fields absent from the request are silently set to their zero values (`""`, `null`, `[]`, `false`), destroying core OAuth fields like `client_id` and `redirect_uris`.

The API already documents a `columns` query parameter, but the controller never parses it.

**Reproduced on v3.73.0** — a minimal "flip one bool" update with `?columns=enableSigninSession` wipes `client_id`, `display_name`, `redirect_uris`, etc.

## Fix

- **Controller** (`controllers/application.go`): Parse the `columns` query parameter and convert to snake_case using `util.CamelToSnakeCase`, matching the existing `UpdateUser` pattern.
- **Object layer** (`object/application.go`): Accept `columns []string` parameter. When non-empty, use `.Cols(columns...)` for selective updates; otherwise preserve existing `AllCols()` behavior for backward compatibility.
- Update callers in `controllers/resource.go` and `mcpself/application.go` to pass `nil` (all columns, existing behavior).

## Verification

- `go build ./object/ ./controllers/ ./mcpself/` — all compile
- `go vet ./object/ ./controllers/ ./mcpself/` — passes
- Follows the exact same pattern as `UpdateUser` + `updateUser` in the same codebase

Fixes #5533