### PR TITLE
feat: make LDAP/AD forgot password restriction configurable

### DIFF
--- a/object/ldap.go
+++ b/object/ldap.go
@@ -41,6 +41,8 @@ type Ldap struct {
 	AutoSync     int    `json:"autoSync"`
 	LastSync     string `xorm:"varchar(100)" json:"lastSync"`
 	EnableGroups bool   `xorm:"bool" json:"enableGroups"`
+
+	EnablePasswordReset bool `xorm:"bool" json:"enablePasswordReset"`
 }
 
 func AddLdap(ldap *Ldap) (bool, error) {
@@ -154,7 +156,7 @@ func UpdateLdap(ldap *Ldap) (bool, error) {
 	}
 
 	affected, err := ormer.Engine.ID(ldap.Id).Cols("owner", "server_name", "host",
-		"port", "enable_ssl", "username", "password", "base_dn", "filter", "filter_fields", "auto_sync", "default_group", "default_groups", "password_type", "allow_self_signed_cert", "custom_attributes", "enable_groups").Update(ldap)
+		"port", "enable_ssl", "username", "password", "base_dn", "filter", "filter_fields", "auto_sync", "default_group", "default_groups", "password_type", "allow_self_signed_cert", "custom_attributes", "enable_groups", "enable_password_reset").Update(ldap)
 	if err != nil {
 		return false, nil
 	}

--- a/object/ldap_conn.go
+++ b/object/ldap_conn.go
@@ -833,9 +833,22 @@ func GetExistUuids(owner string, uuids []string) ([]string, error) {
 // user from receiving a verification code and typing a new password before finding out.
 // Signing in, changing the password with the old one and an admin reset are not affected,
 // none of them depends on the bind account having write access.
+// The check is skipped if an LDAP server of the organization sets EnablePasswordReset,
+// meaning its bind account is confirmed to have the permission to reset user passwords.
 func CheckLdapPasswordForget(user *User) error {
 	if user == nil || user.Ldap == "" {
 		return nil
+	}
+
+	ldaps, err := GetLdaps(user.Owner)
+	if err != nil {
+		return err
+	}
+
+	for _, ldapServer := range ldaps {
+		if ldapServer.EnablePasswordReset {
+			return nil
+		}
 	}
 
 	return fmt.Errorf("the password of the LDAP user: %s is managed by the LDAP server, please contact your administrator to reset it", user.Name)

--- a/web/src/LdapEditPage.js
+++ b/web/src/LdapEditPage.js
@@ -182,6 +182,16 @@ class LdapEditPage extends React.Component {
             }} />
           </Col>
         </Row>
+        <Row style={{marginTop: "20px"}} >
+          <Col style={{lineHeight: "32px", textAlign: "right", paddingRight: "25px"}} span={3}>
+            {Setting.getLabel(i18next.t("ldap:Enable password reset"), i18next.t("ldap:Enable password reset - Tooltip"))} :
+          </Col>
+          <Col span={21} >
+            <Switch checked={this.state.ldap.enablePasswordReset ?? false} onChange={checked => {
+              this.updateLdapField("enablePasswordReset", checked);
+            }} />
+          </Col>
+        </Row>
         <Row style={{marginTop: "20px"}}>
           <Col style={{lineHeight: "32px", textAlign: "right", paddingRight: "25px"}} span={3}>
             {Setting.getLabel(i18next.t("ldap:Base DN"), i18next.t("ldap:Base DN - Tooltip"))} :

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -786,6 +786,8 @@
     "Default group": "Default group",
     "Default group - Tooltip": "Group to which users belong after synchronization",
     "Edit LDAP": "Edit LDAP",
+    "Enable password reset": "Enable password reset",
+    "Enable password reset - Tooltip": "Allow LDAP users to reset their passwords via the Casdoor forgot-password flow. Enable it only if the bind account has permission to reset passwords on the LDAP server (e.g. Microsoft AD over LDAPS)",
     "Enable SSL": "Enable SSL",
     "Enable SSL - Tooltip": "Whether to enable SSL",
     "Filter fields": "Filter fields",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -786,6 +786,8 @@
     "Default group": "默认群组",
     "Default group - Tooltip": "同步用户后用户所在的群组",
     "Edit LDAP": "编辑LDAP",
+    "Enable password reset": "启用密码重置",
+    "Enable password reset - Tooltip": "允许LDAP用户通过Casdoor的忘记密码流程重置密码。仅当LDAP服务器上配置的绑定账号有重置用户密码的权限时才启用（例如通过LDAPS连接的Microsoft AD）",
     "Enable SSL": "启用SSL",
     "Enable SSL - Tooltip": "是否启用SSL",
     "Filter fields": "过滤字段",


### PR DESCRIPTION
The check added in c13cd7a rejects all LDAP users from the forgot-password flow. But LDAP servers like Microsoft AD over LDAPS can reset passwords when the bind account has the permission.

Add an "Enable password reset" option to each LDAP server config (default off, keeping the current behavior). Administrators can turn it on to let LDAP users use the forgot-password flow again.

Fixes #5745
