### PR TITLE
feat: show display name in role and permission selectors

### DIFF
--- a/web/src/PermissionEditPage.js
+++ b/web/src/PermissionEditPage.js
@@ -244,7 +244,7 @@ class PermissionEditPage extends React.Component {
                 if (res.status !== "ok") {
                   return res;
                 }
-                const data = res.data.map((user) => Setting.getOption(`${user.owner}/${user.name}`, `${user.owner}/${user.name}`));
+                const data = res.data.map((user) => Setting.getOption(user.displayName ? `${user.displayName} (${user.owner}/${user.name})` : `${user.owner}/${user.name}`, `${user.owner}/${user.name}`));
                 if (args?.[1] === 1 && Array.isArray(res?.data)) {
                   res.data = [
                     Setting.getOption(i18next.t("general:All"), "*"),
@@ -281,7 +281,7 @@ class PermissionEditPage extends React.Component {
                 if (res.status !== "ok") {
                   return res;
                 }
-                const data = res.data.map((group) => Setting.getOption(`${group.owner}/${group.name}`, `${group.owner}/${group.name}`));
+                const data = res.data.map((group) => Setting.getOption(group.displayName ? `${group.displayName} (${group.owner}/${group.name})` : `${group.owner}/${group.name}`, `${group.owner}/${group.name}`));
                 if (args?.[2] === 1 && Array.isArray(res?.data)) {
                   res.data = [
                     Setting.getOption(i18next.t("general:All"), "*"),

--- a/web/src/RoleEditPage.js
+++ b/web/src/RoleEditPage.js
@@ -151,7 +151,7 @@ class RoleEditPage extends React.Component {
                 return [this.state.role.owner, page, pageSize, field, searchText];
               }}
               reloadKey={this.state.role.owner}
-              optionMapper={(user) => Setting.getOption(`${user.owner}/${user.name}`, `${user.owner}/${user.name}`)}
+              optionMapper={(user) => Setting.getOption(user.displayName ? `${user.displayName} (${user.owner}/${user.name})` : `${user.owner}/${user.name}`, `${user.owner}/${user.name}`)}
               filterOption={false}
               onChange={(value => {this.updateRoleField("users", value);})}
             />
@@ -172,7 +172,7 @@ class RoleEditPage extends React.Component {
                 return [this.state.role.owner, false, page, pageSize, field, searchText, "", ""];
               }}
               reloadKey={this.state.role.owner}
-              optionMapper={(group) => Setting.getOption(`${group.owner}/${group.name}`, `${group.owner}/${group.name}`)}
+              optionMapper={(group) => Setting.getOption(group.displayName ? `${group.displayName} (${group.owner}/${group.name})` : `${group.owner}/${group.name}`, `${group.owner}/${group.name}`)}
               filterOption={false}
               onChange={(value => {this.updateRoleField("groups", value);})}
             />


### PR DESCRIPTION
## Summary
  Improve readability in role and permission edit pages by showing `displayName` in user and
  group selectors, while keeping `owner/name` visible for identification.

  ## Changes
  - `web/src/RoleEditPage.js`
    - User selector now displays: `displayName (owner/name)`
    - Group selector now displays: `displayName (owner/name)`
  - `web/src/PermissionEditPage.js`
    - User selector now displays: `displayName (owner/name)`
    - Group selector now displays: `displayName (owner/name)`

  ## Notes
  - Falls back to `owner/name` when `displayName` is empty
  - The underlying selected value is unchanged