### PR TITLE
fix: signinMethods "Hide password" rule not enforced server-side

### DIFF
--- a/object/application_util.go
+++ b/object/application_util.go
@@ -483,7 +483,7 @@ func (application *Application) IsPasswordEnabled() bool {
 		return application.EnablePassword
 	} else {
 		for _, signinMethod := range application.SigninMethods {
-			if signinMethod.Name == "Password" {
+			if signinMethod.Name == "Password" && signinMethod.Rule != "Hide password" {
 				return true
 			}
 		}
@@ -533,7 +533,7 @@ func (application *Application) IsCodeSigninViaSmsEnabled() bool {
 func (application *Application) IsLdapEnabled() bool {
 	if len(application.SigninMethods) > 0 {
 		for _, signinMethod := range application.SigninMethods {
-			if signinMethod.Name == "LDAP" {
+			if signinMethod.Name == "LDAP" && signinMethod.Rule != "Hide password" {
 				return true
 			}
 		}
@@ -544,7 +544,7 @@ func (application *Application) IsLdapEnabled() bool {
 func (application *Application) IsFaceIdEnabled() bool {
 	if len(application.SigninMethods) > 0 {
 		for _, signinMethod := range application.SigninMethods {
-			if signinMethod.Name == "Face ID" {
+			if signinMethod.Name == "Face ID" && signinMethod.Rule != "Hide password" {
 				return true
 			}
 		}

--- a/object/application_util_test.go
+++ b/object/application_util_test.go
@@ -77,3 +77,65 @@ func TestRedirectUriMatchesPattern(t *testing.T) {
 		}
 	}
 }
+
+// A signinMethods entry with Rule "Hide password" must not make the
+// corresponding IsXEnabled() check return true — that rule exists
+// specifically so an application can keep a method configured (e.g. to
+// remember its settings) while actually disabling it. Before this fix,
+// IsPasswordEnabled/IsLdapEnabled/IsFaceIdEnabled only checked whether an
+// entry with the right Name existed, ignoring Rule entirely.
+func TestSigninMethodHiddenByRuleIsNotEnabled(t *testing.T) {
+	tests := []struct {
+		name          string
+		signinMethods []*SigninMethod
+		enabledMethod func(*Application) bool
+		wantEnabled   bool
+	}{
+		{
+			name:          "Password hidden via rule is not enabled",
+			signinMethods: []*SigninMethod{{Name: "Password", DisplayName: "Password", Rule: "Hide password"}},
+			enabledMethod: (*Application).IsPasswordEnabled,
+			wantEnabled:   false,
+		},
+		{
+			name:          "Password with rule All is enabled",
+			signinMethods: []*SigninMethod{{Name: "Password", DisplayName: "Password", Rule: "All"}},
+			enabledMethod: (*Application).IsPasswordEnabled,
+			wantEnabled:   true,
+		},
+		{
+			name:          "LDAP hidden via rule is not enabled",
+			signinMethods: []*SigninMethod{{Name: "LDAP", DisplayName: "LDAP", Rule: "Hide password"}},
+			enabledMethod: (*Application).IsLdapEnabled,
+			wantEnabled:   false,
+		},
+		{
+			name:          "LDAP without hide rule is enabled",
+			signinMethods: []*SigninMethod{{Name: "LDAP", DisplayName: "LDAP", Rule: "None"}},
+			enabledMethod: (*Application).IsLdapEnabled,
+			wantEnabled:   true,
+		},
+		{
+			name:          "Face ID hidden via rule is not enabled",
+			signinMethods: []*SigninMethod{{Name: "Face ID", DisplayName: "Face ID", Rule: "Hide password"}},
+			enabledMethod: (*Application).IsFaceIdEnabled,
+			wantEnabled:   false,
+		},
+		{
+			name:          "Face ID without hide rule is enabled",
+			signinMethods: []*SigninMethod{{Name: "Face ID", DisplayName: "Face ID", Rule: "None"}},
+			enabledMethod: (*Application).IsFaceIdEnabled,
+			wantEnabled:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			application := &Application{SigninMethods: tt.signinMethods}
+			got := tt.enabledMethod(application)
+			if got != tt.wantEnabled {
+				t.Errorf("got enabled=%v, want %v", got, tt.wantEnabled)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #5761.

`Application.IsPasswordEnabled()`, `IsLdapEnabled()`, and `IsFaceIdEnabled()` (`object/application_util.go`) only checked whether a `signinMethods` entry with the matching `Name` existed — they never looked at `Rule`. So an application configured with `{"name": "Password", "rule": "Hide password"}` (the mechanism #3258 added specifically so a provider can be the sole login method, fixing #3255) still accepted password logins through `/api/login`. The rule only changed what the frontend rendered, not what the backend actually allowed — a real gap for anyone relying on it to make OAuth/SAML the only way in, as in #5754.

The fix mirrors logic that already exists correctly elsewhere in the codebase:
- Backend: `HasSigninMethod()` in `object/application.go` already checks `signinMethod.Rule != "Hide password"`.
- Frontend: `isSigninMethodEnabled()` in `web/src/Setting.js` already does the same check.

`IsPasswordWithLdapEnabled()` didn't need a change — it already requires `Rule == "All"`, which a "Hide password" entry never satisfies.

## Test plan

- Added `TestSigninMethodHiddenByRuleIsNotEnabled` to `object/application_util_test.go`, table-driven, covering `IsPasswordEnabled`/`IsLdapEnabled`/`IsFaceIdEnabled` both with and without the "Hide password" rule.
- `go test ./object/... -run TestSigninMethodHiddenByRuleIsNotEnabled -v` — all 6 cases pass.
- `go test ./object/... -run TestRedirectUriMatchesPattern` — existing test in the same file still passes (no regression).
- `gofmt -l` and `go vet ./object/...` clean.

## Scope note

While diagnosing this I also found that storing an *empty* `signinMethods` list (attempting "no built-in methods, OAuth only") doesn't stay empty — `extendApplicationWithSigninMethods()` unconditionally appends a live `Face ID` entry whenever the stored list has `len() == 0`, silently re-enabling Face ID for anyone with a registered face. That's the same root issue reported in discussion #5517. I've left that one out of this PR: a correct fix needs to distinguish "never configured" from "deliberately empty," and while Go's `nil` vs. non-nil-empty-slice preserves that distinction fine through `encoding/json`, I wasn't able to confirm it survives the xorm round-trip through the `varchar(2000)` column without deeper testing than I could do here. Happy to take a stab at it in a follow-up if a maintainer can confirm the intended semantics (or point me at how that column is (de)serialized).
