### PR TITLE
feat: align reset email and phone buttons in user edit page

### DIFF
--- a/web/src/UserEditPage.js
+++ b/web/src/UserEditPage.js
@@ -499,17 +499,16 @@ class UserEditPage extends React.Component {
           <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
             {Setting.getLabel(i18next.t("general:Email"), i18next.t("general:Email - Tooltip"))} :
           </Col>
-          <Col style={{paddingRight: "20px"}} span={5} >
+          <Col style={{paddingRight: "20px"}} span={Setting.isMobile() ? 22 : 6} >
             <Input
               value={this.state.user.email}
-              style={{width: "280Px"}}
               disabled={!Setting.isLocalAdminUser(this.props.account) ? true : disabled}
               onChange={e => {
                 this.updateUserField("email", e.target.value);
               }}
             />
           </Col>
-          <Col span={Setting.isMobile() ? 22 : 5} >
+          <Col span={Setting.isMobile() ? 22 : 6} >
             {/* backend auto get the current user, so admin can not edit. Just self can reset*/}
             {this.isSelf() ? <ResetModal application={this.state.application} disabled={disabled} buttonText={i18next.t("user:Reset Email...")} destType={"email"} /> : null}
           </Col>
@@ -521,8 +520,8 @@ class UserEditPage extends React.Component {
           <Col style={{marginTop: "5px"}} span={Setting.isMobile() ? 22 : 2}>
             {Setting.getLabel(i18next.t("general:Phone"), i18next.t("general:Phone - Tooltip"))} :
           </Col>
-          <Col style={{paddingRight: "20px"}} span={5} >
-            <Input.Group compact style={{width: "280Px"}}>
+          <Col style={{paddingRight: "20px"}} span={Setting.isMobile() ? 22 : 6} >
+            <Input.Group compact>
               <CountryCodeSelect
                 style={{width: "30%"}}
                 // disabled={!Setting.isLocalAdminUser(this.props.account) ? true : disabled}
@@ -540,7 +539,7 @@ class UserEditPage extends React.Component {
                 }} />
             </Input.Group>
           </Col>
-          <Col span={Setting.isMobile() ? 24 : 5} >
+          <Col span={Setting.isMobile() ? 22 : 6} >
             {this.isSelf() ? (<ResetModal application={this.state.application} countryCode={this.getCountryCode()} disabled={disabled} buttonText={i18next.t("user:Reset Phone...")} destType={"phone"} />) : null}
           </Col>
         </Row>


### PR DESCRIPTION
<img width="852" height="508" alt="image" src="https://github.com/user-attachments/assets/e1373c8e-e808-4b0e-a001-a1802b9ab17c" />

change to 
<img width="1638" height="568" alt="image" src="https://github.com/user-attachments/assets/490a5f39-1d53-4bf5-89d2-753250c427a3" />