### PR TITLE
feat: link OAuth tokens to Beego session for session-scoped revoke

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -368,7 +368,7 @@ func (c *ApiController) Signup() {
 			return
 		}
 
-		code, err := object.GetOAuthCode(userId, clientId, "", "password", responseType, redirectUri, scope, state, nonce, codeChallenge, "", c.Ctx.Request.Host, c.GetAcceptLanguage())
+		code, err := object.GetOAuthCode(userId, clientId, "", "password", responseType, redirectUri, scope, state, nonce, codeChallenge, "", c.Ctx.Request.Host, c.GetAcceptLanguage(), c.Ctx.Input.CruSession.SessionID(context.Background()))
 		if err != nil {
 			c.ResponseError(err.Error(), nil)
 			return
@@ -613,6 +613,12 @@ func (c *ApiController) SsoLogout() {
 		// Logout from current session only
 		sessionIds = []string{currentSessionId}
 
+		_, err = object.ExpireTokensBySessionIds(sessionIds)
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
+
 		// Only delete the current session's Beego session
 		object.DeleteBeegoSession(sessionIds)
 
@@ -711,7 +717,8 @@ func (c *ApiController) GetAccount() {
 
 	accessToken := c.GetSessionToken()
 	if accessToken == "" {
-		accessToken, err = object.GetAccessTokenByUser(user, c.Ctx.Request.Host)
+		beegoSessionId := c.Ctx.Input.CruSession.SessionID(context.Background())
+		accessToken, err = object.GetAccessTokenByUser(user, c.Ctx.Request.Host, beegoSessionId)
 		if err != nil {
 			c.ResponseError(err.Error())
 			return
@@ -876,6 +883,11 @@ func (c *ApiController) GetCaptcha() {
 
 func (c *ApiController) deleteUserSession(user string, beegoSessionId string) error {
 	owner, username, err := util.GetOwnerAndNameFromIdWithError(user)
+	if err != nil {
+		return err
+	}
+
+	_, err = object.ExpireTokensBySessionIds([]string{beegoSessionId})
 	if err != nil {
 		return err
 	}

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -188,7 +188,7 @@ func (c *ApiController) HandleLoggedIn(application *object.Application, user *ob
 		if consentRequired {
 			resp = &Response{Status: "ok", Data: map[string]bool{"required": true}}
 		} else {
-			code, err := object.GetOAuthCode(userId, clientId, form.Provider, form.SigninMethod, responseType, redirectUri, scope, state, nonce, codeChallenge, resource, c.Ctx.Request.Host, c.GetAcceptLanguage())
+			code, err := object.GetOAuthCode(userId, clientId, form.Provider, form.SigninMethod, responseType, redirectUri, scope, state, nonce, codeChallenge, resource, c.Ctx.Request.Host, c.GetAcceptLanguage(), c.Ctx.Input.CruSession.SessionID(context.Background()))
 			if err != nil {
 				c.ResponseError(err.Error(), nil)
 				return
@@ -206,7 +206,7 @@ func (c *ApiController) HandleLoggedIn(application *object.Application, user *ob
 			if !valid {
 				resp = &Response{Status: "error", Msg: "error: invalid_scope", Data: ""}
 			} else {
-				token, _ := object.GetTokenByUser(application, user, expandedScope, nonce, c.Ctx.Request.Host)
+				token, _ := object.GetTokenByUser(application, user, expandedScope, nonce, c.Ctx.Request.Host, c.Ctx.Input.CruSession.SessionID(context.Background()))
 				resp = tokenToResponse(token)
 			}
 		}

--- a/controllers/consent.go
+++ b/controllers/consent.go
@@ -15,6 +15,7 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/casdoor/casdoor/object"
@@ -216,6 +217,7 @@ func (c *ApiController) GrantConsent() {
 		request.Resource,
 		c.Ctx.Request.Host,
 		c.GetAcceptLanguage(),
+		c.Ctx.Input.CruSession.SessionID(context.Background()),
 	)
 	if err != nil {
 		c.ResponseError(err.Error())

--- a/controllers/server.go
+++ b/controllers/server.go
@@ -15,6 +15,7 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -201,7 +202,7 @@ func (c *ApiController) GetMcpAccessToken() {
 		return
 	}
 
-	token, err := object.GetTokenByUser(application, user, "read", "", c.Ctx.Request.Host)
+	token, err := object.GetTokenByUser(application, user, "read", "", c.Ctx.Request.Host, c.Ctx.Input.CruSession.SessionID(context.Background()))
 	if err != nil {
 		c.ResponseError(err.Error())
 		return

--- a/controllers/token.go
+++ b/controllers/token.go
@@ -15,6 +15,7 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -351,6 +352,16 @@ func (c *ApiController) GetOAuthToken() {
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
+	}
+
+	if grantType == "authorization_code" {
+		if tokenWrapper, ok := token.(*object.TokenWrapper); ok {
+			sessionId := c.Ctx.Input.CruSession.SessionID(context.Background())
+			if bindErr := object.BindTokenSessionIdByAccessToken(tokenWrapper.AccessToken, sessionId); bindErr != nil {
+				c.ResponseError(bindErr.Error())
+				return
+			}
+		}
 	}
 
 	if pendingDeviceCode != "" {

--- a/object/session.go
+++ b/object/session.go
@@ -187,6 +187,11 @@ func DeleteSession(id, curSessionId string) (bool, error) {
 		return false, fmt.Errorf("session:session id %s is the current session and cannot be deleted", curSessionId)
 	}
 
+	_, err = ExpireTokensBySessionIds(session.SessionId)
+	if err != nil {
+		return false, err
+	}
+
 	DeleteBeegoSession(session.SessionId)
 
 	affected, err := ormer.Engine.ID(core.PK{owner, name, application}).Delete(&Session{})
@@ -227,6 +232,11 @@ func DeleteSessionId(id string, sessionId string) (bool, error) {
 	}
 	if session == nil {
 		return false, nil
+	}
+
+	_, err = ExpireTokensBySessionIds([]string{sessionId})
+	if err != nil {
+		return false, err
 	}
 
 	DeleteBeegoSession([]string{sessionId})

--- a/object/token.go
+++ b/object/token.go
@@ -46,6 +46,7 @@ type Token struct {
 	CodeExpireIn     int64  `json:"codeExpireIn"`
 	Resource         string `xorm:"varchar(255)" json:"resource"`           // RFC 8707 Resource Indicator
 	DPoPJkt          string `xorm:"varchar(255) 'dpop_jkt'" json:"dPoPJkt"` // RFC 9449 DPoP JWK thumbprint binding
+	SessionId        string `xorm:"varchar(100) index" json:"sessionId"`    // Beego session id that minted this token
 }
 
 func GetTokenCount(owner, organization, field, value string) (int64, error) {
@@ -262,6 +263,36 @@ func ExpireTokenByUser(owner, username string) (bool, error) {
 	}
 
 	return affected != 0, nil
+}
+
+func ExpireTokensBySessionIds(sessionIds []string) (bool, error) {
+	if len(sessionIds) == 0 {
+		return false, nil
+	}
+
+	affected, err := ormer.Engine.Table(&Token{}).In("session_id", sessionIds).Where("expires_in > 0").Update(map[string]interface{}{"expires_in": 0})
+	if err != nil {
+		return false, err
+	}
+
+	return affected != 0, nil
+}
+
+func BindTokenSessionIdByAccessToken(accessToken, sessionId string) error {
+	if accessToken == "" || sessionId == "" {
+		return nil
+	}
+
+	token, err := GetTokenByAccessToken(accessToken)
+	if err != nil {
+		return err
+	}
+	if token == nil || token.SessionId != "" {
+		return nil
+	}
+
+	_, err = ormer.Engine.Table(&Token{}).Where("owner = ? and name = ?", token.Owner, token.Name).Update(map[string]interface{}{"session_id": sessionId})
+	return err
 }
 
 // updateTokenDPoP updates the token_type and dpop_jkt columns for DPoP binding (RFC 9449).

--- a/object/token_oauth.go
+++ b/object/token_oauth.go
@@ -456,7 +456,7 @@ func GetJwtBearerToken(application *Application, assertion string, scope string,
 }
 
 // GetTokenByUser mints a token for the given user (Implicit flow helper).
-func GetTokenByUser(application *Application, user *User, scope string, nonce string, host string) (*Token, error) {
+func GetTokenByUser(application *Application, user *User, scope string, nonce string, host string, sessionId string) (*Token, error) {
 	err := ExtendUserWithRolesAndPermissions(user)
 	if err != nil {
 		return nil, err
@@ -481,6 +481,7 @@ func GetTokenByUser(application *Application, user *User, scope string, nonce st
 		Scope:        scope,
 		TokenType:    "Bearer",
 		CodeIsUsed:   true,
+		SessionId:    sessionId,
 	}
 	_, err = AddToken(token)
 	if err != nil {
@@ -740,7 +741,7 @@ func GetTokenExchangeToken(application *Application, clientSecret string, subjec
 	return token, nil, nil
 }
 
-func GetAccessTokenByUser(user *User, host string) (string, error) {
+func GetAccessTokenByUser(user *User, host string, sessionId string) (string, error) {
 	application, err := GetApplicationByUser(user)
 	if err != nil {
 		return "", err
@@ -749,7 +750,7 @@ func GetAccessTokenByUser(user *User, host string) (string, error) {
 		return "", fmt.Errorf("the application for user %s is not found", user.Id)
 	}
 
-	token, err := GetTokenByUser(application, user, "profile", "", host)
+	token, err := GetTokenByUser(application, user, "profile", "", host, sessionId)
 	if err != nil {
 		return "", err
 	}

--- a/object/token_oauth_util.go
+++ b/object/token_oauth_util.go
@@ -299,7 +299,7 @@ func CheckOAuthLogin(clientId string, responseType string, redirectUri string, s
 	return "", application, nil
 }
 
-func GetOAuthCode(userId string, clientId string, provider string, signinMethod string, responseType string, redirectUri string, scope string, state string, nonce string, challenge string, resource string, host string, lang string) (*Code, error) {
+func GetOAuthCode(userId string, clientId string, provider string, signinMethod string, responseType string, redirectUri string, scope string, state string, nonce string, challenge string, resource string, host string, lang string, sessionId string) (*Code, error) {
 	user, err := GetUser(userId)
 	if err != nil {
 		return nil, err
@@ -378,6 +378,7 @@ func GetOAuthCode(userId string, clientId string, provider string, signinMethod 
 		CodeIsUsed:    false,
 		CodeExpireIn:  time.Now().Add(time.Minute * 5).Unix(),
 		Resource:      resource,
+		SessionId:     sessionId,
 	}
 	_, err = AddToken(token)
 	if err != nil {
@@ -515,6 +516,7 @@ func RefreshToken(application *Application, grantType string, refreshToken strin
 		ExpiresIn:    int(application.ExpireInHours * float64(hourSeconds)),
 		Scope:        scope,
 		TokenType:    "Bearer",
+		SessionId:    token.SessionId,
 	}
 	_, err = AddToken(newToken)
 	if err != nil {
@@ -640,7 +642,7 @@ func mintImplicitToken(application *Application, username string, scope string, 
 		}, nil
 	}
 
-	token, err := GetTokenByUser(application, user, scope, nonce, host)
+	token, err := GetTokenByUser(application, user, scope, nonce, host, "")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/routers/static_filter.go
+++ b/routers/static_filter.go
@@ -16,6 +16,7 @@ package routers
 
 import (
 	"compress/gzip"
+	stdcontext "context"
 	"errors"
 	"fmt"
 	"io"
@@ -121,7 +122,7 @@ func fastAutoSignin(ctx *context.Context) (string, error) {
 		return "", nil
 	}
 
-	code, err := object.GetOAuthCode(userId, clientId, "", "autoSignin", responseType, redirectUri, scope, state, nonce, codeChallenge, resource, ctx.Request.Host, getAcceptLanguage(ctx))
+	code, err := object.GetOAuthCode(userId, clientId, "", "autoSignin", responseType, redirectUri, scope, state, nonce, codeChallenge, resource, ctx.Request.Host, getAcceptLanguage(ctx), ctx.Input.CruSession.SessionID(stdcontext.Background()))
 	if err != nil {
 		return "", err
 	} else if code.Message != "" {


### PR DESCRIPTION
Fixes #5737

## Summary

- Add `session_id` on `Token`, set when minting OAuth codes/tokens and inherited on refresh.
- Add `ExpireTokensBySessionIds` to set `expires_in = 0` for tokens linked to ending sessions.
- Revoke linked tokens when a session is deleted (admin UI), on single-session logout, and on logout without `id_token_hint`.
- Best-effort backfill of `session_id` on authorization_code exchange when the Casdoor session cookie is present.

## Test plan

- [ ] Sign in via OAuth authorization code; confirm the token row has `sessionId` in admin/API.
- [ ] Delete that session in Casdoor admin → token `expiresIn` becomes `0`; refresh fails.
- [ ] Sign in from two browsers; deleting one session does not expire the other device's token.
- [ ] `POST /api/sso-logout?logoutAll=false` expires tokens for the current session only.
- [ ] `GET /api/logout` without `id_token_hint` expires tokens for the current session.
- [ ] Refresh issues a new token row with the same `sessionId`.