### PR TITLE
feat: add global search param to get-users API

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -1018,7 +1018,7 @@ func (c *ApiController) Login() {
 
 					properties := map[string]string{}
 					var count int64
-					count, err = object.GetUserCount(application.Organization, "", "", "")
+					count, err = object.GetUserCount(application.Organization, "", "", "", "")
 					if err != nil {
 						c.ResponseError(err.Error())
 						return

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -77,6 +77,7 @@ func (c *ApiController) GetGlobalUsers() {
 // @Tag User API
 // @Description
 // @Param   owner     query    string  true        "The owner of users"
+// @Param   search    query    string  false       "Global search by name, displayName and email"
 // @Success 200 {array} object.User The Response object
 // @router /get-users [get]
 func (c *ApiController) GetUsers() {
@@ -88,10 +89,12 @@ func (c *ApiController) GetUsers() {
 	value := c.Ctx.Input.Query("value")
 	sortField := c.Ctx.Input.Query("sortField")
 	sortOrder := c.Ctx.Input.Query("sortOrder")
+	search := c.Ctx.Input.Query("search")
 
 	if limit == "" || page == "" {
+		searchCond := object.BuildUserSearchCond(search, "")
 		if groupName != "" {
-			users, err := object.GetMaskedUsers(object.GetGroupUsers(util.GetId(owner, groupName)))
+			users, err := object.GetMaskedUsers(object.GetGroupUsersWithFilter(util.GetId(owner, groupName), searchCond))
 			if err != nil {
 				c.ResponseError(err.Error())
 				return
@@ -100,7 +103,7 @@ func (c *ApiController) GetUsers() {
 			return
 		}
 
-		users, err := object.GetMaskedUsers(object.GetUsers(owner))
+		users, err := object.GetMaskedUsers(object.GetUsersWithFilter(owner, searchCond))
 		if err != nil {
 			c.ResponseError(err.Error())
 			return
@@ -109,14 +112,14 @@ func (c *ApiController) GetUsers() {
 		c.ResponseOk(users)
 	} else {
 		limit := util.ParseInt(limit)
-		count, err := object.GetUserCount(owner, field, value, groupName)
+		count, err := object.GetUserCount(owner, field, value, groupName, search)
 		if err != nil {
 			c.ResponseError(err.Error())
 			return
 		}
 
 		paginator := pagination.NewPaginator(c.Ctx.Request, limit, count)
-		users, err := object.GetPaginationUsers(owner, paginator.Offset(), limit, field, value, sortField, sortOrder, groupName)
+		users, err := object.GetPaginationUsers(owner, paginator.Offset(), limit, field, value, sortField, sortOrder, groupName, search)
 		if err != nil {
 			c.ResponseError(err.Error())
 			return
@@ -764,7 +767,7 @@ func (c *ApiController) GetUserCount() {
 	var count int64
 	var err error
 	if isOnline == "" {
-		count, err = object.GetUserCount(owner, "", "", "")
+		count, err = object.GetUserCount(owner, "", "", "", "")
 	} else {
 		count, err = object.GetOnlineUserCount(owner, util.ParseInt(isOnline))
 	}

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -345,7 +345,7 @@ func checkQuotaForUser() error {
 		return nil
 	}
 
-	count, err := object.GetUserCount("", "", "", "")
+	count, err := object.GetUserCount("", "", "", "", "")
 	if err != nil {
 		return err
 	}

--- a/object/group.go
+++ b/object/group.go
@@ -259,7 +259,7 @@ func DeleteGroup(group *Group) (bool, error) {
 		return false, errors.New("group has children group")
 	}
 
-	if count, err := GetGroupUserCount(group.GetId(), "", ""); err != nil {
+	if count, err := GetGroupUserCount(group.GetId(), "", "", ""); err != nil {
 		return false, err
 	} else if count > 0 {
 		return false, errors.New("group has users")
@@ -310,7 +310,7 @@ func ConvertToTreeData(groups []*Group, parentId string) []*Group {
 	return treeData
 }
 
-func GetGroupUserCount(groupId string, field, value string) (int64, error) {
+func GetGroupUserCount(groupId string, field, value string, search string) (int64, error) {
 	owner, _, err := util.GetOwnerAndNameFromIdWithError(groupId)
 	if err != nil {
 		return 0, err
@@ -320,20 +320,21 @@ func GetGroupUserCount(groupId string, field, value string) (int64, error) {
 		return 0, err
 	}
 
-	if field == "" && value == "" {
+	if field == "" && value == "" && search == "" {
 		return int64(len(names)), nil
 	} else {
 		tableNamePrefix := conf.GetConfigString("tableNamePrefix")
 		session := ormer.Engine.Table(tableNamePrefix+"user").
 			Where("owner = ?", owner).In("name", names)
-		if util.FilterField(field) {
+		if field != "" && value != "" && util.FilterField(field) {
 			session = session.And(fmt.Sprintf("user.%s like ?", util.CamelToSnakeCase(field)), "%"+value+"%")
 		}
+		session = applyUserSearchFilter(session, search, "")
 		return session.Count()
 	}
 }
 
-func GetPaginationGroupUsers(groupId string, offset, limit int, field, value, sortField, sortOrder string) ([]*User, error) {
+func GetPaginationGroupUsers(groupId string, offset, limit int, field, value, sortField, sortOrder string, search string) ([]*User, error) {
 	users := []*User{}
 	owner, _, err := util.GetOwnerAndNameFromIdWithError(groupId)
 	if err != nil {
@@ -356,6 +357,7 @@ func GetPaginationGroupUsers(groupId string, offset, limit int, field, value, so
 	if field != "" && value != "" && util.FilterField(field) {
 		session = session.And(fmt.Sprintf("%s.%s like ?", prefixedUserTable, util.CamelToSnakeCase(field)), "%"+value+"%")
 	}
+	session = applyUserSearchFilter(session, search, "")
 
 	if sortField == "" || sortOrder == "" || !util.FilterField(sortField) {
 		sortField = "created_time"
@@ -378,6 +380,10 @@ func GetPaginationGroupUsers(groupId string, offset, limit int, field, value, so
 }
 
 func GetGroupUsers(groupId string) ([]*User, error) {
+	return GetGroupUsersWithFilter(groupId, nil)
+}
+
+func GetGroupUsersWithFilter(groupId string, cond builder.Cond) ([]*User, error) {
 	users := []*User{}
 	owner, _, err := util.GetOwnerAndNameFromIdWithError(groupId)
 	if err != nil {
@@ -387,7 +393,11 @@ func GetGroupUsers(groupId string) ([]*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = ormer.Engine.Where("owner = ?", owner).In("name", names).Find(&users)
+	session := ormer.Engine.Where("owner = ?", owner).In("name", names)
+	if cond != nil {
+		session = session.And(cond)
+	}
+	err = session.Find(&users)
 	if err != nil {
 		return nil, err
 	}

--- a/object/user.go
+++ b/object/user.go
@@ -355,11 +355,12 @@ func GetPaginationGlobalUsers(offset, limit int, field, value, sortField, sortOr
 	return users, nil
 }
 
-func GetUserCount(owner, field, value string, groupName string) (int64, error) {
+func GetUserCount(owner, field, value string, groupName string, search string) (int64, error) {
 	session := GetSession(owner, -1, -1, field, value, "", "")
+	session = applyUserSearchFilter(session, search, "")
 
 	if groupName != "" {
-		return GetGroupUserCount(util.GetId(owner, groupName), field, value)
+		return GetGroupUserCount(util.GetId(owner, groupName), field, value, search)
 	}
 
 	return session.Count(&User{})
@@ -420,14 +421,19 @@ func GetSortedUsers(owner string, sorter string, limit int) ([]*User, error) {
 	return users, nil
 }
 
-func GetPaginationUsers(owner string, offset, limit int, field, value, sortField, sortOrder string, groupName string) ([]*User, error) {
+func GetPaginationUsers(owner string, offset, limit int, field, value, sortField, sortOrder string, groupName string, search string) ([]*User, error) {
 	users := []*User{}
 
 	if groupName != "" {
-		return GetPaginationGroupUsers(util.GetId(owner, groupName), offset, limit, field, value, sortField, sortOrder)
+		return GetPaginationGroupUsers(util.GetId(owner, groupName), offset, limit, field, value, sortField, sortOrder, search)
 	}
 
 	session := GetSessionForUser(owner, offset, limit, field, value, sortField, sortOrder)
+	columnPrefix := ""
+	if offset != -1 {
+		columnPrefix = "a."
+	}
+	session = applyUserSearchFilter(session, search, columnPrefix)
 	err := session.Find(&users)
 	if err != nil {
 		return nil, err
@@ -1061,7 +1067,7 @@ func AddUser(user *User, lang string) (bool, error) {
 
 	rankingItem := GetAccountItemByName("Ranking", organization)
 	if rankingItem != nil {
-		count, err := GetUserCount(user.Owner, "", "", "")
+		count, err := GetUserCount(user.Owner, "", "", "", "")
 		if err != nil {
 			return false, err
 		}

--- a/object/user_search.go
+++ b/object/user_search.go
@@ -1,0 +1,50 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"fmt"
+
+	"github.com/xorm-io/builder"
+	"github.com/xorm-io/xorm"
+)
+
+// BuildUserSearchCond builds OR condition for global user search by name, display_name and email.
+// Empty search returns nil (no filter). columnPrefix is used for table aliases (e.g. "a.").
+func BuildUserSearchCond(search string, columnPrefix string) builder.Cond {
+	if search == "" {
+		return nil
+	}
+
+	pattern := fmt.Sprintf("%%%s%%", search)
+	nameCol := columnPrefix + "name"
+	displayNameCol := columnPrefix + "display_name"
+	emailCol := columnPrefix + "email"
+
+	return builder.Or(
+		builder.Expr(fmt.Sprintf("%s like ?", nameCol), pattern),
+		builder.Expr(fmt.Sprintf("%s like ?", displayNameCol), pattern),
+		builder.Expr(fmt.Sprintf("%s like ?", emailCol), pattern),
+	)
+}
+
+// applyUserSearchFilter applies global user search to the session. No-op when search is empty.
+func applyUserSearchFilter(session *xorm.Session, search string, columnPrefix string) *xorm.Session {
+	cond := BuildUserSearchCond(search, columnPrefix)
+	if cond == nil {
+		return session
+	}
+	return session.And(cond)
+}

--- a/object/user_search_test.go
+++ b/object/user_search_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/xorm-io/builder"
+)
+
+func TestBuildUserSearchCondEmpty(t *testing.T) {
+	if cond := BuildUserSearchCond("", ""); cond != nil {
+		t.Fatalf("expected nil cond for empty search, got %#v", cond)
+	}
+	if cond := BuildUserSearchCond("", "a."); cond != nil {
+		t.Fatalf("expected nil cond for empty search with prefix, got %#v", cond)
+	}
+}
+
+func TestBuildUserSearchCondOrFields(t *testing.T) {
+	cond := BuildUserSearchCond("ivan", "")
+	if cond == nil {
+		t.Fatal("expected non-nil cond")
+	}
+
+	sql, args, err := builder.ToSQL(cond)
+	if err != nil {
+		t.Fatalf("builder.ToSQL: %v", err)
+	}
+
+	lowerSQL := strings.ToLower(sql)
+	for _, col := range []string{"name", "display_name", "email"} {
+		if !strings.Contains(lowerSQL, col) {
+			t.Fatalf("sql %q should contain column %q", sql, col)
+		}
+	}
+	if !strings.Contains(lowerSQL, " or ") {
+		t.Fatalf("sql %q should contain OR between fields", sql)
+	}
+	if len(args) != 3 {
+		t.Fatalf("expected 3 args, got %d: %#v", len(args), args)
+	}
+	for _, arg := range args {
+		if arg != "%ivan%" {
+			t.Fatalf("expected arg %%ivan%%, got %#v", arg)
+		}
+	}
+}
+
+func TestBuildUserSearchCondColumnPrefix(t *testing.T) {
+	cond := BuildUserSearchCond("ivan", "a.")
+	if cond == nil {
+		t.Fatal("expected non-nil cond")
+	}
+
+	sql, _, err := builder.ToSQL(cond)
+	if err != nil {
+		t.Fatalf("builder.ToSQL: %v", err)
+	}
+
+	for _, col := range []string{"a.name", "a.display_name", "a.email"} {
+		if !strings.Contains(sql, col) {
+			t.Fatalf("sql %q should contain prefixed column %q", sql, col)
+		}
+	}
+}

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -4465,6 +4465,13 @@
                         "description": "The owner of users",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "search",
+                        "description": "Global search by name, displayName and email",
+                        "required": false,
+                        "type": "string"
                     }
                 ],
                 "responses": {

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -2909,6 +2909,11 @@ paths:
         description: The owner of users
         required: true
         type: string
+      - in: query
+        name: search
+        description: Global search by name, displayName and email
+        required: false
+        type: string
       responses:
         "200":
           description: The Response object


### PR DESCRIPTION
Allow filtering users by name, displayName, or email via optional search query.

#5707 