### PR TITLE
feat: keep the RFC 8707 resource audience on the refresh_token grant

### DIFF
--- a/controllers/token.go
+++ b/controllers/token.go
@@ -384,6 +384,7 @@ func (c *ApiController) RefreshToken() {
 	scope := c.Ctx.Input.Query("scope")
 	clientId := c.Ctx.Input.Query("client_id")
 	clientSecret := c.Ctx.Input.Query("client_secret")
+	resource := c.Ctx.Input.Query("resource")
 	host := c.Ctx.Request.Host
 
 	if clientId == "" {
@@ -395,6 +396,9 @@ func (c *ApiController) RefreshToken() {
 			grantType = tokenRequest.GrantType
 			scope = tokenRequest.Scope
 			refreshToken = tokenRequest.RefreshToken
+			if resource == "" {
+				resource = tokenRequest.Resource
+			}
 		}
 	}
 
@@ -404,7 +408,7 @@ func (c *ApiController) RefreshToken() {
 	}
 
 	dpopProof := c.Ctx.Request.Header.Get("DPoP")
-	refreshToken2, err := object.RefreshToken(application, grantType, refreshToken, scope, clientId, clientSecret, host, dpopProof)
+	refreshToken2, err := object.RefreshToken(application, grantType, refreshToken, scope, clientId, clientSecret, resource, host, dpopProof)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return

--- a/object/token_oauth.go
+++ b/object/token_oauth.go
@@ -99,7 +99,7 @@ func GetOAuthToken(grantType string, clientId string, clientSecret string, code 
 	case "urn:ietf:params:oauth:grant-type:token-exchange": // Token Exchange Grant (RFC 8693)
 		token, tokenError, err = GetTokenExchangeToken(application, clientSecret, subjectToken, subjectTokenType, audience, scope, host)
 	case "refresh_token":
-		refreshToken2, err := RefreshToken(application, grantType, refreshToken, scope, clientId, clientSecret, host, dpopProof)
+		refreshToken2, err := RefreshToken(application, grantType, refreshToken, scope, clientId, clientSecret, resource, host, dpopProof)
 		if err != nil {
 			return nil, err
 		}

--- a/object/token_oauth_util.go
+++ b/object/token_oauth_util.go
@@ -390,7 +390,7 @@ func GetOAuthCode(userId string, clientId string, provider string, signinMethod 
 	}, nil
 }
 
-func RefreshToken(application *Application, grantType string, refreshToken string, scope string, clientId string, clientSecret string, host string, dpopProof string) (interface{}, error) {
+func RefreshToken(application *Application, grantType string, refreshToken string, scope string, clientId string, clientSecret string, resource string, host string, dpopProof string) (interface{}, error) {
 	if grantType != "refresh_token" {
 		return &TokenError{
 			Error:            UnsupportedGrantType,
@@ -436,6 +436,27 @@ func RefreshToken(application *Application, grantType string, refreshToken strin
 			ErrorDescription: "refresh token is expired",
 		}, nil
 	}
+
+	// The refresh token must belong to the authenticated client, exactly as the
+	// authorization_code exchange checks it. Without this a client may present a
+	// refresh token issued to a different application and, together with the
+	// audience restore below, mint a token carrying another grant's resource.
+	if application.Name != token.Application {
+		return &TokenError{
+			Error:            InvalidGrant,
+			ErrorDescription: fmt.Sprintf("the token is for wrong application (client_id), application.Name: [%s], token.Application: [%s]", application.Name, token.Application),
+		}, nil
+	}
+
+	// RFC 8707: the refreshed token must keep the audience of the original grant.
+	// The client MAY repeat the resource parameter; when it does, it has to match.
+	if resource != "" && resource != token.Resource {
+		return &TokenError{
+			Error:            InvalidGrant,
+			ErrorDescription: fmt.Sprintf("resource parameter does not match the original grant, expected: [%s], got: [%s]", token.Resource, resource),
+		}, nil
+	}
+	resource = token.Resource
 
 	cert, err := getCertByApplication(application)
 	if err != nil {
@@ -494,7 +515,7 @@ func RefreshToken(application *Application, grantType string, refreshToken strin
 		return nil, err
 	}
 
-	newAccessToken, newRefreshToken, tokenName, err := generateJwtToken(application, user, "", "", "", scope, "", host)
+	newAccessToken, newRefreshToken, tokenName, err := generateJwtToken(application, user, "", "", "", scope, resource, host)
 	if err != nil {
 		return &TokenError{
 			Error:            EndpointError,
@@ -515,6 +536,7 @@ func RefreshToken(application *Application, grantType string, refreshToken strin
 		ExpiresIn:    int(application.ExpireInHours * float64(hourSeconds)),
 		Scope:        scope,
 		TokenType:    "Bearer",
+		Resource:     resource,
 	}
 	_, err = AddToken(newToken)
 	if err != nil {


### PR DESCRIPTION
### What

RFC 8707 Resource Indicators (#5096, #5098) bind the access-token audience to the `resource` from the authorization request. The `refresh_token` grant was never wired into this, so a refreshed token silently drops the audience.

### The bug

`RefreshToken()` does not take a `resource` argument, never reads the `Resource` column of the token it just looked up, and calls `generateJwtToken()` with an empty resource — so the refreshed token falls back to `aud = application.ClientId`. The new token row is also written without `Resource`, so the binding is lost in the database too and no later refresh can recover it.

For a resource server that validates the audience — the whole point of RFC 8707 — every refreshed token is then rejected, i.e. the session breaks once per token lifetime.

Reproduced on `v3.155.2`:

```
authorization_code  -> aud = ["https://api.example.com/mcp/abc"]   # correct
refresh_token       -> aud = ["<client_id>"]                       # audience lost
```

### The fix

- add `resource` to `RefreshToken()` and forward it from both callers (`GetOAuthToken` and the `/login/oauth/refresh_token` controller, which previously read the parameter only from the JSON body);
- restore the audience from the stored `token.Resource` when the client does not repeat the parameter, as RFC 8707 §2.2 allows;
- reject a `resource` that does not match the original grant with `invalid_grant`, mirroring the existing check on the code exchange;
- persist `Resource` on the new token row so chained refreshes keep working.

Because the refreshed token now carries `token.Resource` into its audience, the refresh path first confirms the refresh token belongs to the authenticated client — the same `application.Name == token.Application` check the code exchange already performs. Without it a client could present a refresh token issued to another application and mint a token carrying that grant's audience.

After the fix:

```
refresh_token (same client)          -> aud = ["https://api.example.com/mcp/abc"]   # preserved
refresh_token (different client)     -> invalid_grant: the token is for wrong application
```

### Compatibility

Clients that never send `resource` are unaffected: the audience stays `application.ClientId` exactly as before. No schema change — `Token.Resource` already exists from #5098.
