### PR TITLE
fix: sync casbin user rules after user rename

### DIFF
--- a/object/user.go
+++ b/object/user.go
@@ -1449,7 +1449,25 @@ func userChangeTrigger(owner string, oldName string, newName string) error {
 		return err
 	}
 
-	return session.Commit()
+	oldId := util.GetId(owner, oldName)
+	newId := util.GetId(owner, newName)
+	tableNamePrefix := conf.GetConfigString("tableNamePrefix")
+	affected, err := session.Table(tableNamePrefix+"casbin_user_rule").
+		Where("ptype = ? AND v0 = ?", "g", oldId).
+		Update(map[string]string{"v0": newId})
+	if err != nil {
+		return err
+	}
+
+	if err = session.Commit(); err != nil {
+		return err
+	}
+
+	if affected > 0 && userEnforcer != nil && userEnforcer.enforcer != nil {
+		_ = userEnforcer.enforcer.LoadPolicy()
+	}
+
+	return nil
 }
 
 func (user *User) IsMfaEnabled() bool {

--- a/object/user_test.go
+++ b/object/user_test.go
@@ -21,7 +21,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/casdoor/casdoor/conf"
 	"github.com/casdoor/casdoor/util"
+	xormadapter "github.com/casdoor/xorm-adapter/v3"
 	"github.com/xorm-io/core"
 )
 
@@ -162,4 +164,60 @@ func TestGetEmailsForUsers(t *testing.T) {
 
 	text := strings.Join(emails, "\n")
 	println(text)
+}
+
+func TestUserChangeTriggerRenamesCasbinRule(t *testing.T) {
+	InitConfig()
+
+	const (
+		owner   = "built-in"
+		oldName = "test-rename-old"
+		newName = "test-rename-new"
+		group   = "group:test-rename-group"
+	)
+	oldId := util.GetId(owner, oldName)
+	newId := util.GetId(owner, newName)
+	tableName := conf.GetConfigString("tableNamePrefix") + "casbin_user_rule"
+
+	if _, err := xormadapter.NewAdapterByEngineWithTableName(ormer.Engine, "casbin_user_rule", conf.GetConfigString("tableNamePrefix")); err != nil {
+		t.Fatalf("create casbin user rule table: %v", err)
+	}
+
+	rule := &xormadapter.CasbinRule{Ptype: "g", V0: oldId, V1: group}
+	if _, err := ormer.Engine.Table(tableName).Insert(rule); err != nil {
+		t.Fatalf("seed g rule: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = ormer.Engine.Table(tableName).
+			Where("ptype = ? AND v0 = ? AND v1 = ?", "g", newId, group).
+			Delete(&xormadapter.CasbinRule{})
+	})
+
+	if err := userChangeTrigger(owner, oldName, newName); err != nil {
+		t.Fatalf("userChangeTrigger: %v", err)
+	}
+
+	var rows []*xormadapter.CasbinRule
+	if err := ormer.Engine.Table(tableName).
+		Where("ptype = ? AND v1 = ?", "g", group).
+		Find(&rows); err != nil {
+		t.Fatalf("query g rules: %v", err)
+	}
+
+	var foundNew, foundOld bool
+	for _, r := range rows {
+		switch r.V0 {
+		case newId:
+			foundNew = true
+		case oldId:
+			foundOld = true
+		}
+	}
+
+	if !foundNew {
+		t.Errorf("expected g rule with v0=%q, none found (rows=%+v)", newId, rows)
+	}
+	if foundOld {
+		t.Errorf("expected old g rule with v0=%q to be renamed away, still present (rows=%+v)", oldId, rows)
+	}
 }


### PR DESCRIPTION
• ## What
  - Update `casbin_user_rule` when a user is renamed, so `g` policies keep pointing to the new user ID.
  - Refresh `userEnforcer` policy cache only when the rename actually changes at least one rule.
  - Add a regression test for the rename flow.

  ## Why
  - Prevent stale group mappings after a user rename.
  - Keep the database and in-memory Casbin policy state aligned.
  - Prevent group-related APIs from returning users that are no longer valid after a rename.

  ## Test
  - `go test ./object -run TestUserChangeTriggerRenamesCasbinRule -count=1 -v -tags skipCi`