### PR TITLE
fix(verification): pre-check email and phone existence before sending signup verification code (fix #5770)

### DIFF
--- a/controllers/verification.go
+++ b/controllers/verification.go
@@ -309,7 +309,12 @@ func (c *ApiController) SendVerificationCode() {
 			return
 		}
 
-		if vform.Method == LoginVerification || vform.Method == ForgetVerification {
+		if vform.Method == SignupVerification || vform.Method == "" || vform.Method == "register" {
+			if object.HasUserByField(organization.Name, "email", strings.ToLower(vform.Dest)) {
+				c.ResponseError(c.T("check:Email already exists"))
+				return
+			}
+		} else if vform.Method == LoginVerification || vform.Method == ForgetVerification {
 			if user != nil && util.GetMaskedEmail(user.Email) == vform.Dest {
 				vform.Dest = user.Email
 			}
@@ -364,7 +369,12 @@ func (c *ApiController) SendVerificationCode() {
 
 		sendResp = object.SendVerificationCodeToEmail(organization, user, provider, clientIp, vform.Dest, vform.Method, c.Ctx.Request.Host, application.Name, application)
 	case object.VerifyTypePhone:
-		if vform.Method == LoginVerification || vform.Method == ForgetVerification {
+		if vform.Method == SignupVerification || vform.Method == "" || vform.Method == "register" {
+			if object.HasUserByPhoneAndCountryCode(organization.Name, vform.Dest, vform.CountryCode) {
+				c.ResponseError(c.T("check:Phone already exists"))
+				return
+			}
+		} else if vform.Method == LoginVerification || vform.Method == ForgetVerification {
 			if user != nil && util.GetMaskedPhone(user.Phone) == vform.Dest {
 				vform.Dest = user.Phone
 			}


### PR DESCRIPTION
Fixes #5770

### Problem
On the signup page, clicking **Get Code** for an email or phone number that is already registered would still trigger sending the verification code (wasting paid email/SMS quota). The duplicate check was only performed when the signup form was submitted.

### Solution
In controllers/verification.go SendVerificationCode():
- For VerifyTypeEmail, pre-check if the email already exists in the organization (object.HasUserByField(organization.Name, email, normalizedEmail)) when method is signup. If it exists, immediately return check:Email already exists and skip sending.
- For VerifyTypePhone, pre-check if the phone already exists in the organization (object.HasUserByPhoneAndCountryCode(organization.Name, dest, countryCode)) when method is signup. If it exists, immediately return check:Phone already exists and skip sending.