### PR TITLE
feat: forward the request language to the Custom HTTP Email provider

### DIFF
--- a/controllers/verification.go
+++ b/controllers/verification.go
@@ -347,6 +347,14 @@ func (c *ApiController) SendVerificationCode() {
 			return
 		}
 
+		// let a "Custom HTTP Email" webhook localize the email, a signup code is sent before the user exists
+		if provider.HttpHeaders == nil {
+			provider.HttpHeaders = map[string]string{}
+		}
+		if _, ok := provider.HttpHeaders["Accept-Language"]; !ok {
+			provider.HttpHeaders["Accept-Language"] = c.GetAcceptLanguage()
+		}
+
 		sendResp = object.SendVerificationCodeToEmail(organization, user, provider, clientIp, vform.Dest, vform.Method, c.Ctx.Request.Host, application.Name, application)
 	case object.VerifyTypePhone:
 		if vform.Method == LoginVerification || vform.Method == ForgetVerification {

--- a/email/custom_http_test.go
+++ b/email/custom_http_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package email
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/casdoor/casdoor/proxy"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHttpEmailProviderSendForwardsHttpHeaders(t *testing.T) {
+	proxy.InitHttpClient()
+
+	scenarios := []struct {
+		description string
+		method      string
+		contentType string
+	}{
+		{"Should forward the headers on a form POST", http.MethodPost, ""},
+		{"Should forward the headers on a JSON POST", http.MethodPost, "application/json"},
+		{"Should forward the headers on a GET", http.MethodGet, ""},
+	}
+
+	for _, scenery := range scenarios {
+		t.Run(scenery.description, func(t *testing.T) {
+			var received http.Header
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				received = r.Header.Clone()
+			}))
+			defer server.Close()
+
+			httpHeaders := map[string]string{"Accept-Language": "ru", "X-Token": "123"}
+			provider := NewHttpEmailProvider(server.URL, scenery.method, httpHeaders, nil, scenery.contentType)
+
+			err := provider.Send("from@example.com", "Casdoor", []string{"to@example.com"}, "subject", "content")
+			assert.Nil(t, err)
+
+			assert.Equal(t, "ru", received.Get("Accept-Language"))
+			assert.Equal(t, "123", received.Get("X-Token"))
+		})
+	}
+}
+
+func TestHttpEmailProviderSendUnsupportedMethod(t *testing.T) {
+	provider := NewHttpEmailProvider("http://localhost", http.MethodPatch, nil, nil, "")
+
+	err := provider.Send("from@example.com", "Casdoor", []string{"to@example.com"}, "subject", "content")
+	assert.EqualError(t, err, "HttpEmailProvider's Send() error, unsupported method: PATCH")
+}


### PR DESCRIPTION
Signup verification code email is sent before the user exists, so the selected language on the signup page is not used to send the email if using a HTTP Email provider.

This patch forwards the selected language in the `Accept-Language` header to the HTTP Email provider so it can send the emails in the correct language, even if the user doesn't exist yet