### PR TITLE
feat(idp/telegram): generate stable username fallback for accounts without public username

### DIFF
--- a/idp/telegram.go
+++ b/idp/telegram.go
@@ -152,6 +152,12 @@ func (idp *TelegramIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, erro
 	username, _ := authData["username"].(string)
 	photoUrl, _ := authData["photo_url"].(string)
 
+	// Telegram usernames are optional. Generate a stable fallback so downstream
+	// user-record creation never receives an empty username.
+	if username == "" {
+		username = fmt.Sprintf("telegram_%d", userId)
+	}
+
 	// Build display name with fallback
 	displayName := strings.TrimSpace(firstName + " " + lastName)
 	if displayName == "" {


### PR DESCRIPTION
## Problem

Telegram usernames are optional. A user who has never set a public username sends an empty string in the widget auth payload. Casdoor then tries to create or look up a user record with an empty `username`, which causes errors such as:

```
the user's owner and name should not be empty
```

This silently blocks login for any Telegram user who has not set a public username — a common case for new accounts, privacy-conscious users, and bot-operated accounts.

## Fix

Generate a deterministic fallback `telegram_<userId>` when the `username` field is absent.

```go
if username == "" {
    username = fmt.Sprintf("telegram_%d", userId)
}
```

The fallback is applied **after** Telegram auth-data signature verification (line 152, after `verifyTelegramAuthData`), so the signed payload is never mutated and the security check remains fully intact.

The Telegram numeric user ID is permanent and unique, making it a reliable basis for the fallback username.

## Testing

- Verified with a Telegram account that has no public username set
- Existing accounts with a username are unaffected (the condition is only entered when `username == ""`)
- Auth-data signature verification passes unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)