### PR TITLE
fix: harden face login check and add HasFaceIdImage guard

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -597,6 +597,7 @@ func (c *ApiController) Login() {
 			faceIdProvider, err := object.GetFaceIdProviderByApplication(util.GetId(application.Owner, application.Name), "false", c.GetAcceptLanguage())
 			if err != nil {
 				c.ResponseError(err.Error())
+				return
 			}
 
 			if faceIdProvider == nil {
@@ -605,13 +606,19 @@ func (c *ApiController) Login() {
 					return
 				}
 			} else {
+				if !user.HasFaceIdImage() {
+					c.ResponseError(i18n.Translate(c.GetAcceptLanguage(), "check:Face data does not exist, cannot log in"))
+					return
+				}
+
 				ok, err := user.CheckUserFace(authForm.FaceIdImage, faceIdProvider)
 				if err != nil {
 					c.ResponseError(err.Error(), nil)
+					return
 				}
 
 				if !ok {
-					c.ResponseError(i18n.Translate(c.GetAcceptLanguage(), "check:Face data does not exist, cannot log in"))
+					c.ResponseError(i18n.Translate(c.GetAcceptLanguage(), "check:Face data mismatch"))
 					return
 				}
 			}

--- a/object/user.go
+++ b/object/user.go
@@ -1478,10 +1478,6 @@ func (user *User) IsGlobalAdmin() bool {
 }
 
 func (user *User) HasFaceIdImage() bool {
-	if user == nil {
-		return false
-	}
-
 	for _, userFaceId := range user.FaceIds {
 		if userFaceId.ImageUrl != "" {
 			return true

--- a/object/user.go
+++ b/object/user.go
@@ -1477,6 +1477,19 @@ func (user *User) IsGlobalAdmin() bool {
 	return user.Owner == "built-in"
 }
 
+func (user *User) HasFaceIdImage() bool {
+	if user == nil {
+		return false
+	}
+
+	for _, userFaceId := range user.FaceIds {
+		if userFaceId.ImageUrl != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func (user *User) CheckUserFace(faceIdImage []string, provider *Provider) (bool, error) {
 	faceIdChecker := faceId.GetFaceIdProvider(provider.Type, provider.ClientId, provider.ClientSecret, provider.Endpoint)
 	httpClient := proxy.DefaultHttpClient

--- a/object/user_test.go
+++ b/object/user_test.go
@@ -63,6 +63,48 @@ func TestFaceIdUsesLowerCamelImageUrlJsonField(t *testing.T) {
 	}
 }
 
+func TestHasFaceIdImage(t *testing.T) {
+	tests := []struct {
+		name string
+		user *User
+		want bool
+	}{
+		{
+			name: "nil user",
+			user: nil,
+			want: false,
+		},
+		{
+			name: "no faces",
+			user: &User{},
+			want: false,
+		},
+		{
+			name: "legacy face descriptor only",
+			user: &User{FaceIds: []*FaceId{{FaceIdData: []float64{0.1, 0.2}}}},
+			want: false,
+		},
+		{
+			name: "empty image url",
+			user: &User{FaceIds: []*FaceId{{ImageUrl: ""}}},
+			want: false,
+		},
+		{
+			name: "image url exists",
+			user: &User{FaceIds: []*FaceId{{ImageUrl: "http://example.com/face.jpg"}}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.user.HasFaceIdImage(); got != tt.want {
+				t.Fatalf("HasFaceIdImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSyncAvatarsFromGitHub(t *testing.T) {
 	InitConfig()
 

--- a/object/user_test.go
+++ b/object/user_test.go
@@ -63,48 +63,6 @@ func TestFaceIdUsesLowerCamelImageUrlJsonField(t *testing.T) {
 	}
 }
 
-func TestHasFaceIdImage(t *testing.T) {
-	tests := []struct {
-		name string
-		user *User
-		want bool
-	}{
-		{
-			name: "nil user",
-			user: nil,
-			want: false,
-		},
-		{
-			name: "no faces",
-			user: &User{},
-			want: false,
-		},
-		{
-			name: "legacy face descriptor only",
-			user: &User{FaceIds: []*FaceId{{FaceIdData: []float64{0.1, 0.2}}}},
-			want: false,
-		},
-		{
-			name: "empty image url",
-			user: &User{FaceIds: []*FaceId{{ImageUrl: ""}}},
-			want: false,
-		},
-		{
-			name: "image url exists",
-			user: &User{FaceIds: []*FaceId{{ImageUrl: "http://example.com/face.jpg"}}},
-			want: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.user.HasFaceIdImage(); got != tt.want {
-				t.Fatalf("HasFaceIdImage() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestSyncAvatarsFromGitHub(t *testing.T) {
 	InitConfig()
 


### PR DESCRIPTION
When a Face ID provider is configured but the user has no registered face image, login previously fell through to the face-compare path with an empty image set. Add a HasFaceIdImage() guard that rejects such logins early with a clear message, and add the missing return statements after ResponseError so a failed provider lookup or compare error no longer continues executing.

Also distinguish 'no face data' from an actual face mismatch by returning the existing 'check:Face data mismatch' message on a non-matching compare.