### PR TITLE
fix: avoid panic in GetMaskedEmail when the domain has no dot

### DIFF
--- a/util/string.go
+++ b/util/string.go
@@ -281,6 +281,9 @@ func GetMaskedEmail(email string) string {
 	username := maskString(tokens[0])
 	domain := tokens[1]
 	domainTokens := strings.Split(domain, ".")
+	if len(domainTokens) < 2 {
+		return fmt.Sprintf("%s@%s", username, maskString(domain))
+	}
 	domainTokens[len(domainTokens)-2] = maskString(domainTokens[len(domainTokens)-2])
 	return fmt.Sprintf("%s@%s", username, strings.Join(domainTokens, "."))
 }


### PR DESCRIPTION
## Problem

`util.GetMaskedEmail` panics with `index out of range [-1]` when the email's
domain contains no dot (or is empty):

```
GetMaskedEmail("john@example.com") -> "j**n@e*****e.com"
GetMaskedEmail("user@localhost")   -> panic: runtime error: index out of range [-1]
GetMaskedEmail("user@")            -> panic: runtime error: index out of range [-1]
```

`domainTokens[len(domainTokens)-2]` indexes `-1` when
`strings.Split(domain, ".")` yields a single element.

## Reachability

- `object/mfa.go` passes `user.MfaRadiusUsername` and `user.MfaPushReceiver`
  (both free-form strings, not validated emails) straight into
  `GetMaskedEmail` — a value like `user@radius` panics the MFA flow.
- `controllers/user.go:506` masks `user.Email` in API responses, and
  `controllers/verification.go` compares masked emails. Note that
  `util.IsEmailValid` (which uses `mail.ParseAddress`) **accepts** dotless
  domains like `user@localhost`, so even validated flows can feed such a
  value in; users created via the admin API or syncers are not email-
  validated at all.

## Fix

Guard the single-element case and mask the whole domain instead:

```go
domainTokens := strings.Split(domain, ".")
if len(domainTokens) < 2 {
    return fmt.Sprintf("%s@%s", username, maskString(domain))
}
```

After the fix:

```
GetMaskedEmail("user@localhost") -> "u**r@l*******t"
GetMaskedEmail("user@")          -> "u**r@"
```

Behavior for normal addresses is unchanged.

## Verification

- Base: `92a601c` (upstream `master` at the time of the fix).
- Reproduced the panic before the change with a scratch program calling
  `util.GetMaskedEmail` (output above); no panic after.
- `go build ./...` — exit 0.
- `go vet ./util/` — clean.
- `go test ./util/ -skip 'TestGetNetworkUsage|TestGetVersion'` — ok.
  (`TestGetNetworkUsage` and `TestGetVersion` fail on pristine `master`
  in this environment as well — pre-existing, unrelated; `TestGetVersion`
  also rewrites `util/variable.go` as a side effect, which is discarded.)

## Notes

- No test file added, per the repo's stated code-style guidance.
- The CLA will need to be signed by the account owner for this first PR
  from this account (it is a legal certification, so it is left for a
  human to sign).

## AI assistance

This PR was prepared by an autonomous AI agent (zjncs) — root-cause
analysis, fix, and verification. All commands and outputs above were
actually executed; nothing is fabricated.
