### PR TITLE
feat: preserve rfc 8707 resource in fast auto-signin flow

### DIFF
--- a/routers/static_filter.go
+++ b/routers/static_filter.go
@@ -78,6 +78,7 @@ func fastAutoSignin(ctx *context.Context) (string, error) {
 	state := ctx.Input.Query("state")
 	nonce := ctx.Input.Query("nonce")
 	codeChallenge := ctx.Input.Query("code_challenge")
+	resource := ctx.Input.Query("resource")
 	if clientId == "" || responseType != "code" || redirectUri == "" {
 		return "", nil
 	}
@@ -120,7 +121,7 @@ func fastAutoSignin(ctx *context.Context) (string, error) {
 		return "", nil
 	}
 
-	code, err := object.GetOAuthCode(userId, clientId, "", "autoSignin", responseType, redirectUri, scope, state, nonce, codeChallenge, "", ctx.Request.Host, getAcceptLanguage(ctx))
+	code, err := object.GetOAuthCode(userId, clientId, "", "autoSignin", responseType, redirectUri, scope, state, nonce, codeChallenge, resource, ctx.Request.Host, getAcceptLanguage(ctx))
 	if err != nil {
 		return "", err
 	} else if code.Message != "" {


### PR DESCRIPTION
## Summary

- Preserve the RFC 8707 `resource` parameter in the existing-session fast
  auto-sign-in flow.
- Pass the requested resource to `GetOAuthCode()` instead of an empty string.

## Context

#5666 fixed resource propagation in the consent flow. During follow-up testing,
we found that the existing-session fast auto-signin path has the same resource
propagation gap in `routers/static_filter.go`.

#5292 and #5298 cover the regular browser login path. This change addresses the
separate backend fast auto-sign-in path used for an existing session.

## Specification

- [RFC 8707 Section 2.1: Authorization Request](https://www.rfc-editor.org/rfc/rfc8707.html#section-2.1)
- [RFC 8707 Section 2.2: Access Token Request](https://www.rfc-editor.org/rfc/rfc8707.html#section-2.2)

## Testing

- `gofmt -w routers/static_filter.go`
- `go test ./routers -tags skipCi`
- `git diff --check`

Fixes #5689
