### PR TITLE
feat: prevent LDAP sync from deleting user's existing groups

### DIFF
--- a/object/ldap_conn.go
+++ b/object/ldap_conn.go
@@ -497,7 +497,10 @@ func SyncLdapUsers(owner string, syncUsers []LdapUser, ldapId string) (existUser
 				continue
 			}
 
-			user.Groups = buildLdapUserGroups(organization.Name, ldap, syncUser.MemberOf, existingGroupNameSet)
+			// Merge LDAP-derived groups with the user's existing groups so that
+			// manually-assigned groups (or groups from other sources) are not
+			// wiped out during synchronization.
+			user.Groups = buildLdapUserGroups(organization.Name, ldap, syncUser.MemberOf, existingGroupNameSet, user.Groups)
 			affected, err := UpdateUser(user.GetId(), user, []string{"groups"}, false)
 			if err != nil {
 				return nil, nil, err
@@ -538,7 +541,7 @@ func SyncLdapUsers(owner string, syncUsers []LdapUser, ldapId string) (existUser
 			}
 			formatUserPhone(newUser)
 
-			userGroups := buildLdapUserGroups(organization.Name, ldap, syncUser.MemberOf, existingGroupNameSet)
+			userGroups := buildLdapUserGroups(organization.Name, ldap, syncUser.MemberOf, existingGroupNameSet, nil)
 
 			if len(userGroups) > 0 {
 				newUser.Groups = userGroups
@@ -580,7 +583,7 @@ func getUserByLdap(owner string, ldapUuid string) (*User, error) {
 	return nil, nil
 }
 
-func buildLdapUserGroups(owner string, ldap *Ldap, memberOf []string, existingGroupNameSet map[string]struct{}) []string {
+func buildLdapUserGroups(owner string, ldap *Ldap, memberOf []string, existingGroupNameSet map[string]struct{}, existingUserGroups []string) []string {
 	userGroups := []string{}
 	seen := make(map[string]struct{})
 	addGroup := func(groupId string) {
@@ -592,6 +595,13 @@ func buildLdapUserGroups(owner string, ldap *Ldap, memberOf []string, existingGr
 		}
 		seen[groupId] = struct{}{}
 		userGroups = append(userGroups, groupId)
+	}
+
+	// Preserve the user's existing groups (e.g. manually-assigned groups or
+	// groups from other sources) so synchronization only adds LDAP groups
+	// instead of replacing the whole membership.
+	for _, g := range existingUserGroups {
+		addGroup(g)
 	}
 
 	if len(ldap.DefaultGroups) > 0 {


### PR DESCRIPTION
### Fixes

Fixes #5562 — *LDAP will delete all other groups for that user during synchronization.*

### Summary

During LDAP synchronization, Casdoor was **overwriting** the entire group
membership of already-existing users with only the LDAP-derived groups. As a
result, every scheduled (auto) sync silently removed all of a user's other
groups. This PR changes the behavior so that synchronization **merges** the
LDAP-derived groups into the user's existing groups instead of replacing them.

### Root cause

The regression was **not** introduced in v3.84.0 (that release only shipped the
`SyncedEnforcer` concurrency fix — commit `9f90aa4`, which doesn't touch group
data). The actual cause is in **v3.83.0**, commit `adf5f5a`
(PR #5545 *"Fixed LDAP groups synchronization routine"*). It became visible to
users who upgraded directly to v3.84.0.

Before #5545, `SyncLdapUsers` only assigned groups when **creating a new user**;
existing users' groups were left untouched. PR #5545 added a new sync path for
already-existing users:

```go
user, err := getUserByLdap(owner, syncUser.Uuid)
...
user.Groups = buildLdapUserGroups(organization.Name, ldap, syncUser.MemberOf, existingGroupNameSet)
affected, err := UpdateUser(user.GetId(), user, []string{"groups"}, false)
```

This **replaces** the user's whole `Groups` slice with the freshly-computed LDAP
list. Two things make this destructive:

1. **Overwrite, not merge** — any group the user holds that is not derived from
   LDAP `memberOf` / `DefaultGroups` (e.g. groups assigned manually in the UI or
   via API, or from another source) is dropped.
2. **Silent filtering inside `buildLdapUserGroups`** — the function skips any
   `memberOf` group whose name has no matching Casdoor group
   (`existingGroupNameSet`). So even legitimate LDAP groups that weren't synced
   yet (for example CJK-named groups like `项目部`) are excluded, further
   shrinking the resulting list.

The net effect: on each `autoSync` run, an existing user ends up with only the
subset of groups that both come from LDAP and already exist in Casdoor — every
other group is deleted. This matches exactly what's reported in #5562
(user's other groups disappear after a scheduled LDAP sync).

### Fix

`buildLdapUserGroups` now takes an additional `existingUserGroups []string`
parameter and seeds the result with the user's current groups **before** adding
the LDAP-derived ones. De-duplication is handled by the existing `seen` set, so
the output is the **union** of:

- the user's existing groups, plus
- `DefaultGroups` / `DefaultGroup`, plus
- the `memberOf` groups that exist in Casdoor.

Synchronization therefore only **adds** LDAP groups and never removes groups it
didn't assign.

- For **existing users**, we pass `user.Groups` so their current membership is
  preserved.
- For **new users**, we pass `nil`, keeping the previous behavior unchanged.

### Code changes (`object/ldap_conn.go`)

Existing-user sync path — preserve current groups by passing them in:

```go
// Merge LDAP-derived groups with the user's existing groups so that
// manually-assigned groups (or groups from other sources) are not
// wiped out during synchronization.
user.Groups = buildLdapUserGroups(organization.Name, ldap, syncUser.MemberOf, existingGroupNameSet, user.Groups)
affected, err := UpdateUser(user.GetId(), user, []string{"groups"}, false)
```

New-user path — explicitly pass `nil` (no pre-existing groups):

```go
userGroups := buildLdapUserGroups(organization.Name, ldap, syncUser.MemberOf, existingGroupNameSet, nil)
```

`buildLdapUserGroups` signature + merge logic:

```go
func buildLdapUserGroups(owner string, ldap *Ldap, memberOf []string, existingGroupNameSet map[string]struct{}, existingUserGroups []string) []string {
    userGroups := []string{}
    seen := make(map[string]struct{})
    addGroup := func(groupId string) {
        if groupId == "" {
            return
        }
        if _, ok := seen[groupId]; ok {
            return
        }
        seen[groupId] = struct{}{}
        userGroups = append(userGroups, groupId)
    }

    // Preserve the user's existing groups (e.g. manually-assigned groups or
    // groups from other sources) so synchronization only adds LDAP groups
    // instead of replacing the whole membership.
    for _, g := range existingUserGroups {
        addGroup(g)
    }

    if len(ldap.DefaultGroups) > 0 {
        for _, g := range ldap.DefaultGroups {
            addGroup(g)
        }
    } else if ldap.DefaultGroup != "" {
        addGroup(ldap.DefaultGroup)
    }

    // ... existing memberOf handling unchanged ...
}
```

### Testing

- `go vet ./object/` passes.
- Manually verified that after re-sync, an existing user keeps their previously
  assigned groups **and** gains the LDAP `memberOf` groups, instead of losing
  the non-LDAP ones.