### PR TITLE
fix: skip non-existent and duplicate groups when syncing LDAP users

### DIFF
--- a/object/ldap_conn.go
+++ b/object/ldap_conn.go
@@ -472,6 +472,17 @@ func SyncLdapUsers(owner string, syncUsers []LdapUser, ldapId string) (existUser
 		existUuidSet[uuid] = struct{}{}
 	}
 
+	// Build a set of group names that actually exist in Casdoor for this
+	// organization. memberOf groups that have no matching Casdoor group
+	// (e.g. a CJK group like "项目部" that was not synced) are skipped, so the
+	// user won't end up referencing an empty/non-existent group.
+	existingGroupNameSet := make(map[string]struct{})
+	if casdoorGroups, gErr := GetGroups(owner); gErr == nil {
+		for _, g := range casdoorGroups {
+			existingGroupNameSet[g.Name] = struct{}{}
+		}
+	}
+
 	for _, syncUser := range syncUsers {
 		_, found := existUuidSet[syncUser.Uuid]
 		if found {
@@ -512,18 +523,40 @@ func SyncLdapUsers(owner string, syncUsers []LdapUser, ldapId string) (existUser
 
 			// Assign user to groups based on memberOf attribute
 			userGroups := []string{}
-			if len(ldap.DefaultGroups) > 0 {
-				userGroups = append(userGroups, ldap.DefaultGroups...)
-			} else if ldap.DefaultGroup != "" {
-				userGroups = append(userGroups, ldap.DefaultGroup)
+			seenGroups := make(map[string]struct{})
+			addGroup := func(groupId string) {
+				if groupId == "" {
+					return
+				}
+				if _, ok := seenGroups[groupId]; ok {
+					return
+				}
+				seenGroups[groupId] = struct{}{}
+				userGroups = append(userGroups, groupId)
 			}
 
-			// Extract group names from memberOf DNs
+			if len(ldap.DefaultGroups) > 0 {
+				for _, g := range ldap.DefaultGroups {
+					addGroup(g)
+				}
+			} else if ldap.DefaultGroup != "" {
+				addGroup(ldap.DefaultGroup)
+			}
+
+			// Extract group names from memberOf DNs. Only attach groups that
+			// actually exist in Casdoor, and store them as full "owner/name"
+			// IDs (consistent with DefaultGroups) to avoid empty group refs.
 			for _, memberDn := range syncUser.MemberOf {
 				groupName := dnToGroupName(owner, memberDn)
-				if groupName != "" {
-					userGroups = append(userGroups, groupName)
+				if groupName == "" {
+					continue
 				}
+				if _, ok := existingGroupNameSet[groupName]; !ok {
+					// Group not present in Casdoor (e.g. a CJK group that
+					// wasn't synced); skip to avoid creating an empty group.
+					continue
+				}
+				addGroup(fmt.Sprintf("%s/%s", owner, groupName))
 			}
 
 			if len(userGroups) > 0 {


### PR DESCRIPTION
## Background & Problem

When synchronizing users via LDAP, Casdoor reads the user's `memberOf` attribute and adds the user to the corresponding user groups. The original logic had the following problems:

1. **References to non-existent groups**
   The groups listed in `memberOf` do not necessarily exist in Casdoor. For example, when a group name is in Chinese (CJK), such as `项目部`, and that group has not yet been synced into Casdoor, the old logic would still write the group name directly into the user's `Groups` field. As a result, the user gets associated with an **empty / non-existent group**, which shows up as an anomaly in the frontend and during permission checks (you see a group that cannot be found, cannot be opened, and has no content).

2. **Inconsistent group ID format**
   `ldap.DefaultGroups` uses the full `owner/name` form, whereas the group name parsed from the `memberOf` DN (the return value of `dnToGroupName`) is just the bare group name `name`, without the `owner/` prefix. Mixing the two formats in the same `Groups` list leads to inconsistent group references that are hard to match.

3. **Possible duplicate groups**
   When `DefaultGroups` / `DefaultGroup` overlaps with the groups parsed from `memberOf`, or when `memberOf` itself contains duplicate DNs, the user's `Groups` list ends up with **duplicate entries**, with no deduplication.

---

## Steps to Reproduce

1. Configure an LDAP Provider and enable user synchronization.
2. In LDAP, have a user whose `memberOf` points to a group that **has not yet been synced / does not exist** in Casdoor (e.g. the Chinese group name `项目部`).
3. Trigger LDAP user synchronization.
4. **Expected**: The user is only associated with groups that actually exist in Casdoor.
5. **Actual (before fix)**: The user is associated with a non-existent / empty group, the group reference format is inconsistent, and duplicate groups may appear.

---

## Changes

File: `object/ldap_conn.go`, function: `SyncLdapUsers`

### 1. Pre-build a set of group names that actually exist in the organization

Before the synchronization loop begins, query all Casdoor groups of the current organization once and build them into a set, used later for O(1) checks of whether a given group really exists:

```go
// Build a set of group names that actually exist in Casdoor for this
// organization. memberOf groups that have no matching Casdoor group
// (e.g. a CJK group like "项目部" that was not synced) are skipped, so the
// user won't end up referencing an empty/non-existent group.
existingGroupNameSet := make(map[string]struct{})
if casdoorGroups, gErr := GetGroups(owner); gErr == nil {
    for _, g := range casdoorGroups {
        existingGroupNameSet[g.Name] = struct{}{}
    }
}
```

### 2. Introduce an `addGroup` helper closure with deduplication

Unify all group-adding entry points to automatically ignore empty strings and deduplicate:

```go
userGroups := []string{}
seenGroups := make(map[string]struct{})
addGroup := func(groupId string) {
    if groupId == "" {
        return
    }
    if _, ok := seenGroups[groupId]; ok {
        return
    }
    seenGroups[groupId] = struct{}{}
    userGroups = append(userGroups, groupId)
}
```

`DefaultGroups` / `DefaultGroup` are now added via `addGroup`, deduplicating at the source.

### 3. Only associate groups that actually exist, and normalize to the `owner/name` format

When parsing `memberOf`:
- Skip group names that parse to empty;
- Skip groups that **do not exist** in Casdoor (to avoid referencing empty groups);
- Write existing groups uniformly in the full `owner/name` form, consistent with `DefaultGroups`:

```go
// Extract group names from memberOf DNs. Only attach groups that
// actually exist in Casdoor, and store them as full "owner/name"
// IDs (consistent with DefaultGroups) to avoid empty group refs.
for _, memberDn := range syncUser.MemberOf {
    groupName := dnToGroupName(owner, memberDn)
    if groupName == "" {
        continue
    }
    if _, ok := existingGroupNameSet[groupName]; !ok {
        // Group not present in Casdoor (e.g. a CJK group that
        // wasn't synced); skip to avoid creating an empty group.
        continue
    }
    addGroup(fmt.Sprintf("%s/%s", owner, groupName))
}
```

---

## Result

| Scenario | Before fix | After fix |
|----------|-----------|-----------|
| `memberOf` contains a non-existent group (e.g. an unsynced Chinese group) | User is associated with an empty/non-existent group | The group is skipped, no more empty group references |
| Group ID format | `DefaultGroups` uses `owner/name`, memberOf uses bare `name`, mixed | Unified to `owner/name` |
| Duplicate groups | Duplicate groups may appear | Automatically deduplicated |

---

## Compatibility & Scope

- Only the grouping logic of `SyncLdapUsers` in `object/ldap_conn.go` is modified; **no changes** to the database schema, APIs, or configuration items.
- For scenarios where the group referenced by `memberOf` already exists in Casdoor, the behavior is consistent with before (just more standardized in format and stricter in deduplication).
- Chinese / Unicode group names continue to use the existing `dnToGroupName` handling logic (only replacing the illegal character `/`, preserving Unicode).

---

## Testing

- [x] `go build ./object/` passes (compilation verification).
- [x] Started Casdoor locally and synced LDAP users containing Chinese group names, confirming no more empty group references are generated.