### PR TITLE
feat: self-host Inter font instead of Google Fonts CDN

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "@crowdin/cli": "^3.7.10",
     "@ctrl/tinycolor": "^3.5.0",
     "@emotion/react": "^11.10.5",
+    "@fontsource-variable/inter": "^5.2.8",
     "@metamask/eth-sig-util": "^6.0.0",
     "@uiw/codemirror-extensions-langs": "^4.23.8",
     "@uiw/codemirror-theme-material": "^4.23.8",

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,4 +1,8 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");
+/* Inter Variable font (self-hosted via @fontsource-variable/inter).
+   Replaces the previous Google Fonts CDN @import for GDPR compliance.
+   opsz + wght axes match the prior CDN URL — full variable font. */
+@import "@fontsource-variable/inter/opsz.css";
+@import "@fontsource-variable/inter/opsz-italic.css";
 
 /* AI-themed loading dots animation used by common/Loading.js */
 @keyframes casdoor-ai-bounce {
@@ -24,7 +28,7 @@ html::-webkit-scrollbar {
 body {
   margin: 0;
   font-family:
-    "Inter",
+    "Inter Variable",
     -apple-system,
     BlinkMacSystemFont,
     "Segoe UI",
@@ -270,5 +274,5 @@ a[href^="mailto:"]:active {
 .ant-message .ant-message-notice-content,
 .ant-message .ant-message-custom-content,
 .ant-message .ant-message-custom-content span {
-  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif !important;
+  font-family: "Inter Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif !important;
 }

--- a/web/src/shadcnTheme.js
+++ b/web/src/shadcnTheme.js
@@ -16,7 +16,7 @@
 // Adapted from the "shadcn" preset on https://ant.design/
 
 export const shadcnThemeToken = {
-  fontFamily: "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif",
+  fontFamily: "'Inter Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif",
   colorPrimary: "#262626",
   colorSuccess: "#22c55e",
   colorWarning: "#f97316",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3259,6 +3259,11 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@fontsource-variable/inter@^5.2.8":
+  version "5.2.8"
+  resolved "https://registry.yarnpkg.com/@fontsource-variable/inter/-/inter-5.2.8.tgz#29b11476f5149f6a443b4df6516e26002d87941a"
+  integrity sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==
+
 "@formatjs/ecma402-abstract@1.11.4":
   version "1.11.4"
   resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz#b962dfc4ae84361f9f08fbce411b4e4340930eda"


### PR DESCRIPTION
Closes #5547.

Replaces the hard-coded Google Fonts `@import` for the Inter family with a self-hosted `@fontsource-variable/inter` dependency, so the font ships from the same origin as the rest of the Casdoor frontend. Every login-page render previously triggered an outbound request to `fonts.googleapis.com` (CSS) and `fonts.gstatic.com` (woff2) — a documented GDPR/DSGVO issue in the EU (LG München I, 3 O 17493/20, January 2022) and the same fix Mastodon, Nextcloud, Forgejo, BookStack and others already shipped.

## Changes

- `web/package.json`: add `@fontsource-variable/inter ^5.2.8` (matches the previous CDN's `opsz, wght` variable axes)
- `web/src/index.css`: replace the `@import url("https://fonts.googleapis.com/...")` with two local imports (`opsz.css` + `opsz-italic.css`); rename the two `"Inter"` font-family references to `"Inter Variable"` (the family name exposed by `@fontsource-variable/inter`)
- `web/src/shadcnTheme.js`: same `"Inter"` → `"Inter Variable"` rename for the antd-shadcn preset
- `web/yarn.lock`: lockfile entry for the new dependency

Total diff: **+14 / -4** across 4 files.

## Verification

`yarn build` locally on the patched tree:

- ✅ No `fonts.googleapis.com` or `fonts.gstatic.com` references in any emitted CSS file
- ✅ 14 `inter-*.woff2` files copied to `build/static/media/` (Latin, Latin-Ext, Cyrillic, Cyrillic-Ext, Greek, Greek-Ext, Vietnamese × normal + italic) with standard `unicode-range` subsetting
- ✅ `main.<hash>.css` contains 14 `@font-face` blocks pointing at `/static/media/inter-*.woff2`
- ✅ `body { font-family: Inter Variable, ... }` resolves against those `@font-face` blocks

## Notes

- The font-family rename (`Inter` → `Inter Variable`) is required because `@fontsource-variable/inter` registers `@font-face` under the family name `Inter Variable`, not `Inter`. Three occurrences updated (two in `index.css`, one in `shadcnTheme.js`). All other CSS in Casdoor falls back to the `-apple-system, BlinkMacSystemFont, …` chain that was already part of every font-family declaration, so no visual regression is expected on systems lacking the bundled font for any reason.
- Bundle-size impact: ~720 KB of `inter-*.woff2` files in `static/media/` total across all unicode subsets. Per-page transfer is unchanged in practice — the browser still fetches only the unicode subsets it needs (typically 50-100 KB for Western users), same as the Google Fonts CDN behaviour. Trade-off is identical to other OSS projects that have made this switch.
- The `cdn.casbin.org/img/favicon.png` and `cdn.casbin.org/site/casdoor/manifest.json` references in `web/public/index.html` (also mentioned in #5547) are intentionally **not** in scope of this PR — they're separate URLs and warrant their own discussion (replace with bundled assets vs. admin-configurable). Happy to file a follow-up if you'd like.
