### PR TITLE
fix: prevent account enumeration in forgot-password flow

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -1512,10 +1512,15 @@ func (c *ApiController) GetCaptchaStatus() {
 	}
 
 	clientIp := util.GetClientIpFromRequest(c.Ctx.Request)
-	captchaEnabled, err := object.CheckToEnableCaptcha(application, organization, userId, clientIp)
-	if err != nil {
-		c.ResponseError(err.Error())
-		return
+	var captchaEnabled bool
+	if c.isMaskedPasswordRecoveryCaptchaRequest(organization, userId) {
+		captchaEnabled = shouldEnableMaskedPasswordRecoveryCaptcha(application, clientIp)
+	} else {
+		captchaEnabled, err = object.CheckToEnableCaptcha(application, organization, userId, clientIp)
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
 	}
 	c.ResponseOk(captchaEnabled)
 	return

--- a/controllers/password_recovery.go
+++ b/controllers/password_recovery.go
@@ -1,0 +1,245 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"strings"
+
+	"github.com/beego/beego/v2/core/logs"
+	"github.com/casdoor/casdoor/conf"
+	"github.com/casdoor/casdoor/form"
+	"github.com/casdoor/casdoor/object"
+	"github.com/casdoor/casdoor/util"
+)
+
+const (
+	maskedRecoveryActiveSessionKey       = "maskedRecoveryActive"
+	maskedRecoveryOrganizationSessionKey = "maskedRecoveryOrganization"
+	maskedRecoveryIdentifierSessionKey   = "maskedRecoveryIdentifier"
+	maskedRecoveryApplicationSessionKey  = "maskedRecoveryApplication"
+	maskedRecoveryUserSessionKey         = "maskedRecoveryUser"
+	maskedRecoveryDestSessionKey         = "maskedRecoveryDest"
+
+	maskedRecoveryEmail = "a***@example.com"
+	maskedRecoveryPhone = "*******"
+)
+
+func isMaskedPasswordRecovery(method string) bool {
+	return method == ForgetVerification && conf.GetConfigBool("enableErrorMask")
+}
+
+func getMaskedPasswordRecoveryPublicUser(identifier string) object.User {
+	return object.User{
+		Name:  identifier,
+		Email: maskedRecoveryEmail,
+		Phone: maskedRecoveryPhone,
+	}
+}
+
+func (c *ApiController) getSessionString(key string) string {
+	value := c.GetSession(key)
+	if value == nil {
+		return ""
+	}
+
+	result, _ := value.(string)
+	return result
+}
+
+func (c *ApiController) prepareMaskedPasswordRecovery(organization string, identifier string) {
+	c.SetSession(maskedRecoveryActiveSessionKey, "true")
+	c.SetSession(maskedRecoveryOrganizationSessionKey, organization)
+	c.SetSession(maskedRecoveryIdentifierSessionKey, identifier)
+	c.SetSession(maskedRecoveryApplicationSessionKey, "")
+	c.SetSession(maskedRecoveryUserSessionKey, "")
+	c.SetSession(maskedRecoveryDestSessionKey, "")
+
+	user, err := object.GetUserByFields(organization, identifier)
+	if err != nil {
+		logs.Error("Failed to prepare masked password recovery: %v", err)
+		return
+	}
+	if user == nil || user.IsDeleted || user.IsForbidden || object.CheckLdapPasswordForget(user) != nil {
+		return
+	}
+
+	c.SetSession(maskedRecoveryUserSessionKey, user.GetId())
+}
+
+func (c *ApiController) getMaskedPasswordRecoveryUser() (*object.User, error) {
+	userId := c.getSessionString(maskedRecoveryUserSessionKey)
+	if userId == "" {
+		return nil, nil
+	}
+
+	user, err := object.GetUser(userId)
+	if err != nil || user == nil {
+		return user, err
+	}
+	if user.IsDeleted || user.IsForbidden || object.CheckLdapPasswordForget(user) != nil {
+		return nil, nil
+	}
+
+	return user, nil
+}
+
+func selectMaskedPasswordRecoveryType(user *object.User, preferredType string, canEmail bool, canPhone bool) string {
+	if preferredType == object.VerifyTypeEmail && canEmail && user.Email != "" {
+		return object.VerifyTypeEmail
+	}
+	if preferredType == object.VerifyTypePhone && canPhone && user.Phone != "" {
+		return object.VerifyTypePhone
+	}
+	if canPhone && user.Phone != "" {
+		return object.VerifyTypePhone
+	}
+	if canEmail && user.Email != "" {
+		return object.VerifyTypeEmail
+	}
+
+	return ""
+}
+
+func (c *ApiController) sendMaskedPasswordRecoveryCode(application *object.Application, organization *object.Organization, preferredType string, clientIp string) {
+	c.SetSession(maskedRecoveryApplicationSessionKey, application.Name)
+	c.SetSession(maskedRecoveryDestSessionKey, "")
+
+	user, err := c.getMaskedPasswordRecoveryUser()
+	if err != nil {
+		logs.Error("Failed to resolve masked password recovery user: %v", err)
+		return
+	}
+	if user == nil || user.Owner != application.Organization {
+		return
+	}
+
+	emailProvider, emailErr := application.GetEmailProvider(ForgetVerification)
+	if emailErr != nil {
+		logs.Error("Failed to resolve password recovery email provider: %v", emailErr)
+	}
+
+	countryCode := user.GetCountryCode("")
+	smsProvider, smsErr := application.GetSmsProvider(ForgetVerification, countryCode)
+	if smsErr != nil {
+		logs.Error("Failed to resolve password recovery SMS provider: %v", smsErr)
+	}
+
+	verificationType := selectMaskedPasswordRecoveryType(user, preferredType, emailProvider != nil, smsProvider != nil)
+	var dest string
+	switch verificationType {
+	case object.VerifyTypeEmail:
+		dest = user.Email
+		if emailProvider.HttpHeaders == nil {
+			emailProvider.HttpHeaders = map[string]string{}
+		}
+		if _, ok := emailProvider.HttpHeaders["Accept-Language"]; !ok {
+			emailProvider.HttpHeaders["Accept-Language"] = c.GetAcceptLanguage()
+		}
+		err = object.SendVerificationCodeToEmail(organization, user, emailProvider, clientIp, dest, ForgetVerification, c.Ctx.Request.Host, application.Name, application)
+	case object.VerifyTypePhone:
+		var ok bool
+		dest, ok = util.GetE164Number(user.Phone, countryCode)
+		if !ok {
+			return
+		}
+		err = object.SendVerificationCodeToPhone(organization, user, smsProvider, clientIp, dest, application)
+	default:
+		return
+	}
+	if err != nil {
+		logs.Error("Failed to send masked password recovery code: %v", err)
+		return
+	}
+
+	c.SetSession(maskedRecoveryDestSessionKey, dest)
+}
+
+func shouldEnableMaskedPasswordRecoveryCaptcha(application *object.Application, clientIp string) bool {
+	for _, providerItem := range application.Providers {
+		if providerItem.Provider == nil || providerItem.Provider.Category != "Captcha" {
+			continue
+		}
+
+		switch providerItem.Rule {
+		case "Always", "Dynamic":
+			return true
+		case "Internet-Only":
+			return util.IsInternetIp(clientIp)
+		default:
+			return false
+		}
+	}
+
+	return false
+}
+
+func (c *ApiController) isMaskedPasswordRecoveryCaptchaRequest(organization string, identifier string) bool {
+	return conf.GetConfigBool("enableErrorMask") &&
+		c.getSessionString(maskedRecoveryActiveSessionKey) == "true" &&
+		c.getSessionString(maskedRecoveryOrganizationSessionKey) == organization &&
+		c.getSessionString(maskedRecoveryIdentifierSessionKey) == identifier
+}
+
+func (c *ApiController) isMaskedPasswordRecoveryVerification(authForm *form.AuthForm) bool {
+	return conf.GetConfigBool("enableErrorMask") &&
+		c.getSessionString(maskedRecoveryActiveSessionKey) == "true" &&
+		c.getSessionString(maskedRecoveryOrganizationSessionKey) == authForm.Organization &&
+		strings.EqualFold(c.getSessionString(maskedRecoveryIdentifierSessionKey), authForm.Name) &&
+		c.getSessionString(maskedRecoveryApplicationSessionKey) == authForm.Application
+}
+
+func (c *ApiController) verifyMaskedPasswordRecoveryCode(authForm *form.AuthForm) {
+	responseError := func() {
+		c.ResponseError(c.T("verification:Wrong verification code!"))
+	}
+
+	user, err := c.getMaskedPasswordRecoveryUser()
+	dest := c.getSessionString(maskedRecoveryDestSessionKey)
+	if err != nil || user == nil || dest == "" {
+		responseError()
+		return
+	}
+
+	passed, err := c.checkOrgMasterVerificationCode(user, authForm.Code)
+	if err != nil {
+		responseError()
+		return
+	}
+	if !passed {
+		clientIp := util.GetClientIpFromRequest(c.Ctx.Request)
+		if err = object.CheckVerifyCodeWithLimitAndIp(user, clientIp, dest, authForm.Code, c.GetAcceptLanguage()); err != nil {
+			responseError()
+			return
+		}
+		if err = object.DisableVerificationCode(dest); err != nil {
+			responseError()
+			return
+		}
+	}
+
+	c.SetSession("verifiedCode", authForm.Code)
+	c.SetSession("verifiedUserId", user.GetId())
+	c.clearMaskedPasswordRecovery()
+	c.ResponseOk()
+}
+
+func (c *ApiController) clearMaskedPasswordRecovery() {
+	c.SetSession(maskedRecoveryActiveSessionKey, "")
+	c.SetSession(maskedRecoveryOrganizationSessionKey, "")
+	c.SetSession(maskedRecoveryIdentifierSessionKey, "")
+	c.SetSession(maskedRecoveryApplicationSessionKey, "")
+	c.SetSession(maskedRecoveryUserSessionKey, "")
+	c.SetSession(maskedRecoveryDestSessionKey, "")
+}

--- a/controllers/password_recovery_test.go
+++ b/controllers/password_recovery_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/casdoor/casdoor/object"
+)
+
+func TestIsMaskedPasswordRecovery(t *testing.T) {
+	t.Setenv("enableErrorMask", "true")
+
+	if !isMaskedPasswordRecovery(ForgetVerification) {
+		t.Fatal("forgot-password recovery should be masked when enableErrorMask is true")
+	}
+	if isMaskedPasswordRecovery(LoginVerification) {
+		t.Fatal("login verification must not use forgot-password masking")
+	}
+}
+
+func TestMaskedPasswordRecoveryPublicUser(t *testing.T) {
+	first := getMaskedPasswordRecoveryPublicUser("known-user")
+	second := getMaskedPasswordRecoveryPublicUser("unknown-user")
+
+	if first.Email != second.Email || first.Phone != second.Phone {
+		t.Fatal("masked recovery responses must expose the same contact placeholders")
+	}
+	if first.Name != "known-user" || second.Name != "unknown-user" {
+		t.Fatal("masked recovery responses should only echo the supplied identifier")
+	}
+}
+
+func TestSelectMaskedPasswordRecoveryType(t *testing.T) {
+	user := &object.User{Email: "user@example.com", Phone: "1234567"}
+
+	tests := []struct {
+		name          string
+		preferredType string
+		canEmail      bool
+		canPhone      bool
+		expected      string
+	}{
+		{name: "preferred email", preferredType: object.VerifyTypeEmail, canEmail: true, canPhone: true, expected: object.VerifyTypeEmail},
+		{name: "preferred phone", preferredType: object.VerifyTypePhone, canEmail: true, canPhone: true, expected: object.VerifyTypePhone},
+		{name: "fall back to email", preferredType: object.VerifyTypePhone, canEmail: true, canPhone: false, expected: object.VerifyTypeEmail},
+		{name: "no provider", preferredType: object.VerifyTypeEmail, canEmail: false, canPhone: false, expected: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := selectMaskedPasswordRecoveryType(user, test.preferredType, test.canEmail, test.canPhone)
+			if actual != test.expected {
+				t.Fatalf("expected %q, got %q", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestShouldEnableMaskedPasswordRecoveryCaptcha(t *testing.T) {
+	application := &object.Application{
+		Providers: []*object.ProviderItem{{
+			Rule:     "Dynamic",
+			Provider: &object.Provider{Category: "Captcha"},
+		}},
+	}
+
+	if !shouldEnableMaskedPasswordRecoveryCaptcha(application, "127.0.0.1") {
+		t.Fatal("dynamic CAPTCHA must not depend on whether the recovery account exists")
+	}
+}

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -467,6 +467,11 @@ func (c *ApiController) GetEmailAndPhone() {
 		c.ResponseError("Error")
 		return
 	}
+	if conf.GetConfigBool("enableErrorMask") {
+		c.prepareMaskedPasswordRecovery(organization, username)
+		c.ResponseOk(getMaskedPasswordRecoveryPublicUser(username), "username")
+		return
+	}
 
 	user, err := object.GetUserByFields(organization, username)
 	if err != nil {
@@ -533,6 +538,11 @@ func (c *ApiController) SetPassword() {
 	// }
 
 	userId := util.GetId(userOwner, userName)
+	if conf.GetConfigBool("enableErrorMask") && code != "" {
+		if verifiedUserId := c.getSessionString("verifiedUserId"); verifiedUserId != "" {
+			userId = verifiedUserId
+		}
+	}
 
 	user, err := object.GetUser(userId)
 	if err != nil {

--- a/controllers/verification.go
+++ b/controllers/verification.go
@@ -171,6 +171,7 @@ func (c *ApiController) SendVerificationCode() {
 		c.ResponseError(fmt.Sprintf(c.T("auth:The application: %s does not exist"), vform.ApplicationId))
 		return
 	}
+	maskedPasswordRecovery := isMaskedPasswordRecovery(vform.Method)
 
 	// Check if "Forgot password?" signin item is visible when using forget verification
 	if vform.Method == ForgetVerification {
@@ -201,7 +202,7 @@ func (c *ApiController) SendVerificationCode() {
 	var user *object.User
 	// Try to resolve user for CAPTCHA rule checking
 	// checkUser != "", means method is ForgetVerification
-	if vform.CheckUser != "" {
+	if vform.CheckUser != "" && !maskedPasswordRecovery {
 		owner := application.Organization
 		user, err = object.GetUser(util.GetId(owner, vform.CheckUser))
 		if err != nil {
@@ -256,10 +257,15 @@ func (c *ApiController) SendVerificationCode() {
 	}
 
 	// Check if CAPTCHA should be enabled based on the rule (Dynamic/Always/Internet-Only)
-	enableCaptcha, err := object.CheckToEnableCaptcha(application, organization.Name, username, clientIp)
-	if err != nil {
-		c.ResponseError(err.Error())
-		return
+	var enableCaptcha bool
+	if maskedPasswordRecovery {
+		enableCaptcha = shouldEnableMaskedPasswordRecoveryCaptcha(application, clientIp)
+	} else {
+		enableCaptcha, err = object.CheckToEnableCaptcha(application, organization.Name, username, clientIp)
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
 	}
 
 	if vform.CaptchaToken != "" {
@@ -297,6 +303,12 @@ func (c *ApiController) SendVerificationCode() {
 				}
 			}
 		}
+	}
+
+	if maskedPasswordRecovery {
+		c.sendMaskedPasswordRecoveryCode(application, organization, vform.Type, clientIp)
+		c.ResponseOk()
+		return
 	}
 
 	sendResp := errors.New("invalid dest type")
@@ -612,6 +624,10 @@ func (c *ApiController) VerifyCode() {
 	err := json.Unmarshal(c.Ctx.Input.RequestBody, &authForm)
 	if err != nil {
 		c.ResponseError(err.Error())
+		return
+	}
+	if c.isMaskedPasswordRecoveryVerification(&authForm) {
+		c.verifyMaskedPasswordRecoveryCode(&authForm)
 		return
 	}
 


### PR DESCRIPTION
## Summary

Prevent account enumeration in the forgot-password flow when `enableErrorMask` is enabled.

## Problem

The existing masking policy only replaced selected error messages. The forgot-password flow still returned structurally different responses depending on whether an account existed:

- The initial account lookup returned contact information for an existing user and an error for an unknown user.
- The verification-code endpoint returned account-dependent errors.
- Replacing every response with an error would prevent legitimate users from completing password recovery.

A response-only middleware is therefore insufficient because the recovery flow still needs a real destination and user identity after the public response has been masked.

## Solution

- Return the same public contact placeholders and response status for every supplied identifier.
- Keep the real recovery user and destination in the server-side session.
- Send a verification code only when an eligible account and provider exist, while returning the same public response in all cases.
- Bind code verification and password reset to the user stored in the recovery session.
- Make Dynamic CAPTCHA behavior independent of account existence.
- Apply this behavior only to `method=forget` when `enableErrorMask` is enabled.

Other verification flows, including login, signup, and MFA, are unchanged. Behavior also remains unchanged when `enableErrorMask` is disabled.

## Testing

- Added regression tests for:
  - forgot-password masking activation;
  - fixed public contact placeholders;
  - email/SMS delivery selection and fallback;
  - account-independent Dynamic CAPTCHA behavior.

- Full controller test suite:

  ```text
  go test ./controllers -count=1
  ok github.com/casdoor/casdoor/controllers