### PR TITLE
fix: only append admin columns when columns query is empty

### DIFF
--- a/object/user.go
+++ b/object/user.go
@@ -856,7 +856,8 @@ func UpdateUser(id string, user *User, columns []string, isAdmin bool) (bool, er
 		}
 	}
 
-	if len(columns) == 0 {
+	columnsWereEmpty := len(columns) == 0
+	if columnsWereEmpty {
 		columns = []string{
 			"owner", "display_name", "avatar", "first_name", "last_name",
 			"location", "address", "addresses", "country_code", "region", "language", "affiliation", "title", "id_card_type", "id_card", "homepage", "bio", "tag", "language", "gender", "birthday", "education", "score", "karma", "ranking", "signup_application", "register_type", "register_source",
@@ -872,7 +873,9 @@ func UpdateUser(id string, user *User, columns []string, isAdmin bool) (bool, er
 			"cart", "application_scopes",
 		}
 	}
-	if isAdmin {
+	// Only expand the admin-sensitive whitelist for full updates.
+	// When callers pass an explicit columns list, respect it as a partial-update whitelist.
+	if isAdmin && columnsWereEmpty {
 		columns = append(columns, "name", "id", "email", "phone", "country_code", "type", "balance", "balance_credit", "balance_currency", "mfa_items", "register_type", "register_source",
 			"is_admin", "is_forbidden", "is_deleted", "uid_number")
 	}


### PR DESCRIPTION
## Summary
Respect the `columns` whitelist on `/api/update-user` for admin callers.

1. **Keep admin-sensitive fields for full updates only**  
   When `columns` is empty, admins still get `email`, `phone`, `is_forbidden`, and the rest appended as before.
2. **Honor explicit `columns` as a partial-update whitelist**  
   When callers pass `columns` (e.g. `?columns=tag`), only those columns are updated — admin status no longer expands the list.
3. **Leave the UI path unchanged**  
   The web console does not send `columns`, so admin edit behavior stays the same.

## Test plan
- [ ] Admin update without `columns` still persists email / phone / isForbidden
- [ ] Admin update with `?columns=tag` updates only `tag` (plus hash / updated_time)
- [ ] `go test ./object/` passes

Fixes #5723