### PR TITLE
fix: preserve safe adapter policy tables

### DIFF
--- a/object/adapter_safe.go
+++ b/object/adapter_safe.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"github.com/casbin/casbin/v2/model"
 	xormadapter "github.com/casdoor/xorm-adapter/v3"
 	"github.com/xorm-io/xorm"
 )
@@ -9,6 +10,26 @@ type SafeAdapter struct {
 	*xormadapter.Adapter
 	engine    *xorm.Engine
 	tableName string
+}
+
+type safeCasbinRule struct {
+	Id    int64  `xorm:"pk autoincr"`
+	Ptype string `xorm:"varchar(100) index not null default ''"`
+	V0    string `xorm:"varchar(100) index not null default ''"`
+	V1    string `xorm:"varchar(100) index not null default ''"`
+	V2    string `xorm:"varchar(100) index not null default ''"`
+	V3    string `xorm:"varchar(100) index not null default ''"`
+	V4    string `xorm:"varchar(100) index not null default ''"`
+	V5    string `xorm:"varchar(100) index not null default ''"`
+
+	tableName string `xorm:"-"`
+}
+
+func (rule *safeCasbinRule) TableName() string {
+	if rule.tableName == "" {
+		return "casbin_rule"
+	}
+	return rule.tableName
 }
 
 func NewSafeAdapter(a *Adapter) *SafeAdapter {
@@ -23,15 +44,44 @@ func NewSafeAdapter(a *Adapter) *SafeAdapter {
 	}
 }
 
+func (a *SafeAdapter) SavePolicy(model model.Model) error {
+	lines := make([]*safeCasbinRule, 0, 64)
+
+	for ptype, ast := range model["p"] {
+		for _, rule := range ast.Policy {
+			lines = append(lines, a.buildCasbinRule(ptype, rule))
+		}
+	}
+
+	for ptype, ast := range model["g"] {
+		for _, rule := range ast.Policy {
+			lines = append(lines, a.buildCasbinRule(ptype, rule))
+		}
+	}
+
+	_, err := a.engine.Transaction(func(tx *xorm.Session) (interface{}, error) {
+		_, err := tx.Where("ptype IS NOT NULL").Delete(&safeCasbinRule{tableName: a.policyTableName()})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, line := range lines {
+			_, err = tx.InsertOne(line)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return nil, nil
+	})
+	return err
+}
+
 func (a *SafeAdapter) RemovePolicy(sec string, ptype string, rule []string) error {
 	line := a.buildCasbinRule(ptype, rule)
 
 	session := a.engine.NewSession()
 	defer session.Close()
-
-	if a.tableName != "" {
-		session = session.Table(a.tableName)
-	}
 
 	_, err := session.
 		MustCols("ptype", "v0", "v1", "v2", "v3", "v4", "v5").
@@ -45,14 +95,7 @@ func (a *SafeAdapter) RemovePolicies(sec string, ptype string, rules [][]string)
 		for _, rule := range rules {
 			line := a.buildCasbinRule(ptype, rule)
 
-			var session *xorm.Session
-			if a.tableName != "" {
-				session = tx.Table(a.tableName)
-			} else {
-				session = tx
-			}
-
-			_, err := session.
+			_, err := tx.
 				MustCols("ptype", "v0", "v1", "v2", "v3", "v4", "v5").
 				Delete(line)
 			if err != nil {
@@ -71,10 +114,6 @@ func (a *SafeAdapter) UpdatePolicy(sec string, ptype string, oldRule []string, n
 	session := a.engine.NewSession()
 	defer session.Close()
 
-	if a.tableName != "" {
-		session = session.Table(a.tableName)
-	}
-
 	_, err := session.
 		Where("ptype = ? AND v0 = ? AND v1 = ? AND v2 = ? AND v3 = ? AND v4 = ? AND v5 = ?",
 			oldLine.Ptype, oldLine.V0, oldLine.V1, oldLine.V2, oldLine.V3, oldLine.V4, oldLine.V5).
@@ -90,14 +129,7 @@ func (a *SafeAdapter) UpdatePolicies(sec string, ptype string, oldRules [][]stri
 			oldLine := a.buildCasbinRule(ptype, oldRule)
 			newLine := a.buildCasbinRule(ptype, newRules[i])
 
-			var session *xorm.Session
-			if a.tableName != "" {
-				session = tx.Table(a.tableName)
-			} else {
-				session = tx
-			}
-
-			_, err := session.
+			_, err := tx.
 				Where("ptype = ? AND v0 = ? AND v1 = ? AND v2 = ? AND v3 = ? AND v4 = ? AND v5 = ?",
 					oldLine.Ptype, oldLine.V0, oldLine.V1, oldLine.V2, oldLine.V3, oldLine.V4, oldLine.V5).
 				MustCols("ptype", "v0", "v1", "v2", "v3", "v4", "v5").
@@ -112,20 +144,31 @@ func (a *SafeAdapter) UpdatePolicies(sec string, ptype string, oldRules [][]stri
 }
 
 func (a *SafeAdapter) GetRules() ([]*xormadapter.CasbinRule, error) {
-	rules := []*xormadapter.CasbinRule{}
+	rules := []*safeCasbinRule{}
 	session := a.engine.NewSession()
 	defer session.Close()
 
-	if a.tableName != "" {
-		session = session.Table(a.tableName)
+	err := session.Table(&safeCasbinRule{tableName: a.policyTableName()}).Find(&rules)
+	if err != nil {
+		return nil, err
 	}
 
-	err := session.Find(&rules)
-	return rules, err
+	res := make([]*xormadapter.CasbinRule, 0, len(rules))
+	for _, rule := range rules {
+		res = append(res, rule.toXormCasbinRule())
+	}
+	return res, nil
 }
 
-func (a *SafeAdapter) buildCasbinRule(ptype string, rule []string) *xormadapter.CasbinRule {
-	line := xormadapter.CasbinRule{Ptype: ptype}
+func (a *SafeAdapter) policyTableName() string {
+	if a.tableName == "" {
+		return "casbin_rule"
+	}
+	return a.tableName
+}
+
+func (a *SafeAdapter) buildCasbinRule(ptype string, rule []string) *safeCasbinRule {
+	line := safeCasbinRule{Ptype: ptype, tableName: a.policyTableName()}
 
 	l := len(rule)
 	if l > 0 {
@@ -148,4 +191,17 @@ func (a *SafeAdapter) buildCasbinRule(ptype string, rule []string) *xormadapter.
 	}
 
 	return &line
+}
+
+func (rule *safeCasbinRule) toXormCasbinRule() *xormadapter.CasbinRule {
+	return &xormadapter.CasbinRule{
+		Id:    rule.Id,
+		Ptype: rule.Ptype,
+		V0:    rule.V0,
+		V1:    rule.V1,
+		V2:    rule.V2,
+		V3:    rule.V3,
+		V4:    rule.V4,
+		V5:    rule.V5,
+	}
 }

--- a/object/adapter_safe_test.go
+++ b/object/adapter_safe_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"testing"
+
+	"github.com/casbin/casbin/v2/model"
+	xormadapter "github.com/casdoor/xorm-adapter/v3"
+	"github.com/xorm-io/xorm"
+	_ "modernc.org/sqlite"
+)
+
+func TestSafeAdapterSavePolicyReplacesRulesWithoutDroppingTable(t *testing.T) {
+	engine, err := xorm.NewEngine("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+	defer engine.Close()
+
+	const tableName = "casbin_api_rule"
+
+	err = engine.Sync2(&xormadapter.CasbinRule{})
+	if err != nil {
+		t.Fatalf("Sync2() error = %v", err)
+	}
+	_, err = engine.Exec("ALTER TABLE casbin_rule RENAME TO " + tableName)
+	if err != nil {
+		t.Fatalf("rename table error = %v", err)
+	}
+	_, err = engine.Exec("CREATE INDEX casbin_api_rule_marker_idx ON " + tableName + " (ptype)")
+	if err != nil {
+		t.Fatalf("create marker index error = %v", err)
+	}
+
+	safeAdapter := &SafeAdapter{
+		engine:    engine,
+		tableName: tableName,
+	}
+
+	err = safeAdapter.SavePolicy(newPolicyModel(t, [][]string{
+		{"built-in", "*", "*", "*", "*", "*"},
+	}))
+	if err != nil {
+		t.Fatalf("first SavePolicy() error = %v", err)
+	}
+
+	rules := getSafeAdapterRules(t, safeAdapter)
+	if len(rules) != 1 {
+		t.Fatalf("len(rules) = %d, want 1", len(rules))
+	}
+
+	err = safeAdapter.SavePolicy(newPolicyModel(t, [][]string{
+		{"app", "*", "GET", "/api/get-account", "*", "*"},
+		{"*", "*", "POST", "/api/login", "*", "*"},
+	}))
+	if err != nil {
+		t.Fatalf("second SavePolicy() error = %v", err)
+	}
+
+	rules = getSafeAdapterRules(t, safeAdapter)
+	if len(rules) != 2 {
+		t.Fatalf("len(rules) = %d, want 2", len(rules))
+	}
+
+	err = safeAdapter.UpdatePolicy("p", "p",
+		[]string{"app", "*", "GET", "/api/get-account", "*", "*"},
+		[]string{"app", "*", "GET", "/api/get-user", "*", "*"})
+	if err != nil {
+		t.Fatalf("UpdatePolicy() error = %v", err)
+	}
+
+	rules = getSafeAdapterRules(t, safeAdapter)
+	if len(rules) != 2 {
+		t.Fatalf("len(rules) after update = %d, want 2", len(rules))
+	}
+	assertPolicyExists(t, rules, []string{"app", "*", "GET", "/api/get-user", "*", "*"})
+
+	err = safeAdapter.RemovePolicy("p", "p", []string{"*", "*", "POST", "/api/login", "*", "*"})
+	if err != nil {
+		t.Fatalf("RemovePolicy() error = %v", err)
+	}
+
+	rules = getSafeAdapterRules(t, safeAdapter)
+	if len(rules) != 1 {
+		t.Fatalf("len(rules) after remove = %d, want 1", len(rules))
+	}
+
+	var markerIndexCount int64
+	markerIndexCount, err = engine.SQL("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND tbl_name = ? AND name = ?", tableName, "casbin_api_rule_marker_idx").Count()
+	if err != nil {
+		t.Fatalf("marker index query error = %v", err)
+	}
+	if markerIndexCount != 1 {
+		t.Fatal("SavePolicy() dropped and recreated the policy table")
+	}
+}
+
+func newPolicyModel(t *testing.T, policies [][]string) model.Model {
+	t.Helper()
+
+	m, err := model.NewModelFromString(`[request_definition]
+r = subOwner, subName, method, urlPath, objOwner, objName
+
+[policy_definition]
+p = subOwner, subName, method, urlPath, objOwner, objName
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = r.subOwner == p.subOwner && r.subName == p.subName && r.method == p.method && r.urlPath == p.urlPath && r.objOwner == p.objOwner && r.objName == p.objName`)
+	if err != nil {
+		t.Fatalf("NewModelFromString() error = %v", err)
+	}
+
+	for _, policy := range policies {
+		if len(policy) != 6 {
+			t.Fatalf("policy has %d fields, want 6", len(policy))
+		}
+		m["p"]["p"].Policy = append(m["p"]["p"].Policy, policy)
+	}
+
+	return m
+}
+
+func getSafeAdapterRules(t *testing.T, safeAdapter *SafeAdapter) []*xormadapter.CasbinRule {
+	t.Helper()
+
+	rules, err := safeAdapter.GetRules()
+	if err != nil {
+		t.Fatalf("GetRules() error = %v", err)
+	}
+	return rules
+}
+
+func assertPolicyExists(t *testing.T, rules []*xormadapter.CasbinRule, policy []string) {
+	t.Helper()
+
+	for _, rule := range rules {
+		if rule.Ptype == "p" &&
+			rule.V0 == policy[0] &&
+			rule.V1 == policy[1] &&
+			rule.V2 == policy[2] &&
+			rule.V3 == policy[3] &&
+			rule.V4 == policy[4] &&
+			rule.V5 == policy[5] {
+			return
+		}
+	}
+
+	t.Fatalf("policy %v was not found in rules %#v", policy, rules)
+}


### PR DESCRIPTION
## Summary

This fixes `SafeAdapter` policy persistence for adapters that use a custom policy table, such as the built-in API adapter table `casbin_api_rule`.

The current safe adapter embeds `xorm-adapter`'s `CasbinRule`, whose `TableName()` falls back to `casbin_rule` unless its private `tableName` field is set inside the adapter package. As a result, table-specific safe adapter operations can target the default policy table instead of the adapter's configured table.

The patch adds an internal policy row type that carries the configured table name through Xorm's `TableName()` hook and implements `SavePolicy()` without dropping and recreating the policy table.

## Why

With Casdoor master (`6e443ad5`) and CockroachDB v25.3 configured via the PostgreSQL wire-compatible driver:

```ini
driverName = postgres
dataSourceName = user=root host=casdoor-crdb port=26257 sslmode=disable dbname=casdoor serial_normalization=virtual_sequence
dbName = casdoor
```

Casdoor initialized the schema on a fresh database, then failed during built-in API policy initialization:

```text
panic: pq: unexpected transaction status idle
github.com/casdoor/casdoor/authz.InitApi()
    /src/authz/authz.go:153
```

The failing boundary is `Enforcer.SavePolicy()` for the built-in API enforcer.

## Changes

- Adds `SafeAdapter.SavePolicy()` that replaces policy rows transactionally without dropping the policy table.
- Uses an internal policy row type so custom adapter tables are honored by Xorm.
- Keeps `GetRules`, `RemovePolicy`, `RemovePolicies`, `UpdatePolicy`, and `UpdatePolicies` aligned with the configured adapter table.
- Adds a regression test that verifies a custom table is preserved and not dropped/recreated.

## Validation

Focused unit test:

```text
go test ./object -run TestSafeAdapterSavePolicyReplacesRulesWithoutDroppingTable -count=1
ok github.com/casdoor/casdoor/object
```

Local CockroachDB repro:

- Baseline master + CockroachDB v25.3 + `driverName=postgres` failed with `pq: unexpected transaction status idle` in `authz.InitApi()`.
- Patched branch + fresh CockroachDB v25.3 started successfully:

```text
http server Running on http://:8000
```

- Policy table check after patched startup:

```text
api_rules      98
_default_rules 0
```

(`api_rules` is `SELECT count(*) FROM casbin_api_rule`; `_default_rules` is `SELECT count(*) FROM casbin_rule`.)

## Notes

`driverName = CockroachDB` was also checked for the top-level Casdoor DB path and currently fails earlier with `panic: unsupported driver name: CockroachDB`, so this PR targets the documented PostgreSQL-compatible CockroachDB configuration path.
