### PR TITLE
feat: add avatar claim to custom jwt

### DIFF
--- a/web/src/table/TokenAttributeTable.js
+++ b/web/src/table/TokenAttributeTable.js
@@ -25,7 +25,7 @@ class TokenAttributeTable extends React.Component {
       classes: props,
     };
     // List of available user fields for "Existing Field" category
-    this.userFields = ["Owner", "Name", "Id", "DisplayName", "Email", "Phone", "Tag", "Roles", "Permissions", "permissionNames", "Groups"];
+    this.userFields = ["Owner", "Name", "Id", "DisplayName", "Avatar", "Email", "Phone", "Tag", "Roles", "Permissions", "permissionNames", "Groups"];
   }
 
   updateTable(table) {


### PR DESCRIPTION
## What does this PR do?

Add avatar claim to custom JWT payload.

## Why?

The user model already contains Avatar field, but custom JWT generation does not include this existing field.

This makes it difficult for applications consuming Casdoor JWT to get user avatar information.

## Changes

- Add avatar field when generating custom JWT
- Keep existing JWT fields unchanged

## Testing

Tested locally with custom JWT generation.