### PR TITLE
feat: add Android ARM64 to GoReleaser build targets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,6 +23,7 @@ builds:
       - linux
       - windows
       - darwin
+      - android
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
## Summary
- Add `android` to GoReleaser's `goos` list to build `android/arm64` binaries
- `CGO_ENABLED=0` is already set, so no NDK or CGo dependencies required

## Test plan
- [ ] Verify GoReleaser produces `casdoor_Android_arm64.tar.gz` in the release
- [ ] Test the binary runs on an Android ARM64 device