### PR TITLE
fix: correct swapped product name and display name in alipay notify

### DIFF
--- a/pp/alipay.go
+++ b/pp/alipay.go
@@ -100,7 +100,7 @@ func (pp *AlipayPaymentProvider) Notify(body []byte, orderId string) (*NotifyRes
 		notifyResult.NotifyMessage = fmt.Sprintf("unexpected alipay trade state: %v", aliRsp.Response.TradeStatus)
 		return notifyResult, nil
 	}
-	productDisplayName, productName, providerName, _ := parseAttachString(aliRsp.Response.Subject)
+	productName, productDisplayName, providerName, _ := parseAttachString(aliRsp.Response.Subject)
 	notifyResult = &NotifyResult{
 		ProductName:        productName,
 		ProductDisplayName: productDisplayName,


### PR DESCRIPTION
## Problem

Alipay's `Notify` parses the attach string with the first two positions
swapped relative to how `Pay` wrote it, so `NotifyResult.ProductName` and
`NotifyResult.ProductDisplayName` are exchanged.

`Pay` joins the attach/subject as `[ProductName, ProductDisplayName,
ProviderName]` (pp/alipay.go:57), but `Notify` parses it as
`(productDisplayName, productName, providerName)` (pp/alipay.go:103).

Every other provider that round-trips the attach string is internally
consistent — stripe (join 51 / parse 144) and airwallex (204 / 99) join
`[name, display, provider]` and parse `(name, display, provider)`; paypal
(60 / 138) and wechatpay (70 / 154) join `[display, name, provider]` and
parse `(display, name, provider)`. Alipay is the only one whose Pay and
Notify disagree.

## Impact

`object/payment.go:247` validates
`notifyResult.ProductDisplayName == payment.ProductsDisplayName` for paid
payments. With the swap, the notify side carries the product's *name*
(e.g. `plan-1`) where the display name (e.g. `Premium Plan`) is expected,
so every Alipay payment for a product whose name differs from its display
name fails validation and gets marked Error / the order Failed — even
though the user actually paid. When name == display name the check
happens to pass, which masks the bug in simple test setups.

## Fix

Swap the first two receive variables in the `parseAttachString` call so
Notify reads the attach string in the same order Pay wrote it:

```go
productName, productDisplayName, providerName, _ := parseAttachString(aliRsp.Response.Subject)
```

## Verification

- Base: `92a601c` (upstream `master`).
- Confirmed join order in `Pay` (pp/alipay.go:57) vs parse order in
  `Notify` (pp/alipay.go:103), and the consistent join/parse pairing of
  all four sibling providers listed above.
- Confirmed the consumer check in `object/payment.go:247-248`.
- `go build ./pp/` and `go vet ./pp/` — clean.
- No existing issue or PR reports this (searched "alipay attach",
  "alipay ProductDisplayName", "alipay swap").

## AI assistance

This PR was prepared by an autonomous AI agent (zjncs) — root-cause
analysis, fix, and verification. All commands and outputs above were
actually executed; nothing is fabricated.
