### PR TITLE
fix(auth): return generic sign-in error for unknown users

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -591,7 +591,7 @@ func (c *ApiController) Login() {
 				c.ResponseError(err.Error(), nil)
 				return
 			} else if user == nil {
-				c.ResponseError(fmt.Sprintf(c.T("general:The user: %s doesn't exist"), util.GetId(authForm.Organization, authForm.Username)))
+				c.ResponseError(object.InvalidSigninCredentialsMsg(c.GetAcceptLanguage()))
 				return
 			}
 
@@ -655,7 +655,7 @@ func (c *ApiController) Login() {
 				c.ResponseError(err.Error(), nil)
 				return
 			} else if user == nil {
-				c.ResponseError(fmt.Sprintf(c.T("general:The user: %s doesn't exist"), util.GetId(authForm.Organization, authForm.Username)))
+				c.ResponseError(object.InvalidSigninCredentialsMsg(c.GetAcceptLanguage()))
 				return
 			}
 

--- a/object/check.go
+++ b/object/check.go
@@ -374,7 +374,7 @@ func CheckUserPassword(organization string, username string, password string, la
 	}
 
 	if user == nil || user.IsDeleted {
-		return nil, newSigninError(SigninReasonUserNotFound, fmt.Sprintf(i18n.Translate(lang, "general:The user: %s doesn't exist"), util.GetId(organization, username)))
+		return nil, NewSigninUserNotFoundError(lang)
 	}
 
 	if user.IsForbidden {
@@ -388,7 +388,7 @@ func CheckUserPassword(organization string, username string, password string, la
 
 	if isSigninViaLdap {
 		if user.Ldap == "" {
-			return nil, fmt.Errorf(i18n.Translate(lang, "check:The user: %s doesn't exist in LDAP server"), username)
+			return nil, NewSigninUserNotFoundError(lang)
 		}
 	}
 
@@ -401,7 +401,7 @@ func CheckUserPassword(organization string, username string, password string, la
 		err = CheckLdapUserPassword(user, password, lang, enableCaptcha)
 		if err != nil {
 			if err.Error() == "user not exist" {
-				return nil, fmt.Errorf(i18n.Translate(lang, "check:The user: %s doesn't exist in LDAP server"), username)
+				return nil, NewSigninUserNotFoundError(lang)
 			}
 
 			return nil, err

--- a/object/signin_error.go
+++ b/object/signin_error.go
@@ -14,6 +14,8 @@
 
 package object
 
+import "github.com/casdoor/casdoor/i18n"
+
 const (
 	SigninReasonUserNotFound    = "user-not-found"
 	SigninReasonAccountDisabled = "account-disabled"
@@ -33,4 +35,14 @@ func (e *SigninError) Error() string { return e.msg }
 
 func newSigninError(reason, msg string) *SigninError {
 	return &SigninError{Reason: reason, msg: msg}
+}
+
+// InvalidSigninCredentialsMsg is the generic client-facing sign-in failure text (OWASP anti-enumeration).
+func InvalidSigninCredentialsMsg(lang string) string {
+	return i18n.Translate(lang, "check:password or code is incorrect")
+}
+
+// NewSigninUserNotFoundError records user-not-found for audit logs while returning a generic message to the client.
+func NewSigninUserNotFoundError(lang string) *SigninError {
+	return newSigninError(SigninReasonUserNotFound, InvalidSigninCredentialsMsg(lang))
 }


### PR DESCRIPTION
Use a single client-facing message for missing users and failed LDAP
lookups to prevent username enumeration (OWASP). Keep user-not-found
in audit via SigninReasonUserNotFound.

fix: #5685 