### PR TITLE
fix: set organization/user on send-verification-code audit records

### DIFF
--- a/routers/record.go
+++ b/routers/record.go
@@ -58,29 +58,78 @@ func getUserByClientIdSecret(ctx *context.Context) string {
 }
 
 func RecordMessage(ctx *context.Context) {
-	if ctx.Request.URL.Path == "/api/login" || ctx.Request.URL.Path == "/api/signup" {
+	path := ctx.Request.URL.Path
+
+	if path == "/api/login" || path == "/api/signup" {
 		return
 	}
 
-	userId := getUser(ctx)
+	// User who performs the action.
+	ctx.Input.SetParam("recordUserId", getUser(ctx))
 
-	// Special handling for set-password endpoint to capture target user
-	if ctx.Request.URL.Path == "/api/set-password" {
-		// Parse form if not already parsed
-		if err := ctx.Request.ParseForm(); err != nil {
-			fmt.Printf("RecordMessage() error parsing form: %s\n", err.Error())
-		} else {
-			userOwner := ctx.Request.Form.Get("userOwner")
-			userName := ctx.Request.Form.Get("userName")
-
-			if userOwner != "" && userName != "" {
-				targetUserId := util.GetId(userOwner, userName)
-				ctx.Input.SetParam("recordTargetUserId", targetUserId)
-			}
+	// Resolve target user only for unauthenticated flows that pass identity in the form body.
+	switch path {
+	case "/api/set-password":
+		if targetUserId := getSetPasswordTargetUser(ctx); targetUserId != "" {
+			ctx.Input.SetParam("recordTargetUserId", targetUserId)
+		}
+	case "/api/send-verification-code":
+		if targetUserId := getVerificationCodeTargetUser(ctx); targetUserId != "" {
+			ctx.Input.SetParam("recordTargetUserId", targetUserId)
 		}
 	}
+}
 
-	ctx.Input.SetParam("recordUserId", userId)
+func parseRecordForm(ctx *context.Context) bool {
+	if err := ctx.Request.ParseForm(); err != nil {
+		fmt.Printf("RecordMessage() error parsing form: %s\n", err.Error())
+		return false
+	}
+	return true
+}
+
+func getSetPasswordTargetUser(ctx *context.Context) string {
+	if !parseRecordForm(ctx) {
+		return ""
+	}
+
+	userOwner := ctx.Request.Form.Get("userOwner")
+	userName := ctx.Request.Form.Get("userName")
+
+	if userOwner == "" || userName == "" {
+		return ""
+	}
+
+	return util.GetId(userOwner, userName)
+}
+
+func getVerificationCodeTargetUser(ctx *context.Context) string {
+	if !parseRecordForm(ctx) {
+		return ""
+	}
+
+	checkUser := ctx.Request.Form.Get("checkUser")
+	applicationId := ctx.Request.Form.Get("applicationId")
+
+	if checkUser == "" || applicationId == "" {
+		return ""
+	}
+
+	application, err := object.GetApplication(applicationId)
+	if err != nil {
+		fmt.Printf(
+			"RecordMessage() error getting application %s: %s\n",
+			applicationId,
+			err.Error(),
+		)
+		return ""
+	}
+
+	if application == nil {
+		return ""
+	}
+
+	return util.GetId(application.Organization, checkUser)
 }
 
 func AfterRecordMessage(ctx *context.Context) {
@@ -97,11 +146,10 @@ func AfterRecordMessage(ctx *context.Context) {
 		record.Detail = detail
 	}
 
-	// For set-password endpoint, use target user if available
-	// We use defensive error handling here (log instead of panic) because target user
-	// parsing is a new feature. If it fails, we gracefully fall back to the regular
-	// userId flow or empty user/org fields, maintaining backward compatibility.
-	if record.Action == "set-password" && targetUserId != "" {
+	// For unauthenticated flows (e.g. forgot password), use the target user resolved from the request body.
+	// We use defensive error handling here (log instead of panic) because target user parsing can fail;
+	// in that case we gracefully fall back to the session user or empty org/user fields.
+	if targetUserId != "" {
 		owner, user, err := util.GetOwnerAndNameFromIdWithError(targetUserId)
 		if err != nil {
 			fmt.Printf("AfterRecordMessage() error parsing target user %s: %s\n", targetUserId, err.Error())

--- a/routers/record_test.go
+++ b/routers/record_test.go
@@ -1,0 +1,107 @@
+package routers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+func newRecordTestContext(method, path, body, contentType string) *context.Context {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+
+	ctx := context.NewContext()
+	ctx.Reset(httptest.NewRecorder(), req)
+	return ctx
+}
+
+func TestGetSetPasswordTargetUser(t *testing.T) {
+	t.Parallel()
+
+	ctx := newRecordTestContext(
+		http.MethodPost,
+		"/api/set-password",
+		"userOwner=hyperion&userName=user_kk64gr",
+		"application/x-www-form-urlencoded",
+	)
+
+	if got := getSetPasswordTargetUser(ctx); got != "hyperion/user_kk64gr" {
+		t.Fatalf("getSetPasswordTargetUser() = %q, want hyperion/user_kk64gr", got)
+	}
+}
+
+func TestGetSetPasswordTargetUser_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	ctx := newRecordTestContext(
+		http.MethodPost,
+		"/api/set-password",
+		"userOwner=hyperion",
+		"application/x-www-form-urlencoded",
+	)
+
+	if got := getSetPasswordTargetUser(ctx); got != "" {
+		t.Fatalf("getSetPasswordTargetUser() = %q, want empty", got)
+	}
+}
+
+func TestGetVerificationCodeTargetUser_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	ctx := newRecordTestContext(
+		http.MethodPost,
+		"/api/send-verification-code",
+		"checkUser=user_kk64gr",
+		"application/x-www-form-urlencoded",
+	)
+
+	if got := getVerificationCodeTargetUser(ctx); got != "" {
+		t.Fatalf("getVerificationCodeTargetUser() = %q, want empty", got)
+	}
+}
+
+func TestRecordMessage_OtherEndpointDoesNotSetTarget(t *testing.T) {
+	t.Parallel()
+
+	ctx := newRecordTestContext(http.MethodGet, "/api/get-user", "", "")
+
+	RecordMessage(ctx)
+
+	if target := ctx.Input.Params()["recordTargetUserId"]; target != "" {
+		t.Fatalf("recordTargetUserId = %q, want empty", target)
+	}
+}
+
+func TestRecordMessage_SetPasswordSetsTarget(t *testing.T) {
+	t.Parallel()
+
+	ctx := newRecordTestContext(
+		http.MethodPost,
+		"/api/set-password",
+		"userOwner=hyperion&userName=user_kk64gr",
+		"application/x-www-form-urlencoded",
+	)
+
+	RecordMessage(ctx)
+
+	if target := ctx.Input.Params()["recordTargetUserId"]; target != "hyperion/user_kk64gr" {
+		t.Fatalf("recordTargetUserId = %q, want hyperion/user_kk64gr", target)
+	}
+}
+
+func TestRecordMessage_LoginSkipped(t *testing.T) {
+	t.Parallel()
+
+	ctx := newRecordTestContext(http.MethodPost, "/api/login", "", "")
+
+	RecordMessage(ctx)
+
+	if _, ok := ctx.Input.Params()["recordUserId"]; ok {
+		t.Fatal("recordUserId should not be set for /api/login")
+	}
+}


### PR DESCRIPTION
For unauthenticated forgot-password requests, derive recordTargetUserId from applicationId and checkUser. Refactor RecordMessage and add tests.

Fixex #5679 