### PR TITLE
fix: avoid a nil pointer panic in introspect when the token carries no user claims

### DIFF
--- a/controllers/token.go
+++ b/controllers/token.go
@@ -552,10 +552,17 @@ func (c *ApiController) IntrospectToken() {
 			return
 		}
 
+		// UserStandard is embedded as a pointer and is nil when the token
+		// carries no user claims, so Name must not be promoted unguarded.
+		username := ""
+		if jwtToken.UserStandard != nil {
+			username = jwtToken.Name
+		}
+
 		introspectionResponse = object.IntrospectionResponse{
 			Active:    true,
 			Scope:     jwtToken.Scope,
-			Username:  jwtToken.Name,
+			Username:  username,
 			TokenType: jwtToken.TokenType,
 			Exp:       jwtToken.ExpiresAt.Unix(),
 			Iat:       jwtToken.IssuedAt.Unix(),
@@ -589,7 +596,10 @@ func (c *ApiController) IntrospectToken() {
 		if jwtToken.Scope != "" {
 			introspectionResponse.Scope = jwtToken.Scope
 		}
-		if jwtToken.Name != "" {
+		// Claims embeds *User, which is nil when the application's token format
+		// omits the user claims (e.g. JWT-Custom with no tokenFields). Promoting
+		// Name through the nil pointer panics.
+		if jwtToken.User != nil && jwtToken.Name != "" {
 			introspectionResponse.Username = jwtToken.Name
 		}
 		if jwtToken.TokenType != "" {


### PR DESCRIPTION
### Problem

`/api/login/oauth/introspect` returns **HTTP 500** for any **live** access token when the application's token format omits the user claims.

Both branches of `IntrospectToken` read `jwtToken.Name`:

https://github.com/casdoor/casdoor/blob/master/controllers/token.go#L558
https://github.com/casdoor/casdoor/blob/master/controllers/token.go#L592

`Name` is not a field on either claims type. It is promoted through an embedded **pointer**:

https://github.com/casdoor/casdoor/blob/master/object/token_jwt.go#L28-L29

```go
type Claims struct {
	*User
	...
}
```

https://github.com/casdoor/casdoor/blob/master/object/token_standard_jwt.go#L25-L26

```go
type ClaimsStandard struct {
	*UserStandard
	...
}
```

When the token body has no user object, `json.Unmarshal` leaves that pointer nil and the promoted access dereferences it:

```
Handler crashed with error runtime error: invalid memory address or nil pointer dereference
/go/src/casdoor/controllers/token.go:592
/go/pkg/mod/github.com/beego/beego/v2@v2.3.8/server/web/router.go:1234
```

**Only live tokens are affected**, which is why this is easy to miss. An expired or revoked token returns at the `token.ExpiresIn <= 0` guard *before* the parse, so introspection answers `{"active": false}` correctly. It fails exactly when the token is valid.

### Fix

Guard the embedded pointer in both branches. `Username` is left empty when the claim is absent, which is what the response field's `omitempty` already expresses.

### Verification

**1. Reproduced against a running server.** Two applications, identical in every field except `tokenFormat`, in the same organization. The same user, the same run, introspecting an **active** access token obtained moments earlier:

| `tokenFormat` | `tokenFields` | introspect an active token |
| --- | --- | --- |
| `JWT` | `[]` | `200` — `{"active": true, "scope": "...", "client_id": "..."}` |
| `JWT-Custom` | `[]` | **`500`** — beego error page, stack trace above |

Isolating on `tokenFormat` alone is the point: nothing else differs, so the result is attributable to the claims the token carries and not to the request, the user, or the application's other settings.

The same run confirms the guard condition: introspecting a **revoked** token on the `JWT-Custom` application returns `{"active": false}` normally, because it never reaches the parse.

**2. The mechanism, at unit level.** Unmarshalling a user-claim-less token body into `Claims` exactly as `ParseJwtToken` does:

```go
var c Claims
body := `{"iss":"...","sub":"s","aud":["a"],"exp":9999999999,"iat":1,"nbf":1,` +
        `"scope":"openid","tokenType":"access-token"}`
json.Unmarshal([]byte(body), &c)

c.User        // nil
c.Scope       // "openid"        -- fields ON Claims survive
c.TokenType   // "access-token"  --   "
c.Name        // panic: runtime error: invalid memory address or nil pointer dereference
```

`Scope` and `TokenType` are read on the same lines and are unaffected, because they live on the outer struct. `Name` is the only one promoted through the nil pointer, which matches the crash frame.

### Notes

- `JWT-Standard` is patched alongside `JWT-Custom` on inspection rather than on a reproduction: `ClaimsStandard` embeds `*UserStandard` with the same shape and `Username: jwtToken.Name` has the same exposure. It seemed wrong to fix one and leave its twin.
- Anything that introspects — a gateway, a health probe, a monitor — currently gets a 500 on every healthy token and a correct answer on every dead one, which is an awkward shape for a verifier to be in.
