### PR TITLE
fix: parse DingTalk token error code as string instead of int

### DIFF
--- a/idp/dingtalk.go
+++ b/idp/dingtalk.go
@@ -70,7 +70,7 @@ func (idp *DingTalkIdProvider) getConfig(clientId string, clientSecret string, r
 }
 
 type DingTalkAccessToken struct {
-	ErrCode     int    `json:"code"`
+	ErrCode     string `json:"code"`
 	ErrMsg      string `json:"message"`
 	AccessToken string `json:"accessToken"` // Interface call credentials
 	ExpiresIn   int64  `json:"expireIn"`    // access_token interface call credential timeout time, unit (seconds)
@@ -97,8 +97,8 @@ func (idp *DingTalkIdProvider) GetToken(code string) (*oauth2.Token, error) {
 		return nil, err
 	}
 
-	if pToken.ErrCode != 0 {
-		return nil, fmt.Errorf("pToken.Errcode = %d, pToken.Errmsg = %s", pToken.ErrCode, pToken.ErrMsg)
+	if pToken.ErrCode != "" {
+		return nil, fmt.Errorf("pToken.Errcode = %s, pToken.Errmsg = %s", pToken.ErrCode, pToken.ErrMsg)
 	}
 
 	token := &oauth2.Token{


### PR DESCRIPTION
## Description
The DingTalk access-token endpoint returns the error `code` field as a string
(e.g. `"InvalidParameter"`), but `DingTalkAccessToken.ErrCode` was typed as `int`.
Whenever the token request failed, `json.Unmarshal` failed to decode the response
into the struct, so the actual error message was lost and replaced by an
unmarshal error — making DingTalk login failures hard to diagnose.