### PR TITLE
feat: respect staticBaseUrl for unauthenticated favicon URL

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -753,7 +753,7 @@ class App extends Component {
       <React.Fragment>
         {(this.state.account === undefined || this.state.account === null) ?
           <Helmet>
-            <link rel="icon" href={"https://cdn.casdoor.com/static/favicon.png"} />
+            <link rel="icon" href={`${Conf.StaticBaseUrl}/img/favicon.png`} />
           </Helmet> :
           <Helmet>
             <title>{this.state.account.organization?.displayName}</title>


### PR DESCRIPTION
Closes #5557.

`web/src/App.js` hardcoded `https://cdn.casdoor.com/static/favicon.png` for the unauthenticated favicon, bypassing the configurable `staticBaseUrl`. This:

- Defeats intranet-mode: every unauthenticated page render fetches the favicon from `cdn.casdoor.com` regardless of operator configuration.
- Adds an unnecessary 301 hop (`cdn.casdoor.com` → `cdn.casvisor.com`).
- Points at a path (`/static/favicon.png`) that doesn't actually exist in the [`casdoor/static`](https://github.com/casdoor/static) asset repository; the favicon there is at `/img/favicon.png`.

Replacing the literal with `${Conf.StaticBaseUrl}/img/favicon.png` resolves all three: the URL follows the intranet-mode configuration like every other Casdoor static asset, drops the extra redirect, and points at a path that actually exists.

## Changes

- `web/src/App.js`: replace hardcoded `cdn.casdoor.com/static/favicon.png` with `${Conf.StaticBaseUrl}/img/favicon.png`.

Total diff: **+1 / -1** in 1 file.

## Verification

Tested on self-hosted v3.83.0 with `staticBaseUrl=https://auth.example.org/brand/casdoor-cdn`:

- Before: `<link rel="icon" href="https://cdn.casdoor.com/static/favicon.png">` is injected; browser fetches the favicon from `cdn.casdoor.com` (which 301s to `cdn.casvisor.com`).
- After: `<link rel="icon" href="https://auth.example.org/brand/casdoor-cdn/img/favicon.png">` is injected; favicon is served same-origin.

Default behaviour (`staticBaseUrl=https://cdn.casbin.org`) continues to serve a Casdoor-branded favicon (from `cdn.casbin.org/img/favicon.png`, same image content as the previous URL but on the path the rest of the codebase already uses).
