### PR TITLE
fix: persist expires_in=0 in ExpireTokenByUser bulk update

### DIFF
--- a/object/token.go
+++ b/object/token.go
@@ -111,6 +111,26 @@ func GetTokenByAccessToken(accessToken string) (*Token, error) {
 	return &token, nil
 }
 
+// IsUserActive checks whether the token's end user is still allowed to use it, a token issued to
+// a forbidden, soft-deleted or removed user is treated as inactive. The tokens of the
+// "client_credentials" grant are not bound to an end user, so they are always active.
+// Refs: https://datatracker.ietf.org/doc/html/rfc7662
+func (token *Token) IsUserActive() (bool, error) {
+	if token.GrantType == "client_credentials" || token.User == "" {
+		return true, nil
+	}
+
+	user, err := getUser(token.Organization, token.User)
+	if err != nil {
+		return false, err
+	}
+	if user == nil {
+		return false, nil
+	}
+
+	return !user.IsForbidden && !user.IsDeleted, nil
+}
+
 func GetTokenByRefreshToken(refreshToken string) (*Token, error) {
 	token := Token{RefreshTokenHash: getTokenHash(refreshToken)}
 	existed, err := ormer.Engine.Get(&token)
@@ -236,7 +256,7 @@ func GetActiveTokensByUser(organization, username string) ([]*Token, error) {
 }
 
 func ExpireTokenByUser(owner, username string) (bool, error) {
-	affected, err := ormer.Engine.Where("organization = ? and user = ?", owner, username).Cols("expires_in").Update(&Token{ExpiresIn: 0})
+	affected, err := ormer.Engine.Table(&Token{}).Where("organization = ? and user = ?", owner, username).Update(map[string]interface{}{"expires_in": 0})
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## Summary

Fix bulk OAuth token revocation in `ExpireTokenByUser` so `/api/sso-logout?logoutAll=true` and the forbid termination path actually persist `expires_in = 0` in the token store.

Single-token logout via `/api/logout?id_token_hint=` already worked through `ExpireTokenByAccessToken`; bulk logout and #5727 reuse `ExpireTokenByUser`, which did not reliably write zero to the database.

## Change

Use an explicit map update in `ExpireTokenByUser`:

```go
ormer.Engine.Table(&Token{}).
    Where("organization = ? and user = ?", owner, username).
    Update(map[string]interface{}{"expires_in": 0})
```

## Test plan

- [ ] Sign in, confirm `get-token` shows `expiresIn > 0`
- [ ] Call `POST /api/sso-logout?logoutAll=true` with a live user Bearer token
- [ ] Re-read the token via admin/API → `expiresIn = 0`
- [ ] `get-account` with the same Bearer → unauthorized / expired
- [ ] Forbid a signed-in user → all of their token rows have `expires_in = 0`
- [ ] `/api/logout?id_token_hint=` still expires a single token as before

Fixes #5732
Related: #5727, #4390