### PR TITLE
fix: PostgreSQL queries on token.user column

### DIFF
--- a/object/notification.go
+++ b/object/notification.go
@@ -80,7 +80,7 @@ type SsoLogoutNotification struct {
 // GetTokensByUser retrieves all tokens for a specific user
 func GetTokensByUser(owner, username string) ([]*Token, error) {
 	tokens := []*Token{}
-	err := ormer.Engine.Where("organization = ? and user = ?", owner, username).Find(&tokens)
+	err := ormer.Engine.Find(&tokens, &Token{Organization: owner, User: username})
 	if err != nil {
 		return nil, err
 	}

--- a/object/token.go
+++ b/object/token.go
@@ -251,12 +251,12 @@ func DeleteToken(token *Token) (bool, error) {
 
 func GetActiveTokensByUser(organization, username string) ([]*Token, error) {
 	tokens := []*Token{}
-	err := ormer.Engine.Where("organization = ? and user = ? and expires_in > 0", organization, username).Find(&tokens)
+	err := ormer.Engine.Where("expires_in > 0").Find(&tokens, &Token{Organization: organization, User: username})
 	return tokens, err
 }
 
 func ExpireTokenByUser(owner, username string) (bool, error) {
-	affected, err := ormer.Engine.Where("organization = ? and user = ?", owner, username).Cols("expires_in").Update(&Token{ExpiresIn: 0})
+	affected, err := ormer.Engine.Cols("expires_in").Update(&Token{ExpiresIn: 0}, &Token{Organization: owner, User: username})
 	if err != nil {
 		return false, err
 	}

--- a/object/user.go
+++ b/object/user.go
@@ -1524,9 +1524,7 @@ func userChangeTrigger(owner string, oldName string, newName string) error {
 		}
 	}
 
-	resource := new(Resource)
-	resource.User = newName
-	_, err = session.Where("user=?", oldName).Update(resource)
+	_, err = session.Cols("user").Update(&Resource{User: newName}, &Resource{User: oldName})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Replace raw SQL `user = ?` filters with ORM struct conditions so PostgreSQL quotes the `"user"` column correctly.
- Fixes bulk token revocation (`ExpireTokenByUser`), active token lookup (`GetActiveTokensByUser`), SSO logout notifications (`GetTokensByUser`), and resource rename on username change (`userChangeTrigger`).
- Closes #5739.

## Root cause

On PostgreSQL, unquoted `user` in `WHERE` is the session user function, not the table column. Queries match zero rows silently. MySQL is unaffected.

## Test plan

- [ ] Verified on PostgreSQL: `sso-logout?logoutAll=true` sets `expires_in=0` for all user tokens
- [ ] Verified forbidding a user expires OAuth tokens
- [ ] Verified username rename updates `resource.user`
- [ ] Upstream CI (MySQL/SQLite)