### PR TITLE
feat: add API to get direct and group roles for user

### DIFF
--- a/controllers/role.go
+++ b/controllers/role.go
@@ -84,6 +84,31 @@ func (c *ApiController) GetRole() {
 	c.ResponseOk(role)
 }
 
+// GetUserRoles
+// @Title GetUserRoles
+// @Tag Role API
+// @Description get the user's direct roles and roles assigned through groups
+// @Param   owner  query    string  true        "The owner of the user"
+// @Param   name   query    string  true        "The name of the user"
+// @Success 200 {object} object.UserRoles The Response object
+// @router /get-user-roles [get]
+func (c *ApiController) GetUserRoles() {
+	owner := c.Ctx.Input.Query("owner")
+	name := c.Ctx.Input.Query("name")
+	if util.IsStringsEmpty(owner, name) {
+		c.ResponseError(c.T("general:Missing parameter"))
+		return
+	}
+
+	roles, err := object.GetUserRoles(owner, name)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.ResponseOk(roles)
+}
+
 // UpdateRole
 // @Title UpdateRole
 // @Tag Role API

--- a/object/role.go
+++ b/object/role.go
@@ -17,6 +17,7 @@ package object
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/casdoor/casdoor/conf"
@@ -37,6 +38,11 @@ type Role struct {
 	Roles     []string `xorm:"mediumtext" json:"roles"`
 	Domains   []string `xorm:"mediumtext" json:"domains"`
 	IsEnabled bool     `json:"isEnabled"`
+}
+
+type UserRoles struct {
+	DirectRoles []string `json:"directRoles"`
+	GroupRoles  []string `json:"groupRoles"`
 }
 
 func GetRoleCount(owner, field, value string) (int64, error) {
@@ -86,6 +92,52 @@ func getRole(owner string, name string) (*Role, error) {
 func GetRole(id string) (*Role, error) {
 	owner, name := util.GetOwnerAndNameFromIdNoCheck(id)
 	return getRole(owner, name)
+}
+
+// GetUserRoles returns enabled roles assigned directly to the user and through groups.
+func GetUserRoles(owner string, name string) (*UserRoles, error) {
+	user, err := getUser(owner, name)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, fmt.Errorf("The user: %s doesn't exist", util.GetId(owner, name))
+	}
+
+	userId := user.GetId()
+	query := ormer.Engine.Alias("r").Cols("name", "users", "groups", "is_enabled").
+		Where("r.owner = ?", owner).
+		And("r.users like ?", fmt.Sprintf("%%%s%%", userId))
+	for _, group := range user.Groups {
+		query = query.Or("r.owner = ? AND r.groups like ?", owner, fmt.Sprintf("%%%s%%", group))
+	}
+
+	roles := []*Role{}
+	if err = query.Find(&roles); err != nil {
+		return nil, err
+	}
+
+	result := &UserRoles{
+		DirectRoles: []string{},
+		GroupRoles:  []string{},
+	}
+	for _, role := range roles {
+		if role == nil || !role.IsEnabled {
+			continue
+		}
+
+		if util.InSlice(role.Users, userId) {
+			result.DirectRoles = append(result.DirectRoles, role.Name)
+		}
+
+		if util.HaveIntersection(role.Groups, user.Groups) {
+			result.GroupRoles = append(result.GroupRoles, role.Name)
+		}
+	}
+	sort.Strings(result.DirectRoles)
+	sort.Strings(result.GroupRoles)
+
+	return result, nil
 }
 
 func UpdateRole(id string, role *Role, isGlobalAdmin bool, lang string) (bool, error) {

--- a/object/role_test.go
+++ b/object/role_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUserRoles(t *testing.T) {
+	testOrmer, err := NewAdapter("sqlite", "file:user_roles_test?mode=memory&cache=shared", "")
+	require.NoError(t, err)
+	require.NoError(t, testOrmer.Engine.Sync2(new(User), new(Group), new(Role)))
+
+	previousOrmer := ormer
+	ormer = testOrmer
+	t.Cleanup(func() {
+		ormer = previousOrmer
+		require.NoError(t, testOrmer.Engine.Close())
+	})
+
+	userId := "built-in/alice"
+	groupId := "built-in/developers"
+	_, err = testOrmer.Engine.Insert(&Group{
+		Owner:     "built-in",
+		Name:      "developers",
+		IsEnabled: true,
+	})
+	require.NoError(t, err)
+
+	_, err = testOrmer.Engine.Insert(&User{
+		Owner: "built-in",
+		Name:  "alice",
+	})
+	require.NoError(t, err)
+	_, err = testOrmer.Engine.Insert(&User{Owner: "built-in", Name: "bob"})
+	require.NoError(t, err)
+
+	_, err = testOrmer.Engine.Insert([]*Role{
+		{Owner: "built-in", Name: "editor", Users: []string{userId}, IsEnabled: true},
+		{Owner: "built-in", Name: "viewer", Groups: []string{groupId}, IsEnabled: true},
+		{Owner: "built-in", Name: "shared", Users: []string{userId}, Groups: []string{groupId}, IsEnabled: true},
+		{Owner: "built-in", Name: "disabled", Users: []string{userId}, IsEnabled: false},
+		{Owner: "other", Name: "foreign", Users: []string{userId}, IsEnabled: true},
+	})
+	require.NoError(t, err)
+
+	beforeGroupAssignment, err := GetUserRoles("built-in", "alice")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"editor", "shared"}, beforeGroupAssignment.DirectRoles)
+	assert.Empty(t, beforeGroupAssignment.GroupRoles)
+
+	_, err = testOrmer.Engine.Where("owner = ? AND name = ?", "built-in", "alice").
+		Cols("groups").Update(&User{Groups: []string{groupId}})
+	require.NoError(t, err)
+
+	afterGroupAssignment, err := GetUserRoles("built-in", "alice")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"editor", "shared"}, afterGroupAssignment.DirectRoles)
+	assert.Equal(t, []string{"shared", "viewer"}, afterGroupAssignment.GroupRoles)
+
+	withoutRoles, err := GetUserRoles("built-in", "bob")
+	require.NoError(t, err)
+	assert.Empty(t, withoutRoles.DirectRoles)
+	assert.NotNil(t, withoutRoles.DirectRoles)
+	assert.Empty(t, withoutRoles.GroupRoles)
+	assert.NotNil(t, withoutRoles.GroupRoles)
+}

--- a/routers/router.go
+++ b/routers/router.go
@@ -192,6 +192,7 @@ func InitAPI() {
 
 	web.Router("/api/get-roles", &controllers.ApiController{}, "GET:GetRoles")
 	web.Router("/api/get-role", &controllers.ApiController{}, "GET:GetRole")
+	web.Router("/api/get-user-roles", &controllers.ApiController{}, "GET:GetUserRoles")
 	web.Router("/api/update-role", &controllers.ApiController{}, "POST:UpdateRole")
 	web.Router("/api/add-role", &controllers.ApiController{}, "POST:AddRole")
 	web.Router("/api/delete-role", &controllers.ApiController{}, "POST:DeleteRole")

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -3863,6 +3863,39 @@
                 }
             }
         },
+        "/api/get-user-roles": {
+            "get": {
+                "tags": [
+                    "Role API"
+                ],
+                "description": "get the user's direct roles and roles assigned through groups",
+                "operationId": "ApiController.GetUserRoles",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "owner",
+                        "description": "The owner of the user",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "description": "The name of the user",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The Response object",
+                        "schema": {
+                            "$ref": "#/definitions/object.UserRoles"
+                        }
+                    }
+                }
+            }
+        },
         "/api/get-session": {
             "get": {
                 "tags": [
@@ -9155,6 +9188,24 @@
                     }
                 },
                 "users": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "object.UserRoles": {
+            "title": "UserRoles",
+            "type": "object",
+            "properties": {
+                "directRoles": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "groupRoles": {
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -2510,6 +2510,28 @@ paths:
             type: array
             items:
               $ref: '#/definitions/object.Role'
+  /api/get-user-roles:
+    get:
+      tags:
+      - Role API
+      description: get the user's direct roles and roles assigned through groups
+      operationId: ApiController.GetUserRoles
+      parameters:
+      - in: query
+        name: owner
+        description: The owner of the user
+        required: true
+        type: string
+      - in: query
+        name: name
+        description: The name of the user
+        required: true
+        type: string
+      responses:
+        "200":
+          description: The Response object
+          schema:
+            $ref: '#/definitions/object.UserRoles'
   /api/get-session:
     get:
       tags:
@@ -6026,6 +6048,18 @@ definitions:
         items:
           type: string
       users:
+        type: array
+        items:
+          type: string
+  object.UserRoles:
+    title: UserRoles
+    type: object
+    properties:
+      directRoles:
+        type: array
+        items:
+          type: string
+      groupRoles:
         type: array
         items:
           type: string


### PR DESCRIPTION
Add an API for retrieving roles assigned to a user directly and through groups. The query only loads roles related to the requested user.