### PR TITLE
feat: fix unreadable dark mode text on entry pages (login, signup, forget)

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -25,7 +25,7 @@ import {Route, Switch, withRouter} from "react-router-dom";
 import CustomGithubCorner from "./common/CustomGithubCorner";
 import CustomHead from "./basic/CustomHead";
 import * as Conf from "./Conf";
-import {shadcnThemeComponents, shadcnThemeToken} from "./shadcnTheme";
+import {shadcnDarkThemeComponents, shadcnDarkThemeToken, shadcnThemeComponents, shadcnThemeToken} from "./shadcnTheme";
 
 import * as Auth from "./auth/Auth";
 import EntryPage from "./EntryPage";
@@ -618,11 +618,11 @@ class App extends Component {
           spin={{indicator: <AiDots />}}
           theme={{
             token: {
-              ...shadcnThemeToken,
+              ...(Setting.isDarkTheme(this.state.themeAlgorithm) ? shadcnDarkThemeToken : shadcnThemeToken),
               colorPrimary: themeData.colorPrimary,
               borderRadius: themeData.borderRadius,
             },
-            components: shadcnThemeComponents,
+            components: Setting.isDarkTheme(this.state.themeAlgorithm) ? shadcnDarkThemeComponents : shadcnThemeComponents,
             algorithm: Setting.getAlgorithm(this.state.themeAlgorithm),
           }}>
           <StyleProvider hashPriority="high" transformers={[legacyLogicalPropertiesTransformer]}>
@@ -764,12 +764,12 @@ class App extends Component {
           spin={{indicator: <AiDots />}}
           theme={{
             token: {
-              ...shadcnThemeToken,
+              ...(Setting.isDarkTheme(this.state.themeAlgorithm) ? shadcnDarkThemeToken : shadcnThemeToken),
               colorPrimary: this.state.themeData.colorPrimary,
               colorInfo: this.state.themeData.colorPrimary,
               borderRadius: this.state.themeData.borderRadius,
             },
-            components: shadcnThemeComponents,
+            components: Setting.isDarkTheme(this.state.themeAlgorithm) ? shadcnDarkThemeComponents : shadcnThemeComponents,
             algorithm: Setting.getAlgorithm(this.state.themeAlgorithm),
           }}>
           <StyleProvider hashPriority="high" transformers={[legacyLogicalPropertiesTransformer]}>

--- a/web/src/App.less
+++ b/web/src/App.less
@@ -60,7 +60,7 @@ img {
 
 .saas-hosting-btn {
   font-weight: bold;
-  background-color: rgba(87, 52, 211, 0.4);
+  background-color: rgb(87 52 211 / 40%);
   padding: 0 8px;
   display: flex;
   align-items: center;
@@ -69,9 +69,9 @@ img {
   transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 
   &:hover {
-    background-color: rgba(87, 52, 211, 0.65);
+    background-color: rgb(87 52 211 / 65%);
     transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(87, 52, 211, 0.35);
+    box-shadow: 0 4px 12px rgb(87 52 211 / 35%);
   }
 
   &:active {
@@ -105,7 +105,7 @@ img {
   box-shadow: 0 1px 5px 0 rgb(51 51 51 / 14%);
   flex: 1;
   align-items: stretch;
-  margin: 0 3px 3px 3px !important;
+  margin: 0 3px 3px !important;
   border-radius: 4px !important;
 }
 
@@ -127,6 +127,15 @@ img {
   border-radius: 7px;
   background-color: rgb(255 255 255);
   box-shadow: 0 0 20px rgb(0 0 0 / 20%);
+}
+
+.forget-content-dark {
+  padding: 10px 100px 20px;
+  margin: 30px auto;
+  border: 2px solid #333;
+  border-radius: 7px;
+  background-color: rgb(51 51 51);
+  box-shadow: 0 0 20px rgb(255 255 255 / 20%);
 }
 
 .login-panel {

--- a/web/src/ApplicationEditPage.js
+++ b/web/src/ApplicationEditPage.js
@@ -86,6 +86,14 @@ const template = `.login-panel {
   border-radius: 7px;
   background-color: rgb(255 255 255);
   box-shadow: 0 0 20px rgb(0 0 0 / 20%);
+}
+.forget-content-dark {
+  padding: 10px 100px 20px;
+  margin: 30px auto;
+  border: 2px solid #333;
+  border-radius: 7px;
+  background-color: rgb(51 51 51);
+  box-shadow: 0 0 20px rgb(255 255 255 / 20%);
 }`;
 
 const previewGrid = Setting.isMobile() ? 22 : 11;

--- a/web/src/auth/ForgetPage.js
+++ b/web/src/auth/ForgetPage.js
@@ -526,7 +526,7 @@ class ForgetPage extends React.Component {
     return (
       <React.Fragment>
         <CustomGithubCorner />
-        <div className="forget-content" style={{padding: Setting.isMobile() ? "0" : null, boxShadow: Setting.isMobile() ? "none" : null}}>
+        <div className={Setting.isDarkTheme(this.props.themeAlgorithm) ? "forget-content-dark" : "forget-content"} style={{padding: Setting.isMobile() ? "0" : null, boxShadow: Setting.isMobile() ? "none" : null}}>
           {Setting.inIframe() || Setting.isMobile() ? null : <style dangerouslySetInnerHTML={{__html: Setting.getStyleInnerCss(application.formCss)}} />}
           {Setting.inIframe() || !Setting.isMobile() ? null : <style dangerouslySetInnerHTML={{__html: Setting.getStyleInnerCss(application.formCssMobile)}} />}
           <Button type="text"

--- a/web/src/shadcnTheme.js
+++ b/web/src/shadcnTheme.js
@@ -78,6 +78,71 @@ export const shadcnThemeToken = {
   boxShadowSecondary: "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)",
 };
 
+// Dark-mode variant of the shadcn preset above: same shape and typography
+// tokens, with the neutral color scale flipped for dark backgrounds.
+export const shadcnDarkThemeToken = {
+  fontFamily: "'Inter Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif",
+  colorPrimary: "#fafafa",
+  colorSuccess: "#22c55e",
+  colorWarning: "#f97316",
+  colorError: "#ef4444",
+  colorInfo: "#fafafa",
+  colorTextBase: "#fafafa",
+  colorBgBase: "#0a0a0a",
+  colorSuccessBg: "#052e16",
+  colorSuccessBgHover: "#14532d",
+  colorSuccessBorder: "#166534",
+  colorSuccessBorderHover: "#15803d",
+  colorSuccessHover: "#4ade80",
+  colorSuccessActive: "#86efac",
+  colorSuccessText: "#4ade80",
+  colorSuccessTextHover: "#4ade80",
+  colorSuccessTextActive: "#86efac",
+  colorWarningBg: "#431407",
+  colorWarningBgHover: "#7c2d12",
+  colorWarningBorder: "#9a3412",
+  colorWarningBorderHover: "#c2410c",
+  colorWarningHover: "#fb923c",
+  colorWarningActive: "#fdba74",
+  colorWarningText: "#fb923c",
+  colorWarningTextHover: "#fb923c",
+  colorWarningTextActive: "#fdba74",
+  colorErrorBg: "#450a0a",
+  colorErrorBgHover: "#7f1d1d",
+  colorErrorBorder: "#991b1b",
+  colorErrorBorderHover: "#b91c1c",
+  colorErrorHover: "#f87171",
+  colorErrorActive: "#fca5a5",
+  colorErrorText: "#f87171",
+  colorErrorTextHover: "#f87171",
+  colorErrorTextActive: "#fca5a5",
+  colorLink: "#fafafa",
+  colorText: "#fafafa",
+  colorTextSecondary: "#d4d4d4",
+  colorTextTertiary: "#a3a3a3",
+  colorTextQuaternary: "#737373",
+  colorTextDisabled: "#737373",
+  colorBgContainer: "#0a0a0a",
+  colorBgElevated: "#171717",
+  colorBgLayout: "#000000",
+  colorBgSpotlight: "rgba(64, 64, 64, 0.85)",
+  colorBgMask: "rgba(0, 0, 0, 0.65)",
+  colorBorder: "#262626",
+  colorBorderSecondary: "#171717",
+  borderRadius: 10,
+  borderRadiusXS: 2,
+  borderRadiusSM: 6,
+  borderRadiusLG: 14,
+  padding: 16,
+  paddingSM: 12,
+  paddingLG: 24,
+  margin: 16,
+  marginSM: 12,
+  marginLG: 24,
+  boxShadow: "0 1px 3px 0 rgba(0, 0, 0, 0.5), 0 1px 2px -1px rgba(0, 0, 0, 0.5)",
+  boxShadowSecondary: "0 4px 6px -1px rgba(0, 0, 0, 0.5), 0 2px 4px -2px rgba(0, 0, 0, 0.5)",
+};
+
 export const shadcnThemeComponents = {
   Button: {
     primaryShadow: "none",
@@ -147,5 +212,84 @@ export const shadcnThemeComponents = {
     headerBg: "#fafafa",
     headerSplitColor: "#e5e5e5",
     fontWeightStrong: 600,
+  },
+};
+
+export const shadcnDarkThemeComponents = {
+  Button: {
+    primaryShadow: "none",
+    defaultShadow: "none",
+    dangerShadow: "none",
+    defaultBorderColor: "#27272a",
+    defaultColor: "#fafafa",
+    defaultBg: "#09090b",
+    defaultHoverBg: "#18181b",
+    defaultHoverBorderColor: "#3f3f46",
+    defaultHoverColor: "#fafafa",
+    defaultActiveBg: "#27272a",
+    defaultActiveBorderColor: "#3f3f46",
+    borderRadius: 6,
+  },
+  Input: {
+    activeShadow: "none",
+    hoverBorderColor: "#3f3f46",
+    activeBorderColor: "#d4d4d8",
+    borderRadius: 6,
+  },
+  Select: {
+    optionSelectedBg: "#27272a",
+    optionActiveBg: "#18181b",
+    optionSelectedFontWeight: 500,
+    borderRadius: 6,
+  },
+  Alert: {
+    borderRadiusLG: 8,
+  },
+  Modal: {
+    borderRadiusLG: 12,
+  },
+  Progress: {
+    defaultColor: "#fafafa",
+    remainingColor: "#27272a",
+  },
+  Steps: {
+    iconSize: 32,
+  },
+  Switch: {
+    trackHeight: 24,
+    trackMinWidth: 44,
+    innerMinMargin: 4,
+    innerMaxMargin: 24,
+  },
+  Checkbox: {
+    borderRadiusSM: 4,
+  },
+  Slider: {
+    trackBg: "#27272a",
+    trackHoverBg: "#3f3f46",
+    handleSize: 18,
+    handleSizeHover: 20,
+    railSize: 6,
+  },
+  ColorPicker: {
+    borderRadius: 6,
+  },
+  Menu: {
+    itemFontSize: 14,
+    groupTitleFontSize: 12,
+    itemHeight: 40,
+    fontWeightStrong: 600,
+  },
+  Table: {
+    headerBg: "#18181b",
+    headerSplitColor: "#27272a",
+    fontWeightStrong: 600,
+  },
+  // The organization theme's primary color (near-black by default) is kept
+  // as-is in dark mode, so selected tab labels need an explicit light color.
+  Tabs: {
+    itemSelectedColor: "#fafafa",
+    itemHoverColor: "#d4d4d4",
+    inkBarColor: "#fafafa",
   },
 };


### PR DESCRIPTION
Fixes #5639

## Problem

In dark mode, text on the entry pages (`/login`, `/signup`, `/forget`, etc.) is nearly invisible: the "Auto sign in" checkbox label, the "Forgot password?" link, the signin method tabs and the footer all render as dark gray text (`#262626`) on a near-black background.

Root cause: `shadcnThemeToken` in `web/src/shadcnTheme.js` hardcodes light-theme colors (`colorText`, `colorLink`, `colorBgContainer`, ...) as token overrides. In antd v5, token overrides take precedence over the algorithm output, so even though the entry-page `ConfigProvider` already passes `theme.darkAlgorithm`, every text token stays at its light value. #5415 worked around this on the management page with inline styles, but the entry pages don't go through `ManagementPage` and were left broken.

## Fix

- `web/src/shadcnTheme.js`: add `shadcnDarkThemeToken` / `shadcnDarkThemeComponents` — the same shadcn preset with the neutral color scale flipped for dark backgrounds (shape/typography tokens unchanged).
- `web/src/App.js`: both `ConfigProvider`s select the dark variant via the existing `Setting.isDarkTheme(themeAlgorithm)` helper. The organization theme's `colorPrimary`/`borderRadius` overrides are kept as before.
- `web/src/auth/ForgetPage.js` + `web/src/App.less`: the forget page used the hardcoded white `.forget-content` panel unconditionally; add a `.forget-content-dark` variant, following the existing `login-panel-dark` pattern used by `LoginPage`/`SignupPage`/`ConsentPage`.
- `web/src/ApplicationEditPage.js`: add `.forget-content-dark` to the default Form CSS template, next to the existing `.login-panel-dark` entry.

(The remaining changes in `App.less` are auto-fixes applied by the repo's pre-commit stylelint hook.)

## Screenshots

### Login page, dark mode

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/oxsean/casdoor/497a5d97612ff2271239d46e47b6eca535a4aaa6/before-dark-login.png) | ![after](https://raw.githubusercontent.com/oxsean/casdoor/497a5d97612ff2271239d46e47b6eca535a4aaa6/after-dark-login.png) |

### Login page, light mode (unchanged)

![light](https://raw.githubusercontent.com/oxsean/casdoor/497a5d97612ff2271239d46e47b6eca535a4aaa6/after-light-login.png)

### Forget page & signup page, dark mode (after)

| Forget | Signup |
|---|---|
| ![forget](https://raw.githubusercontent.com/oxsean/casdoor/497a5d97612ff2271239d46e47b6eca535a4aaa6/after-dark-forget-fixed.png) | ![signup](https://raw.githubusercontent.com/oxsean/casdoor/497a5d97612ff2271239d46e47b6eca535a4aaa6/after-dark-signup.png) |

### Management page

Dark mode previously rendered light-theme cards (white tables, white breadcrumb area) inside the dark chrome; with the dark token set it becomes consistently dark. Light mode is unchanged.

| Dark before | Dark after | Light (unchanged) |
|---|---|---|
| ![m-before](https://raw.githubusercontent.com/oxsean/casdoor/497a5d97612ff2271239d46e47b6eca535a4aaa6/before-dark-management.png) | ![m-after](https://raw.githubusercontent.com/oxsean/casdoor/497a5d97612ff2271239d46e47b6eca535a4aaa6/after-dark-management.png) | ![m-light](https://raw.githubusercontent.com/oxsean/casdoor/497a5d97612ff2271239d46e47b6eca535a4aaa6/after-light-management.png) |
