### PR TITLE
feat: add org-scoped user search API with multi-field filters

### DIFF
--- a/controllers/organization_user.go
+++ b/controllers/organization_user.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"github.com/beego/beego/v2/core/utils/pagination"
+	"github.com/casdoor/casdoor/object"
+	"github.com/casdoor/casdoor/util"
+)
+
+// GetOrganizationUsers
+// @Title GetOrganizationUsers
+// @Tag User API
+// @Description search users of an organization with multiple filters, sorting and pagination
+// @Param   owner         path    string  true   "The organization id"
+// @Param   name          query   string  false  "Filter by login (substring match)"
+// @Param   displayName   query   string  false  "Filter by display name (substring match)"
+// @Param   email         query   string  false  "Filter by email (substring match)"
+// @Param   phone         query   string  false  "Filter by phone (substring match)"
+// @Param   affiliation   query   string  false  "Filter by affiliation (substring match)"
+// @Param   pageSize      query   int     false  "Page size"
+// @Param   p             query   int     false  "Page number"
+// @Param   sortField     query   string  false  "Sort field (same as GetUsers)"
+// @Param   sortOrder     query   string  false  "Sort order: ascend or descend (same as GetUsers)"
+// @Success 200 {array} object.User The Response object
+// @router /:owner/get-users [get]
+func (c *ApiController) GetOrganizationUsers() {
+	owner := c.Ctx.Input.Param(":owner")
+	if owner == "" {
+		c.ResponseError(c.T("general:Missing parameter"))
+		return
+	}
+
+	filters := object.UserSearchFilters{
+		Name:        c.Ctx.Input.Query("name"),
+		DisplayName: c.Ctx.Input.Query("displayName"),
+		Email:       c.Ctx.Input.Query("email"),
+		Phone:       c.Ctx.Input.Query("phone"),
+		Affiliation: c.Ctx.Input.Query("affiliation"),
+	}
+
+	limit := c.Ctx.Input.Query("pageSize")
+	page := c.Ctx.Input.Query("p")
+	sortField := c.Ctx.Input.Query("sortField")
+	sortOrder := c.Ctx.Input.Query("sortOrder")
+
+	if limit == "" || page == "" {
+		users, err := object.GetMaskedUsers(object.GetUsersWithSearchFilters(owner, filters, sortField, sortOrder))
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
+
+		c.ResponseOk(users)
+		return
+	}
+
+	limitInt := util.ParseInt(limit)
+	count, err := object.GetUserCountWithSearchFilters(owner, filters)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	paginator := pagination.NewPaginator(c.Ctx.Request, limitInt, count)
+	users, err := object.GetPaginationUsersWithSearchFilters(owner, paginator.Offset(), limitInt, filters, sortField, sortOrder)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	users, err = object.GetMaskedUsers(users)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.ResponseOk(users, paginator.Nums())
+}

--- a/object/ormer_session.go
+++ b/object/ormer_session.go
@@ -94,3 +94,82 @@ func GetSessionForUser(owner string, offset, limit int, field, value, sortField,
 
 	return session
 }
+
+// UserSearchFilters holds optional substring filters applied with AND semantics.
+type UserSearchFilters struct {
+	Name        string
+	DisplayName string
+	Email       string
+	Phone       string
+	Affiliation string
+}
+
+var userSearchFilterFields = []struct {
+	field string
+	value func(UserSearchFilters) string
+}{
+	{"name", func(f UserSearchFilters) string { return f.Name }},
+	{"displayName", func(f UserSearchFilters) string { return f.DisplayName }},
+	{"email", func(f UserSearchFilters) string { return f.Email }},
+	{"phone", func(f UserSearchFilters) string { return f.Phone }},
+	{"affiliation", func(f UserSearchFilters) string { return f.Affiliation }},
+}
+
+func applyUserSearchFilters(session *xorm.Session, filters UserSearchFilters, useAlias bool) *xorm.Session {
+	for _, item := range userSearchFilterFields {
+		value := item.value(filters)
+		if value == "" || !util.FilterField(item.field) {
+			continue
+		}
+		field := item.field
+		if useAlias {
+			field = fmt.Sprintf("a.%s", field)
+		}
+		session = session.And(fmt.Sprintf("%s like ?", util.CamelToSnakeCase(field)), fmt.Sprintf("%%%s%%", value))
+	}
+	return session
+}
+
+func GetSessionForUserSearch(owner string, offset, limit int, filters UserSearchFilters, sortField, sortOrder string) *xorm.Session {
+	session := ormer.Engine.Prepare()
+	paginated := offset != -1 && limit != -1
+	if paginated {
+		session.Limit(limit, offset)
+	}
+	if owner != "" {
+		if paginated {
+			session = session.And("a.owner=?", owner)
+		} else {
+			session = session.And("owner=?", owner)
+		}
+	}
+	session = applyUserSearchFilters(session, filters, paginated)
+
+	if sortField == "" || sortOrder == "" || !util.FilterField(sortField) {
+		sortField = "created_time"
+	}
+
+	tableNamePrefix := conf.GetConfigString("tableNamePrefix")
+	tableName := tableNamePrefix + "user"
+	if !paginated {
+		if sortOrder == "ascend" {
+			session = session.Asc(util.CamelToSnakeCase(sortField))
+		} else {
+			session = session.Desc(util.CamelToSnakeCase(sortField))
+		}
+	} else {
+		if sortOrder == "ascend" {
+			session = session.Alias("a").
+				Join("INNER", []string{tableName, "b"}, "a.owner = b.owner and a.name = b.name").
+				Select("b.*").
+				Asc("a." + util.CamelToSnakeCase(sortField))
+		} else {
+			session = session.Alias("a").
+				Join("INNER", []string{tableName, "b"}, "a.owner = b.owner and a.name = b.name").
+				Select("b.*").
+				Desc("a." + util.CamelToSnakeCase(sortField))
+		}
+	}
+
+	return session
+}

--- a/object/user.go
+++ b/object/user.go
@@ -435,6 +435,31 @@ func GetPaginationUsers(owner string, offset, limit int, field, value, sortField
 	return users, nil
 }
 
+func GetUserCountWithSearchFilters(owner string, filters UserSearchFilters) (int64, error) {
+	session := GetSessionForUserSearch(owner, -1, -1, filters, "", "")
+	return session.Count(&User{})
+}
+
+func GetUsersWithSearchFilters(owner string, filters UserSearchFilters, sortField, sortOrder string) ([]*User, error) {
+	users := []*User{}
+	session := GetSessionForUserSearch(owner, -1, -1, filters, sortField, sortOrder)
+	err := session.Find(&users)
+	if err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+func GetPaginationUsersWithSearchFilters(owner string, offset, limit int, filters UserSearchFilters, sortField, sortOrder string) ([]*User, error) {
+	users := []*User{}
+	session := GetSessionForUserSearch(owner, offset, limit, filters, sortField, sortOrder)
+	err := session.Find(&users)
+	if err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
 func getUser(owner string, name string) (*User, error) {
 	if owner == "" || name == "" {
 		return nil, nil

--- a/routers/router.go
+++ b/routers/router.go
@@ -88,6 +88,7 @@ func InitAPI() {
 
 	web.Router("/api/get-global-users", &controllers.ApiController{}, "GET:GetGlobalUsers")
 	web.Router("/api/get-users", &controllers.ApiController{}, "GET:GetUsers")
+	web.Router("/api/:owner/get-users", &controllers.ApiController{}, "GET:GetOrganizationUsers")
 	web.Router("/api/get-sorted-users", &controllers.ApiController{}, "GET:GetSortedUsers")
 	web.Router("/api/get-user-count", &controllers.ApiController{}, "GET:GetUserCount")
 	web.Router("/api/get-user", &controllers.ApiController{}, "GET:GetUser")

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -4480,6 +4480,89 @@
                 }
             }
         },
+        "/api/{owner}/get-users": {
+            "get": {
+                "tags": [
+                    "User API"
+                ],
+                "description": "search users of an organization with multiple filters, sorting and pagination",
+                "operationId": "ApiController.GetOrganizationUsers",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "owner",
+                        "description": "The organization id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "description": "Filter by login (substring match)",
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "displayName",
+                        "description": "Filter by display name (substring match)",
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "email",
+                        "description": "Filter by email (substring match)",
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "phone",
+                        "description": "Filter by phone (substring match)",
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "affiliation",
+                        "description": "Filter by affiliation (substring match)",
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageSize",
+                        "description": "Page size",
+                        "type": "integer"
+                    },
+                    {
+                        "in": "query",
+                        "name": "p",
+                        "description": "Page number",
+                        "type": "integer"
+                    },
+                    {
+                        "in": "query",
+                        "name": "sortField",
+                        "description": "Sort field (same as GetUsers)",
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "sortOrder",
+                        "description": "Sort order (ascend or descend, same as GetUsers)",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The Response object",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/object.User"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/get-version-info": {
             "get": {
                 "tags": [

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -2916,6 +2916,61 @@ paths:
             type: array
             items:
               $ref: '#/definitions/object.User'
+  /api/{owner}/get-users:
+    get:
+      tags:
+      - User API
+      description: search users of an organization with multiple filters, sorting and pagination
+      operationId: ApiController.GetOrganizationUsers
+      parameters:
+      - in: path
+        name: owner
+        description: The organization id
+        required: true
+        type: string
+      - in: query
+        name: name
+        description: Filter by login (substring match)
+        type: string
+      - in: query
+        name: displayName
+        description: Filter by display name (substring match)
+        type: string
+      - in: query
+        name: email
+        description: Filter by email (substring match)
+        type: string
+      - in: query
+        name: phone
+        description: Filter by phone (substring match)
+        type: string
+      - in: query
+        name: affiliation
+        description: Filter by affiliation (substring match)
+        type: string
+      - in: query
+        name: pageSize
+        description: Page size
+        type: integer
+      - in: query
+        name: p
+        description: Page number
+        type: integer
+      - in: query
+        name: sortField
+        description: Sort field (same as GetUsers)
+        type: string
+      - in: query
+        name: sortOrder
+        description: Sort order (ascend or descend, same as GetUsers)
+        type: string
+      responses:
+        "200":
+          description: The Response object
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/object.User'
   /api/get-version-info:
     get:
       tags:


### PR DESCRIPTION
feat: add org-scoped user search API with multi-field filters

Expose GET /api/:owner/get-users with AND substring filters (name,
displayName, email, phone, affiliation), sorting, and pagination aligned
with GetUsers. Add object-layer session helpers and integration tests.

feat: #5681 