### PR TITLE
feat: add org option to output LDAP memberOf as valid DN

### DIFF
--- a/ldap/server.go
+++ b/ldap/server.go
@@ -288,7 +288,11 @@ func buildUserSearchEntry(user *object.User, baseDN string, attrs []string, org 
 	e.AddAttribute("objectClass", "posixAccount")
 	if IsLdapAttrAllowed(org, ldapMemberOfAttr) {
 		for _, group := range user.Groups {
-			e.AddAttribute(ldapMemberOfAttr, message.AttributeValue(group))
+			value := group
+			if org != nil && org.LdapMemberOfDn {
+				value = groupToDN(group, baseDN)
+			}
+			e.AddAttribute(ldapMemberOfAttr, message.AttributeValue(value))
 		}
 	}
 	for _, attr := range attrs {
@@ -338,6 +342,19 @@ func handleRootSearch(w ldap.ResponseWriter, r *message.SearchRequest, res *mess
 	}
 
 	w.Write(res)
+}
+
+// groupToDN converts a Casdoor group id "owner/name" into the group's LDAP
+// entry DN "cn=name,<baseDN>", the same DN a group search returns (see the
+// posixGroup branch in handleSearch). The "owner/" prefix is dropped from the
+// cn so standard LDAP clients, which parse memberOf as a DN and read the
+// leftmost RDN, get the bare group name for role mapping.
+func groupToDN(group, baseDN string) string {
+	name := group
+	if i := strings.Index(group, "/"); i >= 0 {
+		name = group[i+1:]
+	}
+	return fmt.Sprintf("cn=%s,%s", name, baseDN)
 }
 
 func hash(s string) uint32 {

--- a/ldap/server_test.go
+++ b/ldap/server_test.go
@@ -1,0 +1,35 @@
+// Copyright 2022 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ldap
+
+import "testing"
+
+func TestGroupToDN(t *testing.T) {
+	cases := []struct {
+		group, baseDN, want string
+	}{
+		// owner/ prefix dropped from cn; DN matches the group-search entry DN
+		{"devops/dev", "ou=devops,dc=example,dc=com", "cn=dev,ou=devops,dc=example,dc=com"},
+		// group id without an owner prefix is used as-is for the cn
+		{"dev", "ou=devops,dc=example,dc=com", "cn=dev,ou=devops,dc=example,dc=com"},
+		// base without a dc suffix
+		{"devops/dev", "ou=devops", "cn=dev,ou=devops"},
+	}
+	for _, c := range cases {
+		if got := groupToDN(c.group, c.baseDN); got != c.want {
+			t.Errorf("groupToDN(%q, %q) = %q, want %q", c.group, c.baseDN, got, c.want)
+		}
+	}
+}

--- a/ldap/util.go
+++ b/ldap/util.go
@@ -250,6 +250,11 @@ func buildUserFilterCondition(filter interface{}) (builder.Cond, error) {
 		if attr == ldapMemberOfAttr {
 			var names []string
 			groupId := string(f.AssertionValue())
+			if strings.Contains(groupId, "cn=") {
+				if name, org, err := getNameAndOrgFromDN(groupId); err == nil {
+					groupId = util.GetId(org, name)
+				}
+			}
 			users := object.GetGroupUsersWithoutError(groupId)
 			for _, user := range users {
 				names = append(names, user.Name)

--- a/object/organization.go
+++ b/object/organization.go
@@ -96,6 +96,7 @@ type Organization struct {
 	DcrPolicy string `xorm:"varchar(100)" json:"dcrPolicy"`
 
 	LdapAttributes []string `xorm:"mediumtext" json:"ldapAttributes"`
+	LdapMemberOfDn bool     `xorm:"bool" json:"ldapMemberOfDn"`
 
 	KerberosRealm       string `xorm:"varchar(200)" json:"kerberosRealm"`
 	KerberosKdcHost     string `xorm:"varchar(200)" json:"kerberosKdcHost"`

--- a/web/src/OrganizationEditPage.js
+++ b/web/src/OrganizationEditPage.js
@@ -796,6 +796,16 @@ class OrganizationEditPage extends React.Component {
           </Col>
         </Row>
         <Row style={{marginTop: "20px"}}>
+          <Col style={{lineHeight: "32px", textAlign: "right", paddingRight: "25px"}} span={(Setting.isMobile()) ? 22 : 2}>
+            {Setting.getLabel(i18next.t("organization:LDAP memberOf as DN"), i18next.t("organization:LDAP memberOf as DN - Tooltip"))} :
+          </Col>
+          <Col span={22}>
+            <Switch checked={!!this.state.organization.ldapMemberOfDn} onChange={checked => {
+              this.updateOrganizationField("ldapMemberOfDn", checked);
+            }} />
+          </Col>
+        </Row>
+        <Row style={{marginTop: "20px"}}>
           <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
             {Setting.getLabel(i18next.t("general:LDAPs"), i18next.t("general:LDAPs - Tooltip"))} :
           </Col>

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -967,6 +967,8 @@
     "Kerberos service name - Tooltip": "The Kerberos service principal name (defaults to HTTP)",
     "LDAP attributes": "LDAP attributes",
     "LDAP attributes - Tooltip": "Mapping of LDAP directory attributes to Casdoor user fields for directory synchronization",
+    "LDAP memberOf as DN": "LDAP memberOf as DN",
+    "LDAP memberOf as DN - Tooltip": "When enabled, the built-in LDAP server returns memberOf as a valid LDAP DN (cn=group,ou=org,...) instead of the raw \"owner/name\" group id, so standard LDAP clients can parse group membership. Disabled by default for backward compatibility",
     "Modify rule": "Modify rule",
     "New Organization": "New Organization",
     "Optional": "Optional",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -967,6 +967,8 @@
     "Kerberos service name - Tooltip": "Kerberos服务主体名称（默认为HTTP）",
     "LDAP attributes": "LDAP属性",
     "LDAP attributes - Tooltip": "LDAP目录属性到Casdoor用户字段的映射，用于目录同步",
+    "LDAP memberOf as DN": "LDAP memberOf 输出为 DN",
+    "LDAP memberOf as DN - Tooltip": "开启后，内置 LDAP server 的 memberOf 返回合法的 LDAP DN（cn=组,ou=组织,...），而非原始的 \"owner/name\" 组 id，便于标准 LDAP 客户端解析组成员关系。默认关闭以保持向后兼容",
     "Modify rule": "修改规则",
     "New Organization": "添加组织",
     "Optional": "可选",


### PR DESCRIPTION
### Problem

The built-in LDAP server returns `memberOf` as the raw Casdoor group id `owner/name` (e.g. `devops/dev`), which is **not a valid LDAP DN**. Standard LDAP clients that parse `memberOf` as a DN — e.g. Nexus Repository's dynamic group mapping (`userMemberOfAttribute`) — extract the RDN and crash with `IndexOutOfBounds` on `devops/dev`, taking down the Nexus user-list UI.

### Fix

Add an opt-in per-organization option **`ldapMemberOfDn` (default off)**. When enabled, `memberOf` is output as a valid DN `cn=<group>,ou=<owner>,<dc-suffix>` — matching the `posixGroup` entry DN already returned by group searches (`ldap/server.go`) and the format Casdoor's own LDAP client parses (`dnToGroupName` in `object/ldap_conn.go`). Clients can then extract the group name (`dev`) for role mapping.

The reverse `(memberOf=...)` filter also accepts the DN form, for round-trip consistency.

**Backward compatible:** default-off, existing setups return `owner/name` unchanged.

### Verification

- `go build ./...`
- Unit test `TestGroupToDN` (normal, cross-org, no-prefix, no-dc)
- Live `ldapsearch` against the built-in server:
  - off → `memberOf: devops/dev`
  - on  → `memberOf: cn=dev,ou=devops,dc=example,dc=com`
- UI round-trip: org-edit switch (default off) → toggle on → Save → persisted

### UI

A new "LDAP memberOf as DN" switch on the organization edit page, between "LDAP attributes" and "LDAPs". i18n added for en and zh.
