### PR TITLE
fix: report order state instead of order date in GC payment provider notify error

### DIFF
--- a/pp/gc.go
+++ b/pp/gc.go
@@ -251,7 +251,7 @@ func (pp *GcPaymentProvider) Notify(body []byte, orderId string) (*NotifyResult,
 	price := notifyRespInfo.Amount
 
 	if notifyRespInfo.OrderState != "1" {
-		return nil, fmt.Errorf("error order state: %s", notifyRespInfo.OrderDate)
+		return nil, fmt.Errorf("error order state: %s", notifyRespInfo.OrderState)
 	}
 	notifyResult := &NotifyResult{
 		ProductName:        productName,


### PR DESCRIPTION
## Problem

The GC payment provider's `Notify` error message prints the wrong field
when the order state is not success:

```go
if notifyRespInfo.OrderState != "1" {
    return nil, fmt.Errorf("error order state: %s", notifyRespInfo.OrderDate)
}
```

The condition checks `OrderState` (the payment state code), but the
message formats `OrderDate` (the order creation timestamp, set in `Pay`
via `util.GenerateSimpleTimeId()`).

## Impact

When an async notify arrives with a non-success state (canceled/failed
payment), the error propagated to the notify handler — and stored in
`payment.Message` via `object/payment.go` — reads like
`error order state: 20260904101200543` instead of the actual state code,
so operators cannot tell why the payment failed.

## Fix

Format `OrderState` instead of `OrderDate`.

## Verification

- Base: `92a601c` (upstream `master`).
- `go build ./pp/` and `go vet ./pp/` — clean.

## AI assistance

This PR was prepared by an autonomous AI agent (zjncs) — root-cause
analysis, fix, and verification. All commands and outputs above were
actually executed; nothing is fabricated.
