### PR TITLE
fix: add missing Oidc field to User struct for OIDC provider login

### DIFF
--- a/object/user.go
+++ b/object/user.go
@@ -144,6 +144,7 @@ type User struct {
 	Steam           string `xorm:"steam varchar(100)" json:"steam"`
 	Bilibili        string `xorm:"bilibili varchar(100)" json:"bilibili"`
 	Okta            string `xorm:"okta varchar(100)" json:"okta"`
+	Oidc            string `xorm:"oidc varchar(100)" json:"oidc"`
 	Douyin          string `xorm:"douyin varchar(100)" json:"douyin"`
 	Kwai            string `xorm:"kwai varchar(100)" json:"kwai"`
 	Line            string `xorm:"line varchar(100)" json:"line"`
@@ -865,7 +866,7 @@ func UpdateUser(id string, user *User, columns []string, isAdmin bool) (bool, er
 			"hash", "is_default_avatar", "properties", "webauthnCredentials", "mfa_items", "last_change_password_time", "managedAccounts", "face_ids", "mfaAccounts",
 			"signin_wrong_times", "last_signin_wrong_time", "groups", "mfa_phone_enabled", "mfa_email_enabled", "email_verified",
 			"github", "google", "qq", "wechat", "facebook", "dingtalk", "weibo", "gitee", "linkedin", "wecom", "lark", "gitlab", "adfs",
-			"baidu", "alipay", "casdoor", "infoflow", "apple", "azuread", "azureadb2c", "slack", "steam", "bilibili", "okta", "douyin", "kwai", "line", "amazon",
+			"baidu", "alipay", "casdoor", "infoflow", "apple", "azuread", "azureadb2c", "slack", "steam", "bilibili", "okta", "oidc", "douyin", "kwai", "line", "amazon",
 			"auth0", "battlenet", "bitbucket", "box", "cloudfoundry", "dailymotion", "deezer", "digitalocean", "discord", "dropbox",
 			"eveonline", "fitbit", "gitea", "heroku", "influxcloud", "instagram", "intercom", "kakao", "lastfm", "mailru", "meetup",
 			"microsoftonline", "naver", "nextcloud", "onedrive", "oura", "patreon", "paypal", "salesforce", "shopify", "soundcloud",

--- a/web/src/lib/setting.tsx
+++ b/web/src/lib/setting.tsx
@@ -658,7 +658,7 @@ export const UserFields = ["owner", "name", "password", "display_name", "id", "t
   "is_forbidden", "is_deleted", "signup_application", "register_type", "register_source", "hash", "pre_hash", "access_token",
   "created_ip", "last_signin_time", "last_signin_ip", "github", "google", "qq", "wechat", "facebook", "dingtalk",
   "weibo", "gitee", "linkedin", "wecom", "lark", "gitlab", "adfs", "baidu", "alipay", "casdoor", "infoflow", "apple",
-  "azuread", "azureadb2c", "slack", "steam", "bilibili", "okta", "douyin", "kwai", "line", "amazon", "auth0",
+  "azuread", "azureadb2c", "slack", "steam", "bilibili", "okta", "oidc", "douyin", "kwai", "line", "amazon", "auth0",
   "battlenet", "bitbucket", "box", "cloudfoundry", "dailymotion", "deezer", "digitalocean", "discord", "dropbox",
   "eveonline", "fitbit", "gitea", "heroku", "influxcloud", "instagram", "intercom", "kakao", "lastfm", "mailru",
   "meetup", "microsoftonline", "naver", "nextcloud", "onedrive", "oura", "patreon", "paypal", "salesforce", "shopify",


### PR DESCRIPTION
## What does this PR do?

Fixes the OIDC provider login failure reported in #5799:

```
Error 1054 (42S22): Unknown column 'oidc' in 'where clause'
```

### Root cause

When signing in with a provider of type `OIDC`, `getUserByProvider` falls through to `GetUserByField(organization, provider.Type, providerId)` (`controllers/auth.go`), which issues `WHERE oidc = ?` via `strings.ToLower(field)`. The `User` struct has a dedicated linkage column for every built-in provider type (`github`, `google`, `okta`, `azuread`, ...) **except** a generic `oidc` column, so xorm's `Sync2` never creates it and MySQL returns error 1054.

### Fix

- Add `Oidc string `xorm:"oidc varchar(100)" json:"oidc"`` to the `User` struct, mirroring the existing per-provider columns. On startup, xorm `Sync2` (`object/ormor.go`) auto-creates the `oidc` column, so no manual `ALTER TABLE` is needed.
- Add `"oidc"` to the default updatable-columns list in `UpdateUser`, so account linking via `LinkUserAccount` / `SetUserField` (`bean["oidc"] = providerId`) can persist the value on the normal update path.
- Add `"oidc"` to the frontend `UserFields` list so the admin UI treats the field consistently with the other provider linkage fields.

With the column present, both the lookup (`WHERE oidc = ?`) and the link-back succeed, and OIDC login proceeds without the manual workaround from the issue.

## Testing

- `go build ./...` passes.
- `go vet ./object/` clean.
- The repository's `go test` suite requires a live MySQL (`127.0.0.1:3306`) which is not available in this environment; the schema/column logic is exercised by CI.
