### PR TITLE
fix: fix verification code check for SQL Server

### DIFF
--- a/object/verification.go
+++ b/object/verification.go
@@ -226,7 +226,7 @@ func getVerificationRecord(dest string) (*VerificationRecord, error) {
 	record := &VerificationRecord{}
 	record.Receiver = dest
 
-	has, err := ormer.Engine.Desc("time").Where("is_used = false").Get(record)
+	has, err := ormer.Engine.Desc("time").Where("is_used = ?", false).Get(record)
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +264,7 @@ func getUnusedVerificationRecord(dest string) (*VerificationRecord, error) {
 	record := &VerificationRecord{}
 	record.Receiver = dest
 
-	has, err := ormer.Engine.Desc("time").Where("is_used = false").Get(record)
+	has, err := ormer.Engine.Desc("time").Where("is_used = ?", false).Get(record)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Problem

`getVerificationRecord` and `getUnusedVerificationRecord` both filter on `is_used` with a raw boolean literal:

https://github.com/casdoor/casdoor/blob/master/object/verification.go#L229
https://github.com/casdoor/casdoor/blob/master/object/verification.go#L267

```go
has, err := ormer.Engine.Desc("time").Where("is_used = false").Get(record)
```

T-SQL has no boolean literal, so `false` is parsed as an identifier and the query fails on the `mssql` driver:

```
mssql: Invalid column name 'false'.
```

`is_used` is a `bit` column on that engine (`INFORMATION_SCHEMA.COLUMNS` reports `bit`; xorm's mssql dialect maps Go `bool` to `BIT`).

`mssql` is a supported `driverName`, so this is reachable in a supported configuration. Both call sites are on the path from `CheckVerificationCode`, which means **every code-based flow is affected** — password reset and email/phone verification included. The failure is total, not intermittent: the query never succeeds.

The two lines are identical on `master` and on the `v3.162.0` tag.

### Fix

Bind the value instead of inlining it, so xorm renders it per dialect:

```go
has, err := ormer.Engine.Desc("time").Where("is_used = ?", false).Get(record)
```

This is preferred over hardcoding `is_used = 0`, which would work on SQL Server and MySQL but is less clear on PostgreSQL, where the column is a real `boolean`. The parameterised form is already used elsewhere in the codebase for a bool against the same kind of column — for example `object/permission_expire.go`:

```go
ormer.Engine.Where("expire_time is not null and expire_time != ? and is_enabled = ?", "", true)
```

### Verification

Checked on all three engines with the same xorm version and drivers this repo ships, against real tables. Each run inserted two rows for one receiver — one with `is_used` false, one true — so a query cannot pass by matching nothing or by returning the wrong row:

| Engine | `is_used` type | `Where("is_used = false")` | `Where("is_used = ?", false)` |
| --- | --- | --- | --- |
| SQL Server | `bit` | `Invalid column name 'false'` | returns the unused row |
| PostgreSQL | `boolean` | returns the unused row | returns the unused row |
| MySQL | `tinyint` | returns the unused row | returns the unused row |

So the change fixes SQL Server and is a no-op on MySQL and PostgreSQL. Both forms select the unused row rather than the most recent one, and `NULL` handling is unchanged since both are `=` comparisons.
