### PR TITLE
feat: save the language chosen on the signup page to the new user

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -246,6 +246,7 @@ func (c *ApiController) Signup() {
 		Email:             strings.ToLower(authForm.Email),
 		Phone:             authForm.Phone,
 		CountryCode:       authForm.CountryCode,
+		Language:          authForm.Language,
 		Address:           []string{},
 		Affiliation:       authForm.Affiliation,
 		IdCard:            authForm.IdCard,

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -1050,6 +1050,7 @@ func (c *ApiController) Login() {
 						Phone:             userInfo.Phone,
 						CountryCode:       userInfo.CountryCode,
 						Region:            userInfo.CountryCode,
+						Language:          authForm.Language,
 						Score:             initScore,
 						IsAdmin:           false,
 						IsForbidden:       false,

--- a/web/src/auth/AuthCallback.js
+++ b/web/src/auth/AuthCallback.js
@@ -310,6 +310,8 @@ class AuthCallback extends React.Component {
       method: method,
       userCode: innerParams.get("userCode") || "",
       codeVerifier: codeVerifier, // Include PKCE code verifier
+      // The selector on the login page is gone by now, so use the language it stored
+      language: sessionStorage.getItem("signinLanguage") ?? "",
     };
 
     // Clean up the stored code verifier after using it

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -721,7 +721,7 @@ class LoginPage extends React.Component {
           <LanguageSelect
             languages={application.organizationObj.languages}
             mode={signinItem.rule}
-            onClick={key => {this.setState({userLang: key});}}
+            onClick={key => {this.setState({userLang: key}); sessionStorage.setItem("signinLanguage", key);}}
           />
         </div>
       );

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -126,6 +126,7 @@ class SignupPage extends React.Component {
       isTermsOfUseVisible: false,
       termsOfUseContent: "",
       openCaptchaModal: false,
+      userLang: null,
     };
 
     this.form = React.createRef();
@@ -281,6 +282,7 @@ class SignupPage extends React.Component {
           languages={languages}
           mode={languagesItem?.rule}
           style={{top: "55px", right: "5px", position: "absolute"}}
+          onClick={key => {this.setState({userLang: key}); sessionStorage.setItem("signinLanguage", key);}}
         />
       </div>
     );
@@ -381,6 +383,8 @@ class SignupPage extends React.Component {
 
   submitSignup(values) {
     const application = this.getApplicationObj();
+
+    values["language"] = this.state.userLang ?? "";
 
     // Get OAuth parameters if present
     const oAuthParams = Util.getOAuthGetParameters();


### PR DESCRIPTION
Signup copies every field from the signup form onto the new user, except for the selected language. 

This patch stores the language of the signup request on the new user, the same as the login page already does.

The same issue existed on the login page, and was fixed in #3628