### PR TITLE
fix: guard UpdatePolicy against request body with fewer than two policies

### DIFF
--- a/controllers/enforcer.go
+++ b/controllers/enforcer.go
@@ -243,6 +243,11 @@ func (c *ApiController) UpdatePolicy() {
 		return
 	}
 
+	if len(policies) < 2 {
+		c.ResponseError("The request body should contain at least two policies (old and new)")
+		return
+	}
+
 	affected, err := object.UpdatePolicy(id, policies[0].Ptype, util.CasbinToSlice(policies[0]), util.CasbinToSlice(policies[1]))
 	if err != nil {
 		c.ResponseError(err.Error())


### PR DESCRIPTION
## Description

`POST /api/update-policy` (`controllers.UpdatePolicy`) panics with `index out of range` when the request body is a JSON array with fewer than two elements.

The handler unmarshals the user-supplied body into `[]xormadapter.CasbinRule` and only checks the unmarshal error, then immediately indexes `policies[0]` and `policies[1]`:

```go
var policies []xormadapter.CasbinRule
err := json.Unmarshal(c.Ctx.Input.RequestBody, &policies)
if err != nil {
    c.ResponseError(err.Error())
    return
}

affected, err := object.UpdatePolicy(id, policies[0].Ptype, util.CasbinToSlice(policies[0]), util.CasbinToSlice(policies[1]))
```

Bodies such as `[]` or `[{"Ptype":"p","V0":"alice"}]` are valid JSON, so the error check passes and the indexing panics. Since the API is authenticated but reachable by any frontend/SDK caller, a malformed request produces an HTTP 500 with no JSON error body (Beego panic recovery) instead of the usual `ResponseError` JSON.

The web UI always sends the intended two-element array (`web/src/components/casbin/PolicyTable.tsx:137`: `UpdatePolicy(enforcer.owner, enforcer.name, [oldPolicy, policy])`), so legitimate flows are unaffected.

Fix: return an error response when the array has fewer than two elements, mirroring the existing body validation style in `controllers/casbin_api.go` (`"The request body should not be empty"`).

## Verification

Base: `92a601cd611f94eebb153a70ef8db7f59ae34d20` (master)

Minimal repro mimicking the handler's exact code path with the same `xormadapter.CasbinRule` type:

- Before the fix: body `[]` → `json.Unmarshal` succeeds, `len(policies) == 0` → `panic: runtime error: index out of range [0] with length 0`
- After the fix: bodies `[]` and `[{...}]` → error response (`The request body should contain at least two policies (old and new)`), no panic; a two-element array still reaches `object.UpdatePolicy` unchanged

Also: `go build ./controllers/` and `go vet ./controllers/` pass.

## Risk

Low: the guard only triggers for inputs that previously crashed the handler; the normal two-element path is untouched.

---

*This PR was prepared with AI assistance (GitHub Copilot / ZCode autonomous agent). All findings were verified manually against the codebase before submission.*
