### PR TITLE
fix: revoke access when a user is forbidden

### DIFF
--- a/controllers/token.go
+++ b/controllers/token.go
@@ -606,6 +606,16 @@ func (c *ApiController) IntrospectToken() {
 	}
 
 	if token != nil {
+		ownerActive, err := token.IsOwnerActive()
+		if err != nil {
+			c.ResponseTokenError(object.InvalidRequest, err.Error())
+			return
+		}
+		if !ownerActive {
+			respondWithInactiveToken()
+			return
+		}
+
 		application, err = object.GetApplication(fmt.Sprintf("%s/%s", token.Owner, token.Application))
 		if err != nil {
 			c.ResponseTokenError(object.InvalidClient, err.Error())

--- a/mcpself/auth.go
+++ b/mcpself/auth.go
@@ -154,6 +154,11 @@ func (c *McpController) GetClaimsFromToken() *object.Claims {
 		return nil
 	}
 
+	ownerActive, err := token.IsOwnerActive()
+	if err != nil || !ownerActive {
+		return nil
+	}
+
 	application, err := object.GetApplication(token.Application)
 	if err != nil || application == nil {
 		return nil

--- a/object/token.go
+++ b/object/token.go
@@ -111,6 +111,28 @@ func GetTokenByAccessToken(accessToken string) (*Token, error) {
 	return &token, nil
 }
 
+// IsOwnerActive reports whether the end-user for this token may still use it.
+// client_credentials tokens are not bound to a user account. Per RFC 7662, a
+// token for a forbidden/disabled user is treated as inactive.
+func (token *Token) IsOwnerActive() (bool, error) {
+	if token == nil {
+		return false, nil
+	}
+	if token.GrantType == "client_credentials" || token.User == "" {
+		return true, nil
+	}
+
+	user, err := getUser(token.Organization, token.User)
+	if err != nil {
+		return false, err
+	}
+	if user == nil || user.IsForbidden {
+		return false, nil
+	}
+
+	return true, nil
+}
+
 func GetTokenByRefreshToken(refreshToken string) (*Token, error) {
 	token := Token{RefreshTokenHash: getTokenHash(refreshToken)}
 	existed, err := ormer.Engine.Get(&token)

--- a/object/token_owner_active_test.go
+++ b/object/token_owner_active_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import "testing"
+
+func TestTokenIsOwnerActive_WithoutUserLookup(t *testing.T) {
+	t.Run("nil token", func(t *testing.T) {
+		var token *Token
+		ok, err := token.IsOwnerActive()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ok {
+			t.Fatal("expected nil token to be inactive")
+		}
+	})
+
+	t.Run("client_credentials", func(t *testing.T) {
+		token := &Token{GrantType: "client_credentials", Organization: "hyperion", User: ""}
+		ok, err := token.IsOwnerActive()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !ok {
+			t.Fatal("expected client_credentials token to be active")
+		}
+	})
+
+	t.Run("empty user", func(t *testing.T) {
+		token := &Token{GrantType: "authorization_code", Organization: "hyperion", User: ""}
+		ok, err := token.IsOwnerActive()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !ok {
+			t.Fatal("expected empty user to skip forbidden check")
+		}
+	})
+}

--- a/object/user.go
+++ b/object/user.go
@@ -896,6 +896,14 @@ func UpdateUser(id string, user *User, columns []string, isAdmin bool) (bool, er
 		return false, err
 	}
 
+	if affected != 0 && shouldTerminateUserAccess(oldUser, user, columns) {
+		// Use the pre-update identity: tokens/sessions are keyed by the current name.
+		err = TerminateUserAccess(oldUser.Owner, oldUser.Name, "")
+		if err != nil {
+			return false, err
+		}
+	}
+
 	return affected != 0, nil
 }
 
@@ -964,6 +972,13 @@ func UpdateUserForAllFields(id string, user *User) (bool, error) {
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(user)
 	if err != nil {
 		return false, err
+	}
+
+	if affected != 0 && shouldTerminateUserAccess(oldUser, user, nil) {
+		err = TerminateUserAccess(oldUser.Owner, oldUser.Name, "")
+		if err != nil {
+			return false, err
+		}
 	}
 
 	return affected != 0, nil

--- a/object/user_terminate.go
+++ b/object/user_terminate.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import "github.com/casdoor/casdoor/util"
+
+// shouldTerminateUserAccess reports whether an update should end the user's
+// sessions and tokens (account forbidden or soft-deleted).
+// When columns is nil, all fields are considered (full update).
+func shouldTerminateUserAccess(oldUser, newUser *User, columns []string) bool {
+	if oldUser == nil || newUser == nil {
+		return false
+	}
+
+	checkForbidden := columns == nil || util.InSlice(columns, "is_forbidden")
+	if checkForbidden && !oldUser.IsForbidden && newUser.IsForbidden {
+		return true
+	}
+
+	checkDeleted := columns == nil || util.InSlice(columns, "is_deleted")
+	if checkDeleted && !oldUser.IsDeleted && newUser.IsDeleted {
+		return true
+	}
+
+	return false
+}
+
+// TerminateUserAccess expires all OAuth tokens and deletes all sessions for the
+// user, mirroring SSO logout-all. host is used for OIDC back-channel logout
+// issuer resolution and may be empty (falls back to configured origin).
+func TerminateUserAccess(organization, username, host string) error {
+	tokens, err := GetTokensByUser(organization, username)
+	if err != nil {
+		return err
+	}
+
+	// Back-channel logout must run before ExpireTokenByUser: it only considers
+	// tokens with expires_in > 0.
+	SendBackchannelLogout(organization, username, "", host)
+
+	_, err = ExpireTokenByUser(organization, username)
+	if err != nil {
+		return err
+	}
+
+	sessions, err := GetUserSessions(organization, username)
+	if err != nil {
+		return err
+	}
+
+	sessionIds := make([]string, 0)
+	for _, session := range sessions {
+		sessionIds = append(sessionIds, session.SessionId...)
+	}
+
+	_, err = DeleteAllUserSessions(organization, username)
+	if err != nil {
+		return err
+	}
+
+	user, err := getUser(organization, username)
+	if err != nil {
+		return err
+	}
+	if user != nil {
+		// Notification failure must not undo forbid/delete: access is already revoked.
+		_ = SendSsoLogoutNotifications(user, sessionIds, tokens)
+	}
+
+	return nil
+}

--- a/object/user_terminate_test.go
+++ b/object/user_terminate_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import "testing"
+
+func TestShouldTerminateUserAccess(t *testing.T) {
+	active := &User{IsForbidden: false, IsDeleted: false}
+	forbidden := &User{IsForbidden: true, IsDeleted: false}
+	deleted := &User{IsForbidden: false, IsDeleted: true}
+
+	tests := []struct {
+		name    string
+		oldUser *User
+		newUser *User
+		columns []string
+		want    bool
+	}{
+		{
+			name:    "forbid with column",
+			oldUser: active,
+			newUser: forbidden,
+			columns: []string{"is_forbidden"},
+			want:    true,
+		},
+		{
+			name:    "forbid without column",
+			oldUser: active,
+			newUser: forbidden,
+			columns: []string{"display_name"},
+			want:    false,
+		},
+		{
+			name:    "forbid full update",
+			oldUser: active,
+			newUser: forbidden,
+			columns: nil,
+			want:    true,
+		},
+		{
+			name:    "already forbidden",
+			oldUser: forbidden,
+			newUser: forbidden,
+			columns: []string{"is_forbidden"},
+			want:    false,
+		},
+		{
+			name:    "unforbid",
+			oldUser: forbidden,
+			newUser: active,
+			columns: []string{"is_forbidden"},
+			want:    false,
+		},
+		{
+			name:    "soft delete with column",
+			oldUser: active,
+			newUser: deleted,
+			columns: []string{"is_deleted"},
+			want:    true,
+		},
+		{
+			name:    "nil users",
+			oldUser: nil,
+			newUser: forbidden,
+			columns: []string{"is_forbidden"},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldTerminateUserAccess(tt.oldUser, tt.newUser, tt.columns)
+			if got != tt.want {
+				t.Fatalf("shouldTerminateUserAccess() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/routers/auto_signin_filter.go
+++ b/routers/auto_signin_filter.go
@@ -70,6 +70,16 @@ func AutoSigninFilter(ctx *context.Context) {
 			return
 		}
 
+		ownerActive, err := token.IsOwnerActive()
+		if err != nil {
+			responseError(ctx, err.Error())
+			return
+		}
+		if !ownerActive {
+			responseError(ctx, "The user is forbidden to sign in, please contact the administrator")
+			return
+		}
+
 		// Validate DPoP proof for DPoP-bound tokens (RFC 9449).
 		if token.TokenType == "DPoP" {
 			dpopProof := ctx.Request.Header.Get("DPoP")


### PR DESCRIPTION
## Summary
Revoke an account's access immediately when it is forbidden (and keep already-issued tokens inactive during Casdoor validation).

1. **Terminate sessions and tokens on forbid / soft-delete**  
   When `IsForbidden` (or soft-delete) transitions to `true`, call the same path as SSO logout-all: expire tokens, delete all sessions, and send logout notifications.
2. **Treat forbidden owners as inactive during token validation**  
   Add `Token.IsOwnerActive()` and use it in introspection, auto-signin, and MCP auth so leftover access tokens are rejected even if a row still exists.
3. **Leave refresh behavior as-is**  
   Refresh already refused forbidden users; this closes the gap for existing sessions, token rows, and access-token validation.

## Test plan
- [ ] Forbid a signed-in user → Sessions UI no longer shows their sessions
- [ ] Tokens for that user have `expires_in = 0` (or are gone from active use)
- [ ] Introspect a previously issued access token → `active: false`
- [ ] Unforbid the user → no sessions/tokens are recreated automatically
- [ ] Soft-delete also terminates sessions/tokens
- [ ] `go test ./object/ -run 'TestShouldTerminateUserAccess|TestTokenIsOwnerActive'` passes

Fixes #5725  
Fixes #5727