### PR TITLE
fix: keep openid in oauth token for wechat providers

### DIFF
--- a/idp/wechat.go
+++ b/idp/wechat.go
@@ -140,11 +140,10 @@ func (idp *WeChatIdProvider) GetToken(code string) (*oauth2.Token, error) {
 		Expiry:       time.Time{},
 	}
 
-	raw := make(map[string]string)
+	raw := make(map[string]interface{})
 	raw["Openid"] = wechatAccessToken.Openid
-	token.WithExtra(raw)
 
-	return &token, nil
+	return token.WithExtra(raw), nil
 }
 
 //{

--- a/idp/wechat_mobile.go
+++ b/idp/wechat_mobile.go
@@ -109,11 +109,10 @@ func (idp *WeChatMobileIdProvider) GetToken(code string) (*oauth2.Token, error) 
 		Expiry:       time.Time{},
 	}
 
-	raw := make(map[string]string)
+	raw := make(map[string]interface{})
 	raw["Openid"] = wechatAccessToken.Openid
-	token.WithExtra(raw)
 
-	return &token, nil
+	return token.WithExtra(raw), nil
 }
 
 // GetUserInfo retrieves user information using the access token


### PR DESCRIPTION
## Description

Both WeChat IdPs build their `oauth2.Token` with an `Openid` extra that is silently dropped, so `token.Extra("Openid")` always returns `nil` for WeChat logins.

Two compounding defects in `idp/wechat.go` and `idp/wechat_mobile.go` (identical code):

1. `Token.WithExtra` returns a **new** `*Token` clone; the original value is not modified. The code calls `token.WithExtra(raw)` and discards the return value, then returns `&token` — the extra never lands in the returned token.
2. The extra map is typed `map[string]string`, but `Token.Extra` only ever type-asserts `map[string]interface{}` (or `url.Values`), so even if the return value were kept, a `map[string]string` extra can never be read back via `Extra`.

Fixing either defect alone still leaves `Extra("Openid")` broken; both are fixed together by building the extra as `map[string]interface{}` and returning the clone from `WithExtra`.

Consequences on master:
- `idp/wechat.go` `GetUserInfo`: `openid := token.Extra("Openid")` is `nil`, so the userinfo request URL is built with `openid=%!s(<nil>)` and user info lookup fails.
- `idp/wechat_mobile.go` `GetUserInfo`: the empty-openid check trips and returns an error outright.

All other IdPs in the package already use the correct pattern (`map[string]interface{}` + returning/assigning the `WithExtra` clone), e.g. `idp/kwai.go`, `idp/baidu.go`, `idp/wechatcom.go`, `idp/wechatmp.go`, `idp/lark.go` (11 call sites). This PR aligns the two WeChat providers with them.

## Verification

Base: `92a601cd611f94eebb153a70ef8db7f59ae34d20` (master)

- `go build ./idp/` and `go vet ./idp/` pass with the fix.
- Minimal scratch program against `golang.org/x/oauth2` proving the behavior change:
  - old pattern (`WithExtra(map[string]string{...})` discarding the return): `token.Extra("Openid")` → `<nil>`
  - new pattern (`return token.WithExtra(map[string]interface{}{...})`): `token.Extra("Openid")` → `oXyz123` (the injected openid)

Not verified end-to-end against a live WeChat app (requires WeChat credentials); the fix restores the exact value that `GetToken` already receives from WeChat's token response and that `GetUserInfo` already expects.

## Risk

Low: the change only affects the two WeChat IdPs' `GetToken` return value; `AccessToken`/`TokenType`/`Expiry` semantics are unchanged (the clone copies them).

---

*This PR was prepared with AI assistance (GitHub Copilot / ZCode autonomous agent). All findings were verified manually against the codebase before submission.*
