### PR TITLE
fix: make the web build's build-temp swap non-destructive

### DIFF
--- a/web/mv.js
+++ b/web/mv.js
@@ -3,6 +3,35 @@ const path = require("path");
 
 const sourceDir = path.join(__dirname, "build-temp");
 const targetDir = path.join(__dirname, "build");
+const backupDir = path.join(__dirname, "build-old");
+
+// On Windows a directory can linger in a "delete pending" state while another
+// process still holds a handle to a file inside it: the Casdoor server serves
+// files straight out of build/, and virus scanners open freshly written ones.
+// Removes and renames then fail with EPERM/EBUSY, so both are retried here.
+const RETRY_ATTEMPTS = 10;
+const RETRY_DELAY_MS = 200;
+const RETRYABLE_CODES = ["EPERM", "EBUSY", "EACCES", "ENOTEMPTY"];
+
+const rmOptions = {recursive: true, force: true, maxRetries: RETRY_ATTEMPTS, retryDelay: RETRY_DELAY_MS};
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function renameSyncWithRetry(from, to) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      fs.renameSync(from, to);
+      return;
+    } catch (err) {
+      if (attempt >= RETRY_ATTEMPTS || !RETRYABLE_CODES.includes(err.code)) {
+        throw err;
+      }
+      sleepSync(RETRY_DELAY_MS);
+    }
+  }
+}
 
 if (!fs.existsSync(sourceDir)) {
   // eslint-disable-next-line no-console
@@ -10,12 +39,33 @@ if (!fs.existsSync(sourceDir)) {
   process.exit(1);
 }
 
-if (fs.existsSync(targetDir)) {
-  fs.rmSync(targetDir, {recursive: true, force: true});
-  // eslint-disable-next-line no-console
-  console.log(`Target directory "${targetDir}" has been deleted successfully.`);
+// Left behind by an earlier run that was interrupted between the two renames.
+if (fs.existsSync(backupDir)) {
+  fs.rmSync(backupDir, rmOptions);
 }
 
-fs.renameSync(sourceDir, targetDir);
+// Move the previous build aside rather than deleting it up front. If anything
+// below fails, build/ is either still there or gets restored, instead of the
+// server being left with no build to serve at all.
+const hasPreviousBuild = fs.existsSync(targetDir);
+if (hasPreviousBuild) {
+  renameSyncWithRetry(targetDir, backupDir);
+}
+
+try {
+  renameSyncWithRetry(sourceDir, targetDir);
+} catch (err) {
+  if (hasPreviousBuild) {
+    renameSyncWithRetry(backupDir, targetDir);
+    // eslint-disable-next-line no-console
+    console.error(`Could not move "${sourceDir}" into place, restored the previous build.`);
+  }
+  throw err;
+}
+
+if (hasPreviousBuild) {
+  fs.rmSync(backupDir, rmOptions);
+}
+
 // eslint-disable-next-line no-console
 console.log(`Renamed "${sourceDir}" to "${targetDir}" successfully.`);


### PR DESCRIPTION
## Summary
- `web/mv.js`'s `postbuild` step deleted `web/build` *before* renaming `build-temp` into place, so any failure partway through the rename left the app with no build directory at all.
- On Windows this is easy to hit: a directory can stay in a "delete pending" state while another process holds a handle to a file inside it, and if the running server is serving static files straight out of `build/`, the following `renameSync` fails with `EPERM`.
- Reworked the swap to rename the previous build aside, move the new build into place, and only then remove the backup — restoring it automatically if the swap fails. Both the renames and the removals retry on `EPERM`/`EBUSY`/`EACCES`/`ENOTEMPTY`, and a stale backup left by an earlier interrupted run is cleaned up on the next run.

## Test plan
- [x] `yarn build` completes and swaps `build-temp` into `build` correctly with no server holding a lock on the directory (verified: clean run, no leftover `build-temp`/`build-old`, served assets match the new hashes)
- [ ] Verified under real lock contention (server actively serving from `build/` during the build) — the retry loop and rollback path are implemented per Node's documented `EPERM`/`EBUSY` retry semantics but have not yet been exercised by an actual failing rename in this environment