### PR TITLE
feat: respect Provider.customLogo for all types, not just Custom*

### DIFF
--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -1243,7 +1243,7 @@ export function getClickable(text) {
 }
 
 export function getProviderLogoURL(provider) {
-  if (provider.type.startsWith("Custom") && provider.customLogo) {
+  if (provider.customLogo) {
     return provider.customLogo;
   }
   if (provider.category === "OAuth") {


### PR DESCRIPTION
Closes #5555.

`Setting.getProviderLogoURL` currently honours `provider.customLogo` only when `provider.type` starts with `"Custom"`. Every other OAuth provider (Google, MicrosoftOnline, GitHub, Apple, etc.) falls through to the hardcoded `${StaticBaseUrl}/img/social_<type>.png` path, dragging visitors of self-hosted Casdoor instances to `cdn.casbin.org` on every login render — same GDPR/DSGVO problem class as the Inter-font hot-link fixed in #5550.

Removing the type guard turns `customLogo` into a universal opt-out, matching its field name and the admin-UI affordance (the field is shown on every provider, regardless of type). Fallback chain (`${StaticBaseUrl}` for OAuth providers without `customLogo`, `OtherProviderInfo` table for non-OAuth categories) is preserved unchanged.

## Changes

- `web/src/Setting.js`: drop the `provider.type.startsWith("Custom")` guard on the `customLogo` branch.

Total diff: **+1 / -1** in 1 file.

## Verification

Tested on a self-hosted instance (Casdoor v3.83.0):

- Provider `Google` (`type=Google`, `category=OAuth`), `customLogo` set to a same-origin SVG URL.
- Before: login page network tab shows `${StaticBaseUrl}/img/social_google.png` (third-party hop to `cdn.casbin.org`).
- After: login page network tab shows the `customLogo` URL only; no `${StaticBaseUrl}/img/social_*.png` request.
- Providers without `customLogo` continue to use the `${StaticBaseUrl}` fallback unchanged.