### PR TITLE
feat: support recipient for notification sending

### DIFF
--- a/controllers/service.go
+++ b/controllers/service.go
@@ -42,7 +42,8 @@ type SmsForm struct {
 }
 
 type NotificationForm struct {
-	Content string `json:"content"`
+	Content   string `json:"content"`
+	Recipient string `json:"recipient"`
 }
 
 // SendEmail
@@ -224,7 +225,7 @@ func (c *ApiController) SendNotification() {
 		return
 	}
 
-	err = object.SendNotification(provider, notificationForm.Content)
+	err = object.SendNotification(provider, notificationForm.Content, notificationForm.Recipient)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return

--- a/notification/custom_http.go
+++ b/notification/custom_http.go
@@ -20,9 +20,12 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/casdoor/casdoor/proxy"
 )
+
+const customHttpNotificationTimeout = 30 * time.Second
 
 type HttpNotificationClient struct {
 	endpoint  string
@@ -40,29 +43,45 @@ func NewCustomHttpProvider(endpoint string, method string, paramName string) (*H
 }
 
 func (c *HttpNotificationClient) Send(ctx context.Context, subject string, content string) error {
+	return c.SendWithRecipient(ctx, subject, content, "")
+}
+
+func (c *HttpNotificationClient) SendWithRecipient(ctx context.Context, subject string, content string, recipient string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	var req *http.Request
 	var err error
 	if c.method == "POST" {
 		formValues := url.Values{}
 		formValues.Set(c.paramName, content)
-		req, err = http.NewRequest(c.method, c.endpoint, strings.NewReader(formValues.Encode()))
+		if recipient != "" {
+			formValues.Set("recipient", recipient)
+		}
+		req, err = http.NewRequestWithContext(ctx, c.method, c.endpoint, strings.NewReader(formValues.Encode()))
 		if err != nil {
 			return err
 		}
 
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	} else if c.method == "GET" {
-		req, err = http.NewRequest(c.method, c.endpoint, nil)
+		req, err = http.NewRequestWithContext(ctx, c.method, c.endpoint, nil)
 		if err != nil {
 			return err
 		}
 
 		q := req.URL.Query()
 		q.Add(c.paramName, content)
+		if recipient != "" {
+			q.Add("recipient", recipient)
+		}
 		req.URL.RawQuery = q.Encode()
+	} else {
+		return fmt.Errorf("HttpNotificationClient's SendMessage() error, unsupported method: %s", c.method)
 	}
 
-	httpClient := proxy.DefaultHttpClient
+	httpClient := getCustomHttpNotificationClient()
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
@@ -74,4 +93,17 @@ func (c *HttpNotificationClient) Send(ctx context.Context, subject string, conte
 	}
 
 	return err
+}
+
+func getCustomHttpNotificationClient() *http.Client {
+	httpClient := proxy.DefaultHttpClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	client := *httpClient
+	if client.Timeout == 0 {
+		client.Timeout = customHttpNotificationTimeout
+	}
+	return &client
 }

--- a/object/notification.go
+++ b/object/notification.go
@@ -36,14 +36,21 @@ func getNotificationClient(provider *Provider) (notify.Notifier, error) {
 	return client, nil
 }
 
-func SendNotification(provider *Provider, content string) error {
+type notificationRecipientSender interface {
+	SendWithRecipient(context.Context, string, string, string) error
+}
+
+func SendNotification(provider *Provider, content string, recipient string) error {
 	client, err := getNotificationClient(provider)
 	if err != nil {
 		return err
 	}
 
-	err = client.Send(context.Background(), "", content)
-	return err
+	if sender, ok := client.(notificationRecipientSender); ok {
+		return sender.SendWithRecipient(context.Background(), "", content, recipient)
+	}
+
+	return client.Send(context.Background(), "", content)
 }
 
 // SsoLogoutNotification represents the structure of a session-level SSO logout notification
@@ -171,7 +178,7 @@ func SendSsoLogoutNotifications(user *User, sessionIds []string, tokens []*Token
 		}
 
 		// Send the notification using the provider from the providerItem
-		err = SendNotification(providerItem.Provider, content)
+		err = SendNotification(providerItem.Provider, content, "")
 		if err != nil {
 			return fmt.Errorf("failed to send SSO logout notification to provider %s/%s: %w", providerItem.Provider.Owner, providerItem.Provider.Name, err)
 		}


### PR DESCRIPTION
for: https://github.com/casdoor/casdoor-go-sdk/commit/2ed89ffaf6c541cd85cae8511bf5d08d5482c79b

## Summary

This PR adds recipient support to Casdoor notification sending.

- Adds `recipient` to the `/api/send-notification` request body
- Passes the recipient through `object.SendNotification()`
- Lets notification providers opt in to recipient-aware sending via `SendWithRecipient`
- Supports recipient forwarding for Custom HTTP notifications as a `recipient` request parameter
- Keeps existing behavior unchanged for notification providers that do not support recipient-aware sending

This is needed by OpenAgent watch notifications, where each watched-agent event can be sent to a specific watching user.

## Notes

This PR only forwards the recipient to providers that explicitly support it. Mapping Casdoor/OpenAgent users to provider-specific receivers for non-Custom HTTP providers can be handled in a follow-up PR.