### PR TITLE
fix: serve uploaded files with sandbox, nosniff and attachment headers

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,6 +99,7 @@ func main() {
 	// https://studygolang.com/articles/2303
 	web.InsertFilter("*", web.BeforeStatic, routers.RequestBodyFilter)
 	web.InsertFilter("*", web.BeforeStatic, routers.ContentTypeFilter)
+	web.InsertFilter("*", web.BeforeStatic, routers.StaticFilesFilter)
 	web.InsertFilter("*", web.BeforeRouter, routers.StaticFilter)
 	web.InsertFilter("*", web.BeforeRouter, routers.AutoSigninFilter)
 	web.InsertFilter("*", web.BeforeRouter, routers.CorsFilter)

--- a/routers/static_files_filter.go
+++ b/routers/static_files_filter.go
@@ -1,0 +1,77 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routers
+
+import (
+	"path"
+	"strings"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+const uploadedFilesPrefix = "/files/"
+
+// activeContentExts lists the extensions a browser renders as an *active
+// document* (one that can run script) when the URL is opened directly.
+// A resource uploaded through /api/upload-resource is served from the public
+// "/files" static path, so without these headers an .svg containing
+// <script> executes in the origin of the Casdoor server itself and can drive
+// the whole API with the session cookie of whoever opens the link.
+var activeContentExts = map[string]bool{
+	".htm":   true,
+	".html":  true,
+	".mht":   true,
+	".mhtml": true,
+	".svg":   true,
+	".svgz":  true,
+	".swf":   true,
+	".xht":   true,
+	".xhtml": true,
+	".xml":   true,
+	".xsl":   true,
+	".xslt":  true,
+}
+
+// StaticFilesFilter hardens the response headers of the "/files" static path,
+// which serves user-uploaded resources.
+//
+// It has to be registered at web.BeforeStatic, i.e. before serverStaticRouter()
+// hands the file to http.ServeContent(): ServeContent only infers a
+// Content-Type when the header is not set yet, so whatever is set here wins.
+//
+// The headers are chosen so that uploads keep working as images (<img src>
+// ignores both CSP and Content-Disposition, so avatars still render) while a
+// direct navigation to an uploaded file can no longer touch the Casdoor origin:
+//
+//   - "sandbox" puts the document in an opaque origin and, without
+//     "allow-scripts", disables script execution altogether.
+//   - "nosniff" stops the browser from upgrading e.g. a .txt upload to
+//     text/html by content sniffing.
+//   - "Content-Disposition: attachment" makes the active content types above
+//     download instead of render, for browsers that do not support CSP sandbox.
+func StaticFilesFilter(ctx *context.Context) {
+	urlPath := ctx.Request.URL.Path
+	if !strings.HasPrefix(urlPath, uploadedFilesPrefix) {
+		return
+	}
+
+	header := ctx.ResponseWriter.Header()
+	header.Set("X-Content-Type-Options", "nosniff")
+	header.Set("Content-Security-Policy", "default-src 'none'; sandbox")
+
+	if activeContentExts[strings.ToLower(path.Ext(urlPath))] {
+		header.Set("Content-Disposition", "attachment")
+	}
+}


### PR DESCRIPTION
### Summary

Anything stored through `/api/upload-resource` is served back from the public `/files` static path with no protective headers. An uploaded `.svg` is an XML *document*, so opening its URL executes any `<script>` it contains as a first-party document on the Casdoor server's own origin — with the session cookie of whoever opened the link. From there the API is reachable as that user: `/api/update-user`, `/api/set-password`, `/api/add-user`, token issuance, and so on.

Uploading is available to any signed-in user, and the resulting URL is attacker-chosen and stable, so this is a stored XSS against every visitor who opens it — including administrators.

### Details

`main.go` publishes the upload directory as a static path:

```go
web.SetStaticPath("/files", "files")
```

Beego derives the `Content-Type` from the file extension and adds nothing else. Against current `master` (`8bb6c39`):

```
$ curl -sD- -o/dev/null http://localhost:8000/files/probe.svg
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 194
Content-Type: image/svg+xml
Last-Modified: Mon, 27 Jul 2026 10:51:46 GMT
Server: beegoServer:2.0.0
```

No `X-Content-Type-Options`, no `Content-Security-Policy`, no `Content-Disposition`. `routers/content_type_filter.go` does not help here — it validates the *request* `Content-Type`, not the response.

### The fix

A new `web.BeforeStatic` filter (`routers/static_files_filter.go`) adds to every `/files` response:

```
X-Content-Type-Options: nosniff
Content-Security-Policy: default-src 'none'; sandbox
```

plus `Content-Disposition: attachment` for the extensions a browser renders as an active document (`.svg`, `.html`, `.xhtml`, `.xml`, `.xsl`, `.swf`, …).

`sandbox` without `allow-scripts` is the load-bearing control: it puts the document in an opaque origin and disables scripting, so even a direct navigation to an uploaded SVG can no longer reach the Casdoor origin or its cookies. The other two headers are defence in depth.

The filter must run at `BeforeStatic`, because `serverStaticRouter()` is invoked immediately after that hook (`server/web/router.go:1042` → `:1046`).

### Why this does not break the existing uses of `/files`

* **Avatars** are loaded as `<img src>`. Neither CSP nor `Content-Disposition` applies to a subresource load, so images keep rendering — including SVG avatars, which cannot execute script in an `<img>` context anyway.
* **Terms of use** is fetched with `fetch()` and injected via `srcDoc` (`web/src/common/modal/AgreementModal.js:25`), which `Content-Disposition` does not affect either. The response body is unchanged.
* **Inert content** (`.png`, `.pdf`, …) only gains `nosniff` and the CSP header; no `Content-Disposition`.
* `/api` and the frontend routes are untouched — the filter returns immediately unless the path starts with `/files/`.

If you would rather rely on the CSP sandbox alone, dropping the `Content-Disposition` line is a safe, self-contained edit.

### Verification

Built from source at `8bb6c39` against MySQL 8.0, `runmode = dev`, with an uploaded SVG in the `files` directory.

| Request | before | after |
| --- | --- | --- |
| `GET /files/probe.svg` | `Content-Type: image/svg+xml`, no other headers | `+ nosniff`, `+ default-src 'none'; sandbox`, `+ attachment` |
| `GET /files/ok.png` | `Content-Type: image/png`, no other headers | `+ nosniff`, `+ default-src 'none'; sandbox`, no `attachment` |
| `GET /api/health` | unchanged | unchanged (0 of the three headers) |
| body of `/files/probe.svg` | served | served byte-identically |

`go build ./...`, `go vet ./routers/` and `gofmt -l` are clean.

### Note

This is one half of a chain. The other half is that `/api/upload-resource` is matched by the wildcard policy `p, *, *, POST, /api/upload-resource, *, *` in `authz/authz.go`, so `authz.IsAllowed()` admits every subject and the handler is left to authorize the object itself — which the `avatar`, `idCard*` and `termsOfUse` branches do not do, letting any user attach an uploaded file to any other user's account. That is reported separately; this PR only removes the script-execution primitive.