### PR TITLE
feat: don't mask private keys in /get-certs for admin users

### DIFF
--- a/controllers/cert.go
+++ b/controllers/cert.go
@@ -55,10 +55,18 @@ func (c *ApiController) GetCerts() {
 		}
 
 		paginator := pagination.NewPaginator(c.Ctx.Request, limit, count)
-		certs, err := object.GetMaskedCerts(object.GetPaginationCerts(owner, paginator.Offset(), limit, field, value, sortField, sortOrder))
+		certs, err := object.GetPaginationCerts(owner, paginator.Offset(), limit, field, value, sortField, sortOrder)
 		if err != nil {
 			c.ResponseError(err.Error())
 			return
+		}
+
+		if !c.IsAdmin() {
+			certs, err = object.GetMaskedCerts(certs, err)
+			if err != nil {
+				c.ResponseError(err.Error())
+				return
+			}
 		}
 
 		c.ResponseOk(certs, paginator.Nums())


### PR DESCRIPTION
When an admin user or an app like `built-in` requests the list of certificates from `/api/get-certs`, the resulting certificates always have their `privateKey` fields masked (e.g. `***`)

<img width="575" height="643" alt="Image" src="https://github.com/user-attachments/assets/af2a09a6-72de-4aa8-bfcc-b1e901832112" />

However, when the exact same certificate is requested with the same credentials via `/api/get-cert?id=...` it does have the `privateKey` field unmasked.

<img width="441" height="632" alt="Image" src="https://github.com/user-attachments/assets/960ce7c0-72ff-46d9-bf35-451a9bb3f345" />

Assuming this wasn't intended behavior, it seems to be a regression introduced in this commit:

https://github.com/casdoor/casdoor/commit/5586768c4a50d206dc5c33cd3800b15991ed5cfa

Though the commit targets `/get-cert` it also affects `/get-certs` because the `GetMaskedCert()` function, which is now responsible for masking the keys, is being called by the controller inadvertently without checking if the calling user is an admin:

https://github.com/casdoor/casdoor/blob/08fe8d1c6affbd77e63c5202cfeabf448e84c98e/controllers/cert.go#L56-L63

To fix this, we can call `c.IsAdmin()` to see if the user is an admin or not, and only call `GetMaskedCerts()` for non-admin users
