### PR TITLE
feat: allow group reads without member expansion

### DIFF
--- a/controllers/group.go
+++ b/controllers/group.go
@@ -27,6 +27,7 @@ import (
 // @Tag Group API
 // @Description get groups
 // @Param   owner     query    string  true        "The owner of groups"
+// @Param   withUsers query    bool    false       "Whether to include group members (default true)"
 // @Success 200 {array} object.Group The Response object
 // @router /get-groups [get]
 func (c *ApiController) GetGroups() {
@@ -38,6 +39,7 @@ func (c *ApiController) GetGroups() {
 	sortField := c.Ctx.Input.Query("sortField")
 	sortOrder := c.Ctx.Input.Query("sortOrder")
 	withTree := c.Ctx.Input.Query("withTree")
+	withUsers := c.Ctx.Input.Query("withUsers")
 
 	if limit == "" || page == "" {
 		groups, err := object.GetGroups(owner)
@@ -46,10 +48,12 @@ func (c *ApiController) GetGroups() {
 			return
 		}
 
-		err = object.ExtendGroupsWithUsers(groups)
-		if err != nil {
-			c.ResponseError(err.Error())
-			return
+		if util.ShouldExtendGroupWithUsers(withUsers) {
+			err = object.ExtendGroupsWithUsers(groups)
+			if err != nil {
+				c.ResponseError(err.Error())
+				return
+			}
 		}
 
 		if withTree == "true" {
@@ -90,10 +94,12 @@ func (c *ApiController) GetGroups() {
 			}
 		}
 
-		err = object.ExtendGroupsWithUsers(groups)
-		if err != nil {
-			c.ResponseError(err.Error())
-			return
+		if util.ShouldExtendGroupWithUsers(withUsers) {
+			err = object.ExtendGroupsWithUsers(groups)
+			if err != nil {
+				c.ResponseError(err.Error())
+				return
+			}
 		}
 
 		c.ResponseOk(groups, paginator.Nums())
@@ -106,10 +112,12 @@ func (c *ApiController) GetGroups() {
 // @Tag Group API
 // @Description get group
 // @Param   id     query    string  true        "The id ( owner/name ) of the group"
+// @Param   withUsers query bool    false       "Whether to include group members (default true)"
 // @Success 200 {object} object.Group The Response object
 // @router /get-group [get]
 func (c *ApiController) GetGroup() {
 	id := c.Ctx.Input.Query("id")
+	withUsers := c.Ctx.Input.Query("withUsers")
 
 	group, err := object.GetGroup(id)
 	if err != nil {
@@ -117,10 +125,12 @@ func (c *ApiController) GetGroup() {
 		return
 	}
 
-	err = object.ExtendGroupWithUsers(group)
-	if err != nil {
-		c.ResponseError(err.Error())
-		return
+	if util.ShouldExtendGroupWithUsers(withUsers) {
+		err = object.ExtendGroupWithUsers(group)
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
 	}
 
 	c.ResponseOk(group)

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -2770,6 +2770,12 @@
                         "description": "The id ( owner/name ) of the group",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "withUsers",
+                        "description": "Whether to include group members (default true)",
+                        "type": "boolean"
                     }
                 ],
                 "responses": {
@@ -2796,6 +2802,12 @@
                         "description": "The owner of groups",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "withUsers",
+                        "description": "Whether to include group members (default true)",
+                        "type": "boolean"
                     }
                 ],
                 "responses": {

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -1797,6 +1797,10 @@ paths:
         description: The id ( owner/name ) of the group
         required: true
         type: string
+      - in: query
+        name: withUsers
+        description: Whether to include group members (default true)
+        type: boolean
       responses:
         "200":
           description: The Response object
@@ -1814,6 +1818,10 @@ paths:
         description: The owner of groups
         required: true
         type: string
+      - in: query
+        name: withUsers
+        description: Whether to include group members (default true)
+        type: boolean
       responses:
         "200":
           description: The Response object

--- a/util/group.go
+++ b/util/group.go
@@ -1,0 +1,19 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+func ShouldExtendGroupWithUsers(withUsers string) bool {
+	return withUsers != "false"
+}

--- a/util/group_test.go
+++ b/util/group_test.go
@@ -1,0 +1,24 @@
+package util
+
+import "testing"
+
+func TestShouldExtendGroupWithUsers(t *testing.T) {
+	tests := []struct {
+		name      string
+		withUsers string
+		want      bool
+	}{
+		{name: "keeps default behavior", withUsers: "", want: true},
+		{name: "keeps explicit expansion", withUsers: "true", want: true},
+		{name: "skips explicit expansion opt-out", withUsers: "false", want: false},
+		{name: "keeps compatibility for unknown values", withUsers: "invalid", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldExtendGroupWithUsers(tt.withUsers); got != tt.want {
+				t.Fatalf("ShouldExtendGroupWithUsers(%q) = %v, want %v", tt.withUsers, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Add an optional `withUsers` query parameter to:

- `GET /api/get-group`
- `GET /api/get-groups`

The default remains `true` for backward compatibility. Only an explicit `withUsers=false` skips `ExtendGroupWithUsers()` / `ExtendGroupsWithUsers()`.

## Why

Group metadata consumers do not always need membership data. Today these endpoints always expand members, which calls `GetAllUsersByGroup()` and reloads the complete Casbin policy. For `get-groups`, that work is repeated for each group in the returned page.

Allowing callers to opt out gives metadata reads a bounded path with respect to membership policy size and avoids unnecessary response data. This is the first, compatibility-preserving part of #5714.

This PR intentionally does **not** claim to fix group-member count or pagination. `GET /api/get-users?groupName=...` still materializes the complete membership set before SQL pagination; that broader storage-level count/cursor work remains tracked by #5714.

## Compatibility

- omitted `withUsers`: existing behavior
- `withUsers=true`: existing behavior
- `withUsers=false`: return group metadata without populating `users`
- unknown values: existing behavior

## Tests

- Added focused unit coverage for default, explicit true, explicit false, and unknown values.
- `go test ./util -run '^TestShouldExtendGroupWithUsers$' -count=1 -v`
- `go test ./controllers -tags skipCi -run '^$' -count=1`
- Parsed `swagger/swagger.json` and `swagger/swagger.yml`
- `git diff --check`

Refs #5714
