### PR TITLE
feat: fix cramped toolbar buttons and unnecessary scrollbars in admin UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ server
 
 # include helm-chart
 !manifests/casdoor
+
+web/cypress/videos/
+web/cypress/screenshots/

--- a/web/cypress/support/commands.js
+++ b/web/cypress/support/commands.js
@@ -29,7 +29,12 @@ const selector = {
   loginButton: ".ant-btn",
 };
 Cypress.Commands.add('login', ()=>{
-  cy.visit("http://localhost:7001");
+  cy.visit("http://localhost:7001", {
+    onBeforeLoad(win) {
+      // Disable the page tour so its popover never covers elements the tests click
+      win.localStorage.setItem("isTourVisible", "false");
+    },
+  });
   cy.get(selector.username).type("admin");
   cy.get(selector.password).type("123");
   cy.get(selector.loginButton).click();

--- a/web/src/AdapterEditPage.js
+++ b/web/src/AdapterEditPage.js
@@ -319,7 +319,7 @@ class AdapterEditPage extends React.Component {
         {
           this.state.adapter !== null ? this.renderAdapter() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitAdapterEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitAdapterEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
           {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteAdapter()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/AdapterListPage.js
+++ b/web/src/AdapterListPage.js
@@ -227,7 +227,7 @@ class AdapterListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={adapters} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={adapters} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Adapters")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/AgentListPage.js
+++ b/web/src/AgentListPage.js
@@ -196,7 +196,7 @@ class AgentListPage extends BaseListPage {
 
     return (
       <Table
-        scroll={{x: "max-content"}}
+        scroll={{x: true}}
         dataSource={agents}
         columns={filteredColumns}
         rowKey={record => `${record.owner}/${record.name}`}

--- a/web/src/ApplicationListPage.js
+++ b/web/src/ApplicationListPage.js
@@ -329,7 +329,7 @@ class ApplicationListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={filteredColumns} dataSource={applications} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={filteredColumns} dataSource={applications} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Applications")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/CartListPage.js
+++ b/web/src/CartListPage.js
@@ -372,7 +372,7 @@ class CartListPage extends BaseListPage {
     return (
       <div>
         <Table
-          scroll={{x: "max-content"}}
+          scroll={{x: true}}
           columns={columns}
           dataSource={carts}
           rowKey={(record, index) => `${record.name}-${record.pricingName}-${record.planName}-${index}`}

--- a/web/src/CertEditPage.js
+++ b/web/src/CertEditPage.js
@@ -424,7 +424,7 @@ class CertEditPage extends React.Component {
         {
           this.state.cert !== null ? this.renderCert() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitCertEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitCertEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
           {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteCert()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/CertListPage.js
+++ b/web/src/CertListPage.js
@@ -244,7 +244,7 @@ class CertListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={certs} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={certs} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Certs")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/CouponListPage.js
+++ b/web/src/CouponListPage.js
@@ -232,7 +232,7 @@ class CouponListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={coupons} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={coupons} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => {
             const isAdmin = Setting.isLocalAdminUser(this.props.account);
             return (

--- a/web/src/EnforcerEditPage.js
+++ b/web/src/EnforcerEditPage.js
@@ -244,7 +244,7 @@ class EnforcerEditPage extends React.Component {
         {
           this.state.enforcer !== null ? this.renderEnforcer() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitEnforcerEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitEnforcerEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
           {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteEnforcer()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/EnforcerListPage.js
+++ b/web/src/EnforcerListPage.js
@@ -185,7 +185,7 @@ class EnforcerListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={enforcers} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered
+        <Table scroll={{x: true}} columns={columns} dataSource={enforcers} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered
           pagination={paginationProps}
           title={() => (
             <div>

--- a/web/src/EntryListPage.js
+++ b/web/src/EntryListPage.js
@@ -304,7 +304,7 @@ class EntryListPage extends BaseListPage {
 
     return (
       <Table
-        scroll={{x: "max-content"}}
+        scroll={{x: true}}
         dataSource={entries}
         columns={filteredColumns}
         rowKey={record => `${record.owner}/${record.name}`}

--- a/web/src/FormEditPage.js
+++ b/web/src/FormEditPage.js
@@ -213,7 +213,7 @@ class FormEditPage extends React.Component {
         {
           this.state.form !== null ? this.renderForm() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitFormEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large"
             onClick={() => this.submitFormEdit(true)}>{i18next.t("general:Save & Exit")}</Button>

--- a/web/src/FormListPage.js
+++ b/web/src/FormListPage.js
@@ -193,7 +193,7 @@ class FormListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={forms}
+        <Table scroll={{x: true}} columns={columns} dataSource={forms}
           rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered
           pagination={paginationProps}
           title={() => (

--- a/web/src/GroupEditPage.js
+++ b/web/src/GroupEditPage.js
@@ -273,7 +273,7 @@ class GroupEditPage extends React.Component {
         {
           this.state.group !== null ? this.renderGroup() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitGroupEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitGroupEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
           {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteGroup()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/GroupListPage.js
+++ b/web/src/GroupListPage.js
@@ -186,7 +186,7 @@ class GroupListPage extends BaseListPage {
           onCancel={() => {this.setState({showUploadModal: false, uploadJsonData: [], uploadColumns: []});}}
         >
           <div style={{marginRight: "34px"}}>
-            <Table scroll={{x: "max-content"}} dataSource={this.state.uploadJsonData} columns={this.state.uploadColumns} />
+            <Table scroll={{x: true}} dataSource={this.state.uploadJsonData} columns={this.state.uploadColumns} />
           </div>
         </Modal>
       </>
@@ -333,7 +333,7 @@ class GroupListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={data} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={data} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Groups")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/InvitationEditPage.js
+++ b/web/src/InvitationEditPage.js
@@ -389,7 +389,7 @@ class InvitationEditPage extends React.Component {
         {
           this.state.invitation !== null ? this.renderInvitation() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitInvitationEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitInvitationEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
           {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteInvitation()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/InvitationListPage.js
+++ b/web/src/InvitationListPage.js
@@ -254,7 +254,7 @@ class InvitationListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={invitations} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={invitations} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Invitations")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/KeyEditPage.js
+++ b/web/src/KeyEditPage.js
@@ -303,7 +303,7 @@ class KeyEditPage extends React.Component {
         {
           this.state.key !== null ? this.renderKey() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitKeyEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitKeyEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
         </div>

--- a/web/src/KeyListPage.js
+++ b/web/src/KeyListPage.js
@@ -200,7 +200,7 @@ class KeyListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={keys} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={keys} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Keys")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/LdapEditPage.js
+++ b/web/src/LdapEditPage.js
@@ -338,7 +338,7 @@ class LdapEditPage extends React.Component {
         {
           this.state.ldap !== null ? this.renderLdap() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitLdapEdit()}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitLdapEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
         </div>

--- a/web/src/LdapSyncPage.js
+++ b/web/src/LdapSyncPage.js
@@ -245,7 +245,7 @@ class LdapSyncPage extends React.Component {
         {
           this.renderTable(this.state.users)
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => {
             this.props.history.push(`/organizations/${this.state.organizationName}`);
           }}>

--- a/web/src/ManagementPage.js
+++ b/web/src/ManagementPage.js
@@ -683,7 +683,7 @@ function ManagementPage(props) {
           </div>
         </Sider>
       )}
-      <div style={{marginLeft: contentMarginLeft, transition: "margin-left 0.2s", display: "flex", flexDirection: "column", minHeight: "100vh"}}>
+      <div style={{marginLeft: contentMarginLeft, transition: "margin-left 0.2s", display: "flex", flexDirection: "column", flex: 1}}>
         <Header style={{display: "flex", justifyContent: "space-between", alignItems: "center", padding: "0", marginBottom: "4px", backgroundColor: isDark ? "black" : "white", color: textColor, position: "sticky", top: 0, zIndex: 99, boxShadow: "0 1px 4px rgba(0,0,0,0.08)", height: "52px", lineHeight: "52px"}}>
           <div style={{display: "flex", alignItems: "center"}}>
             {props.requiredEnableMfa ? null : (Setting.isMobile() ? (

--- a/web/src/ModelEditPage.js
+++ b/web/src/ModelEditPage.js
@@ -201,7 +201,7 @@ class ModelEditPage extends React.Component {
         {
           this.state.model !== null ? this.renderModel() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitModelEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitModelEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
           {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteModel()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/ModelListPage.js
+++ b/web/src/ModelListPage.js
@@ -191,7 +191,7 @@ class ModelListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={models} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered
+        <Table scroll={{x: true}} columns={columns} dataSource={models} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered
           pagination={paginationProps}
           title={() => (
             <div>

--- a/web/src/OrderEditPage.js
+++ b/web/src/OrderEditPage.js
@@ -286,7 +286,7 @@ class OrderEditPage extends React.Component {
           this.state.order !== null ? this.renderOrder() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
         {this.state.mode !== "view" && (
-          <div style={{marginTop: "20px", marginLeft: "40px"}}>
+          <div style={{margin: "20px 40px"}}>
             <Button size="large" onClick={() => this.submitOrderEdit(false)}>{i18next.t("general:Save")}</Button>
             <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitOrderEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
             {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteOrder()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/OrderListPage.js
+++ b/web/src/OrderListPage.js
@@ -283,7 +283,7 @@ class OrderListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={orders} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={orders} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => {
             const isAdmin = Setting.isLocalAdminUser(this.props.account);
             return (

--- a/web/src/OrganizationEditPage.js
+++ b/web/src/OrganizationEditPage.js
@@ -919,7 +919,7 @@ class OrganizationEditPage extends React.Component {
             <TransactionTable transactions={this.state.transactions} includeUser={true} />
           </Card>
         ) : null}
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitOrganizationEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitOrganizationEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
           {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteOrganization()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/OrganizationListPage.js
+++ b/web/src/OrganizationListPage.js
@@ -339,7 +339,7 @@ class OrganizationListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={filteredColumns} dataSource={organizations} rowKey="name" size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={filteredColumns} dataSource={organizations} rowKey="name" size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Organizations")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/PaymentEditPage.js
+++ b/web/src/PaymentEditPage.js
@@ -505,7 +505,7 @@ class PaymentEditPage extends React.Component {
           this.renderModal()
         }
         {this.state.mode !== "view" && (
-          <div style={{marginTop: "20px", marginLeft: "40px"}}>
+          <div style={{margin: "20px 40px"}}>
             <Button size="large" onClick={() => this.submitPaymentEdit(false)}>{i18next.t("general:Save")}</Button>
             <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitPaymentEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
             {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deletePayment()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/PaymentListPage.js
+++ b/web/src/PaymentListPage.js
@@ -280,7 +280,7 @@ class PaymentListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={payments} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={payments} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => {
             const isAdmin = Setting.isLocalAdminUser(this.props.account);
             return (

--- a/web/src/PermissionEditPage.js
+++ b/web/src/PermissionEditPage.js
@@ -561,7 +561,7 @@ class PermissionEditPage extends React.Component {
         {
           this.state.permission !== null ? this.renderPermission() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitPermissionEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitPermissionEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
           {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deletePermission()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/PermissionListPage.js
+++ b/web/src/PermissionListPage.js
@@ -183,7 +183,7 @@ class PermissionListPage extends BaseListPage {
           onCancel={() => {this.setState({showUploadModal: false, uploadJsonData: [], uploadColumns: []});}}
         >
           <div style={{marginRight: "34px"}}>
-            <Table scroll={{x: "max-content"}} dataSource={this.state.uploadJsonData} columns={this.state.uploadColumns} />
+            <Table scroll={{x: true}} dataSource={this.state.uploadJsonData} columns={this.state.uploadColumns} />
           </div>
         </Modal>
       </>
@@ -473,7 +473,7 @@ class PermissionListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={permissions} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={permissions} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Permissions")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/PlanEditPage.js
+++ b/web/src/PlanEditPage.js
@@ -302,7 +302,7 @@ class PlanEditPage extends React.Component {
           this.state.plan !== null ? this.renderPlan() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
         {this.state.mode !== "view" && (
-          <div style={{marginTop: "20px", marginLeft: "40px"}}>
+          <div style={{margin: "20px 40px"}}>
             <Button size="large" onClick={() => this.submitPlanEdit(false)}>{i18next.t("general:Save")}</Button>
             <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitPlanEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
             {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deletePlan()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/PlanListPage.js
+++ b/web/src/PlanListPage.js
@@ -218,7 +218,7 @@ class PlanListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={plans} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={plans} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => {
             const isAdmin = Setting.isLocalAdminUser(this.props.account);
             return (

--- a/web/src/PricingEditPage.js
+++ b/web/src/PricingEditPage.js
@@ -277,7 +277,7 @@ class PricingEditPage extends React.Component {
           this.state.pricing !== null ? this.renderPricing() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
         {this.state.mode !== "view" && (
-          <div style={{marginTop: "20px", marginLeft: "40px"}}>
+          <div style={{margin: "20px 40px"}}>
             <Button size="large" onClick={() => this.submitPricingEdit(false)}>{i18next.t("general:Save")}</Button>
             <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitPricingEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
             {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deletePricing()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/PricingListPage.js
+++ b/web/src/PricingListPage.js
@@ -217,7 +217,7 @@ class PricingListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={pricings} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={pricings} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => {
             const isAdmin = Setting.isLocalAdminUser(this.props.account);
             return (

--- a/web/src/ProductEditPage.js
+++ b/web/src/ProductEditPage.js
@@ -422,7 +422,7 @@ class ProductEditPage extends React.Component {
           this.state.product !== null ? this.renderProduct() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
         {this.state.mode !== "view" && (
-          <div style={{marginTop: "20px", marginLeft: "40px"}}>
+          <div style={{margin: "20px 40px"}}>
             <Button size="large" onClick={() => this.submitProductEdit(false)}>{i18next.t("general:Save")}</Button>
             <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitProductEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
             {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteProduct()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/ProductListPage.js
+++ b/web/src/ProductListPage.js
@@ -278,7 +278,7 @@ class ProductListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={products} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={products} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => {
             const isAdmin = Setting.isLocalAdminUser(this.props.account);
             return (

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -1246,7 +1246,7 @@ class ProviderEditPage extends React.Component {
         {
           this.state.provider !== null ? this.renderProvider() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitProviderEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitProviderEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
           {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteProvider()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/ProviderListPage.js
+++ b/web/src/ProviderListPage.js
@@ -239,7 +239,7 @@ class ProviderListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={filteredColumns} dataSource={providers} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={filteredColumns} dataSource={providers} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("application:Providers")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/ResourceListPage.js
+++ b/web/src/ResourceListPage.js
@@ -290,7 +290,7 @@ class ResourceListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={resources} rowKey="name" size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={resources} rowKey="name" size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Resources")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/RoleEditPage.js
+++ b/web/src/RoleEditPage.js
@@ -275,7 +275,7 @@ class RoleEditPage extends React.Component {
         {
           this.state.role !== null ? this.renderRole() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitRoleEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitRoleEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
           {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteRole()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/RoleListPage.js
+++ b/web/src/RoleListPage.js
@@ -174,7 +174,7 @@ class RoleListPage extends BaseListPage {
           onCancel={() => {this.setState({showUploadModal: false, uploadJsonData: [], uploadColumns: []});}}
         >
           <div style={{marginRight: "34px"}}>
-            <Table scroll={{x: "max-content"}} dataSource={this.state.uploadJsonData} columns={this.state.uploadColumns} />
+            <Table scroll={{x: true}} dataSource={this.state.uploadJsonData} columns={this.state.uploadColumns} />
           </div>
         </Modal>
       </>
@@ -316,7 +316,7 @@ class RoleListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={roles} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={roles} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Roles")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/ServerListPage.js
+++ b/web/src/ServerListPage.js
@@ -305,7 +305,7 @@ class ServerListPage extends BaseListPage {
     return (
       <>
         <Table
-          scroll={{x: "max-content"}}
+          scroll={{x: true}}
           dataSource={servers}
           columns={filteredColumns}
           rowKey={record => `${record.owner}/${record.name}`}

--- a/web/src/SessionListPage.js
+++ b/web/src/SessionListPage.js
@@ -148,7 +148,7 @@ class SessionListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={sessions} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={sessions} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Sessions")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/SubscriptionEditPage.js
+++ b/web/src/SubscriptionEditPage.js
@@ -344,7 +344,7 @@ class SubscriptionEditPage extends React.Component {
           this.state.subscription !== null ? this.renderSubscription() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
         {this.state.mode !== "view" && (
-          <div style={{marginTop: "20px", marginLeft: "40px"}}>
+          <div style={{margin: "20px 40px"}}>
             <Button size="large" onClick={() => this.submitSubscriptionEdit(false)}>{i18next.t("general:Save")}</Button>
             <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitSubscriptionEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
             {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteSubscription()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/SubscriptionListPage.js
+++ b/web/src/SubscriptionListPage.js
@@ -257,7 +257,7 @@ class SubscriptionListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={subscriptions} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={subscriptions} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => {
             const isAdmin = Setting.isLocalAdminUser(this.props.account);
             return (

--- a/web/src/SyncerEditPage.js
+++ b/web/src/SyncerEditPage.js
@@ -1247,7 +1247,7 @@ class SyncerEditPage extends React.Component {
         {
           this.state.syncer !== null ? this.renderSyncer() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitSyncerEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitSyncerEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
           {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteSyncer()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/SyncerListPage.js
+++ b/web/src/SyncerListPage.js
@@ -262,7 +262,7 @@ class SyncerListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={syncers} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={syncers} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Syncers")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/TicketListPage.js
+++ b/web/src/TicketListPage.js
@@ -200,7 +200,7 @@ class TicketListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={tickets} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={tickets} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Tickets")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/TokenEditPage.js
+++ b/web/src/TokenEditPage.js
@@ -271,7 +271,7 @@ class TokenEditPage extends React.Component {
         {
           this.state.token !== null ? this.renderToken() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitTokenEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitTokenEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
           {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteToken()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/TransactionEditPage.js
+++ b/web/src/TransactionEditPage.js
@@ -406,7 +406,7 @@ class TransactionEditPage extends React.Component {
           this.state.transaction !== null ? (
             <>
               {this.renderTransaction()}
-              <div style={{marginTop: "20px", marginLeft: "40px"}}>
+              <div style={{margin: "20px 40px"}}>
                 <Button size="large" onClick={() => this.submitTransactionEdit(false)}>{i18next.t("general:Save")}</Button>
                 <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitTransactionEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
                 {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteTransaction()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/TransactionListPage.js
+++ b/web/src/TransactionListPage.js
@@ -139,7 +139,7 @@ class TransactionListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={transactions} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={transactions} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => {
             const isAdmin = Setting.isLocalAdminUser(this.props.account);
             return (

--- a/web/src/UserEditPage.js
+++ b/web/src/UserEditPage.js
@@ -1606,7 +1606,7 @@ class UserEditPage extends React.Component {
         }
         {
           (this.state.user === null || this.props.account === null) ? null :
-            <div style={{marginTop: "20px", marginLeft: "40px"}}>
+            <div style={{margin: "20px 40px"}}>
               <Button size="large" onClick={() => this.submitUserEdit(false)}>{i18next.t("general:Save")}</Button>
               <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitUserEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
               {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteUser()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/UserListPage.js
+++ b/web/src/UserListPage.js
@@ -273,7 +273,7 @@ class UserListPage extends BaseListPage {
           onCancel={() => {this.setState({showUploadModal: false, uploadJsonData: [], uploadColumns: []});}}
         >
           <div style={{marginRight: "34px"}}>
-            <Table scroll={{x: "max-content"}} dataSource={this.state.uploadJsonData} columns={this.state.uploadColumns} />
+            <Table scroll={{x: true}} dataSource={this.state.uploadJsonData} columns={this.state.uploadColumns} />
           </div>
         </Modal>
       </>
@@ -584,7 +584,7 @@ class UserListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={filteredColumns} dataSource={users} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={filteredColumns} dataSource={users} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Users")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/VerificationListPage.js
+++ b/web/src/VerificationListPage.js
@@ -169,7 +169,7 @@ class VerificationListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={verifications} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={verifications} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Verifications")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/WebhookEditPage.js
+++ b/web/src/WebhookEditPage.js
@@ -397,7 +397,7 @@ class WebhookEditPage extends React.Component {
         {
           this.state.webhook !== null ? this.renderWebhook() : <Loading type="page" tip={i18next.t("login:Loading")} />
         }
-        <div style={{marginTop: "20px", marginLeft: "40px"}}>
+        <div style={{margin: "20px 40px"}}>
           <Button size="large" onClick={() => this.submitWebhookEdit(false)}>{i18next.t("general:Save")}</Button>
           <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitWebhookEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
           {this.state.mode === "add" ? <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.deleteWebhook()}>{i18next.t("general:Cancel")}</Button> : null}

--- a/web/src/WebhookEventListPage.js
+++ b/web/src/WebhookEventListPage.js
@@ -303,7 +303,7 @@ class WebhookEventListPage extends React.Component {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={this.state.data} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={this.state.data} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Webhook Events")}

--- a/web/src/WebhookListPage.js
+++ b/web/src/WebhookListPage.js
@@ -234,7 +234,7 @@ class WebhookListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={webhooks} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: true}} columns={columns} dataSource={webhooks} rowKey={(record) => `${record.owner}/${record.name}`} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Webhooks")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,12 +1,17 @@
+/* stylelint-disable no-descending-specificity */
+
 @import "@fontsource-variable/inter/opsz.css";
 @import "@fontsource-variable/inter/opsz-italic.css";
 
 /* AI-themed loading dots animation used by common/Loading.js */
 @keyframes casdoor-ai-bounce {
-  0%, 60%, 100% {
+  0%,
+  60%,
+  100% {
     transform: translateY(0) scale(0.85);
     opacity: 0.5;
   }
+
   30% {
     transform: translateY(-10px) scale(1.1);
     opacity: 1;
@@ -49,7 +54,18 @@ code {
 }
 
 .ant-table.ant-table-medium .ant-table-title {
-  padding: 5px 8px !important;
+  padding: 8px 12px !important;
+}
+
+/* Size the small toolbar buttons in table title bars (Add, Upload, ...) like default buttons, matching the row action buttons */
+.ant-table-title .ant-btn-sm {
+  height: 32px;
+  padding-inline: 15px;
+}
+
+/* Edit page cards put 32px buttons in their 38px title bar; give them room to breathe */
+.ant-card-small > .ant-card-head {
+  min-height: 46px !important;
 }
 
 .ant-table.ant-table-medium .ant-table-footer,
@@ -103,19 +119,19 @@ a.ant-typography-link:active {
 }
 
 /* Raw <a> tags without Ant Design classes (table cell links, mailto, plain hrefs, etc.) */
-a:not([class]):not(.login-link),
+a:not([class], .login-link),
 a[class=""],
 a[href^="mailto:"] {
   transition: opacity 0.2s ease;
 }
 
-a:not([class]):not(.login-link):hover,
+a:not([class], .login-link):hover,
 a[class=""]:hover,
 a[href^="mailto:"]:hover {
   opacity: 0.65;
 }
 
-a:not([class]):not(.login-link):active,
+a:not([class], .login-link):active,
 a[class=""]:active,
 a[href^="mailto:"]:active {
   opacity: 0.4;
@@ -244,8 +260,8 @@ a[href^="mailto:"]:active {
 
 /* Sidebar menu: selected item - darker background */
 .ant-layout-sider .ant-menu-light .ant-menu-item-selected,
-.ant-layout-sider .ant-menu-light>.ant-menu .ant-menu-item-selected {
-  background-color: rgba(0, 0, 0, 0.15) !important;
+.ant-layout-sider .ant-menu-light > .ant-menu .ant-menu-item-selected {
+  background-color: rgb(0 0 0 / 15%) !important;
 }
 
 /* Sidebar menu container: hide scrollbar but keep scroll behavior */
@@ -253,6 +269,7 @@ a[href^="mailto:"]:active {
   scrollbar-width: none; /* Firefox */
   -ms-overflow-style: none; /* IE/Edge */
 }
+
 .sider-menu-container::-webkit-scrollbar {
   display: none; /* Chrome/Safari/WebKit */
 }
@@ -262,5 +279,18 @@ a[href^="mailto:"]:active {
 .ant-message .ant-message-notice-content,
 .ant-message .ant-message-custom-content,
 .ant-message .ant-message-custom-content span {
-  font-family: "Inter Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif !important;
+  font-family:
+    "Inter Variable",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    "Helvetica Neue",
+    sans-serif !important;
+}
+
+/* Table cells never wrap (scroll.x handles overflow), so shrinking only absorbs column padding */
+.ant-table-tbody > tr > td,
+.ant-table-thead > tr > th {
+  white-space: nowrap;
 }


### PR DESCRIPTION
## Problems

Four long-standing layout annoyances in the admin console:

1. **Forced horizontal scrollbars on list pages**: every list page passes `scroll={{x: "max-content"}}`, which makes the table *always* as wide as the sum of the column `width`s — the design widths act as hard floors even when the viewport has room. E.g. the Certs table forced a scrollbar for 75 extra pixels while cells held values like `4096` in a 130px column.
2. **A permanent vertical scrollbar on every page**: `ManagementPage` wraps its content in a `minHeight: 100vh` div, but that div lives inside `#parent-area` (also `min-height: 100vh`) **together with the 68px footer** — so every page overflows by exactly the footer height, even a page with one table row, and the footer is permanently pushed below the fold.
3. **Cramped list page toolbars**: the buttons in every list page's table title bar (`Add`, `Upload (.xlsx)`, ...) are `size="small"` (24px high, 7px inline padding) inside a title bar whose padding is crushed to `5px 8px`, right next to the full-size row action buttons (`Edit`, `Delete`, 32px), which makes the mismatch obvious.
4. **Cramped edit pages**: the card title bar is 38px tall but holds 32px `Save` / `Save & Exit` buttons (3px of air), and the bottom button row has no bottom margin, so it sits **1px** away from the card's bottom border.

## Fix

All column `width` definitions are kept untouched — only the scroll mode changes:

- `web/src/*ListPage.js` (36 files, one line each): `scroll={{x: "max-content"}}` → `scroll={{x: true}}`. The table now renders `width: auto; min-width: 100%`, so the column widths act as *preferred* widths: honored when the viewport has room, shrunk proportionally (never below content) when it doesn't. Tables only scroll when the actual content genuinely exceeds the viewport (e.g. Users with its 20+ columns), and `fixed` (sticky) columns keep working.
- `web/src/index.css`: table cells get `white-space: nowrap` so shrinking only ever absorbs column padding, never wraps content (under `x: "max-content"` nothing could wrap anyway, so this is the status quo made explicit). Also: table title bars get `8px 12px` padding, their small toolbar buttons are sized like default buttons (32px high, 15px inline padding) to match the row action buttons, and small card title bars get `min-height: 46px`.
- `web/src/ManagementPage.js` (one line): content wrapper `minHeight: "100vh"` → `flex: 1`, so content + footer fill exactly one viewport. Short pages no longer scroll and the footer is visible; long pages scroll exactly as before.
- `web/src/*EditPage.js` (25 files, one line each): bottom button row `{marginTop: "20px", marginLeft: "40px"}` → `{margin: "20px 40px"}` for symmetric breathing room above the card's bottom edge.

- `web/cypress/support/commands.js`: the shared `login` command now disables the page tour (`isTourVisible=false`), so the tour popover can never cover elements the tests click — the tokens spec only passed by geometric accident before.

Verified locally on organizations / users / applications / providers / certs / roles / permissions / tokens / webhooks / syncers / sessions / invitations plus the token edit page, a long edit page (`/organizations/built-in`), and a 900px-wide viewport for the sticky-column / genuine-overflow cases.

(`index.css` also picks up the repo's own `stylelint --fix` corrections, a wrapped over-long line, and a file-level `no-descending-specificity` disable for pre-existing selector ordering — the pre-commit hook refuses any commit touching the file otherwise; same approach as the existing disables in `App.less`.)

## Screenshots (1680×1000)

### Certs list — scrollbar gone, columns keep their design proportions, footer on screen, toolbar matches row buttons

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/oxsean/casdoor/46883ab8d8eb821acd6ee966481f0a05b8ba5529/before-certs.png) | ![after](https://raw.githubusercontent.com/oxsean/casdoor/46883ab8d8eb821acd6ee966481f0a05b8ba5529/after-certs.png) |

### Organizations list — wide table still scrolls (legitimately), no vertical scrollbar

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/oxsean/casdoor/46883ab8d8eb821acd6ee966481f0a05b8ba5529/before-orgs.png) | ![after](https://raw.githubusercontent.com/oxsean/casdoor/46883ab8d8eb821acd6ee966481f0a05b8ba5529/after-orgs.png) |

### Token edit page — title bar and bottom buttons breathe

| Before (top) | After (top) |
|---|---|
| ![before](https://raw.githubusercontent.com/oxsean/casdoor/46883ab8d8eb821acd6ee966481f0a05b8ba5529/before-edit-top.png) | ![after](https://raw.githubusercontent.com/oxsean/casdoor/46883ab8d8eb821acd6ee966481f0a05b8ba5529/after-edit-top.png) |

| Before (bottom) | After (bottom) |
|---|---|
| ![before](https://raw.githubusercontent.com/oxsean/casdoor/46883ab8d8eb821acd6ee966481f0a05b8ba5529/before-edit-bottom.png) | ![after](https://raw.githubusercontent.com/oxsean/casdoor/46883ab8d8eb821acd6ee966481f0a05b8ba5529/after-edit-bottom.png) |
