### PR TITLE
fix(apple): capture the real name/email from Sign in with Apple

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -904,6 +904,7 @@ func (c *ApiController) Login() {
 				return
 			}
 			idpInfo.CodeVerifier = authForm.CodeVerifier
+			idpInfo.State = authForm.State
 			var idProvider idp.IdProvider
 			idProvider, err = idp.GetIdProvider(idpInfo, authForm.RedirectUri)
 			if err != nil {
@@ -1571,6 +1572,32 @@ func (c *ApiController) GetCaptchaStatus() {
 func (c *ApiController) Callback() {
 	code := c.GetString("code")
 	state := c.GetString("state")
+
+	// Apple's one-time form_post callback: ONLY when the "name"/"email"
+	// scopes were requested (see the "Apple" case in idp.NewGothIdProvider),
+	// and ONLY on the account's very FIRST authorization ever, Apple includes
+	// a `user` field here carrying the real name/email as JSON. It is never
+	// sent again on any later sign-in, and goth's Apple session has no field
+	// for it -- FetchUser only decodes the ID token, which carries email but
+	// never a name -- so it is lost forever unless captured right here.
+	// Stashed by `state` for idp.GetUserInfo to consume exactly once, moments
+	// later in the same login attempt (see idp.AppleUserInfoCache).
+	if rawUser := c.GetString("user"); rawUser != "" && state != "" {
+		var payload struct {
+			Name struct {
+				FirstName string `json:"firstName"`
+				LastName  string `json:"lastName"`
+			} `json:"name"`
+			Email string `json:"email"`
+		}
+		if err := json.Unmarshal([]byte(rawUser), &payload); err == nil {
+			idp.AppleUserInfoCache.Store(state, idp.AppleUserInfo{
+				FirstName: payload.Name.FirstName,
+				LastName:  payload.Name.LastName,
+				Email:     payload.Email,
+			})
+		}
+	}
 
 	frontendCallbackUrl := fmt.Sprintf("/callback?code=%s&state=%s", url.QueryEscape(code), url.QueryEscape(state))
 	c.Ctx.Redirect(http.StatusFound, frontendCallbackUrl)

--- a/idp/goth.go
+++ b/idp/goth.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/casdoor/casdoor/util"
@@ -90,9 +91,14 @@ type GothIdProvider struct {
 	Provider     goth.Provider
 	Session      goth.Session
 	CodeVerifier string
+	// The OAuth `state` for this login attempt, threaded in from
+	// ProviderInfo.State. Only read by the "apple" branch of getUser, to pick
+	// up the one-time real name/email cached under this same value by
+	// controllers.Callback -- see AppleUserInfoCache.
+	State string
 }
 
-func NewGothIdProvider(providerType string, clientId string, clientSecret string, clientId2 string, clientSecret2 string, redirectUrl string, hostUrl string) (*GothIdProvider, error) {
+func NewGothIdProvider(providerType string, clientId string, clientSecret string, clientId2 string, clientSecret2 string, redirectUrl string, hostUrl string, state string) (*GothIdProvider, error) {
 	var idp GothIdProvider
 	switch providerType {
 	case "Amazon":
@@ -121,7 +127,13 @@ func NewGothIdProvider(providerType string, clientId string, clientSecret string
 		}
 
 		idp = GothIdProvider{
-			Provider: apple.New(clientId, *secret, redirectUrl, nil),
+			// Request the "name"/"email" scopes so Apple actually sends
+			// something to ask for: without them, goth never sets
+			// formPostResponseMode, Apple never uses response_mode=form_post,
+			// and the one-time `user` payload (the only place Apple ever
+			// puts the real name) never arrives at all. See
+			// controllers.Callback for where that payload is then captured.
+			Provider: apple.New(clientId, *secret, redirectUrl, nil, apple.ScopeName, apple.ScopeEmail),
 			Session:  &apple.Session{},
 		}
 	case "AzureAD":
@@ -420,6 +432,7 @@ func NewGothIdProvider(providerType string, clientId string, clientSecret string
 		return nil, fmt.Errorf("OAuth Goth provider type: %s is not supported", providerType)
 	}
 
+	idp.State = state
 	return &idp, nil
 }
 
@@ -481,10 +494,29 @@ func (idp *GothIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	return getUser(gothUser, idp.Provider.Name()), nil
+	return getUser(gothUser, idp.Provider.Name(), idp.State), nil
 }
 
-func getUser(gothUser goth.User, provider string) *UserInfo {
+// AppleUserInfo is the real name/email Apple includes in its one-time
+// form_post callback, captured by controllers.Callback and consumed exactly
+// once here, moments later in the same login attempt.
+type AppleUserInfo struct {
+	FirstName string
+	LastName  string
+	Email     string
+}
+
+// AppleUserInfoCache holds AppleUserInfo keyed by the OAuth `state` it
+// arrived under. A sync.Map rather than a request-scoped value because the
+// data is captured by a DIFFERENT HTTP request (Apple's own POST straight to
+// /api/callback) than the one that later calls GetUserInfo (the frontend's
+// subsequent login call) -- there is no request context to carry it on.
+// LoadAndDelete makes each entry single-use, matching Apple's own behavior:
+// it never resends this payload, so nothing here should ever be read twice
+// or linger past the login attempt it was captured for.
+var AppleUserInfoCache sync.Map
+
+func getUser(gothUser goth.User, provider string, state string) *UserInfo {
 	user := UserInfo{
 		Id:          gothUser.UserID,
 		Username:    gothUser.Name,
@@ -547,7 +579,24 @@ func getUser(gothUser goth.User, provider string) *UserInfo {
 		user.Username = user.Id
 		user.Email = ""
 	} else if provider == "apple" {
+		// goth's Apple FetchUser never has a name to give us -- its Session
+		// only decodes the ID token, which carries email but never a name --
+		// so this used to unconditionally invent a username from the email,
+		// even for a first, name-and-email-scoped authorization where Apple's
+		// one-time form_post callback actually had the real name. Prefer
+		// that, when this login attempt has it cached.
 		user.Username = util.GetUsernameFromEmail(user.Email)
+		if cached, ok := AppleUserInfoCache.LoadAndDelete(state); ok {
+			info := cached.(AppleUserInfo)
+			if info.Email != "" {
+				user.Email = info.Email
+			}
+			if info.FirstName != "" || info.LastName != "" {
+				name := getName(info.FirstName, info.LastName)
+				user.DisplayName = name
+				user.Username = name
+			}
+		}
 	}
 	return &user
 }

--- a/idp/goth_apple_test.go
+++ b/idp/goth_apple_test.go
@@ -1,0 +1,98 @@
+// Copyright 2021 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package idp
+
+import (
+	"testing"
+
+	"github.com/markbates/goth"
+)
+
+// goth's own Apple provider never populates Name/FirstName/LastName/NickName
+// on the goth.User it returns -- its Session only decodes the ID token,
+// which carries email but never a name (see providers/apple/session.go
+// upstream). So every real Apple FetchUser result looks like this: only
+// UserID and Email are ever set.
+func appleGothUser(email string) goth.User {
+	return goth.User{
+		Provider: "apple",
+		UserID:   "001837.abc123def456.7890",
+		Email:    email,
+	}
+}
+
+func TestGetUserAppleWithoutCachedInfo(t *testing.T) {
+	// The pre-fix behavior, and still the correct behavior for a RETURNING
+	// Apple user: no form_post payload arrives on any authorization after the
+	// first, so there is nothing in AppleUserInfoCache, and this must keep
+	// falling back to inventing a username from the email exactly as before.
+	state := "state-no-cache-entry"
+	user := getUser(appleGothUser("abc123@privaterelay.appleid.com"), "apple", state)
+
+	if user.Username != "abc123" {
+		t.Errorf("Username = %q, want %q (derived from email)", user.Username, "abc123")
+	}
+	if user.Email != "abc123@privaterelay.appleid.com" {
+		t.Errorf("Email = %q, want the ID token email unchanged", user.Email)
+	}
+}
+
+func TestGetUserAppleConsumesCachedNameOnce(t *testing.T) {
+	// The bug this fixes: on a FIRST authorization with the name/email scopes
+	// requested, controllers.Callback has already stashed Apple's one-time
+	// `user` payload under the OAuth state. getUser must prefer it over the
+	// invented-from-email fallback, for BOTH DisplayName and Username.
+	state := "state-first-authorization"
+	AppleUserInfoCache.Store(state, AppleUserInfo{
+		FirstName: "Stu",
+		LastName:  "Alexander",
+		Email:     "stu@example.com",
+	})
+
+	user := getUser(appleGothUser("abc123@privaterelay.appleid.com"), "apple", state)
+
+	if user.DisplayName != "Stu Alexander" {
+		t.Errorf("DisplayName = %q, want %q", user.DisplayName, "Stu Alexander")
+	}
+	if user.Username != "Stu Alexander" {
+		t.Errorf("Username = %q, want %q", user.Username, "Stu Alexander")
+	}
+	if user.Email != "stu@example.com" {
+		t.Errorf("Email = %q, want the cached callback email, not the (possibly private-relay) ID token one", user.Email)
+	}
+
+	// Apple never resends this payload -- a second call for the same state
+	// (e.g. a retried or duplicated request) must not find it twice and must
+	// fall back exactly as if it had never been cached.
+	again := getUser(appleGothUser("abc123@privaterelay.appleid.com"), "apple", state)
+	if again.Username != "abc123" {
+		t.Errorf("second call: Username = %q, want %q (cache entry must be single-use)", again.Username, "abc123")
+	}
+}
+
+func TestGetUserAppleIgnoresCacheUnderAnotherState(t *testing.T) {
+	// A cache entry must only ever be picked up by the login attempt that
+	// carries the SAME state it was stored under -- never by an unrelated one.
+	AppleUserInfoCache.Store("state-for-someone-else", AppleUserInfo{
+		FirstName: "Someone",
+		LastName:  "Else",
+	})
+
+	user := getUser(appleGothUser("abc123@privaterelay.appleid.com"), "apple", "state-this-attempt")
+
+	if user.Username != "abc123" {
+		t.Errorf("Username = %q, want %q (must not adopt another state's cached name)", user.Username, "abc123")
+	}
+}

--- a/idp/provider.go
+++ b/idp/provider.go
@@ -46,6 +46,10 @@ type ProviderInfo struct {
 	RedirectUrl   string
 	DisableSsl    bool
 	CodeVerifier  string
+	// The OAuth `state` for this login attempt. Only consumed by the "Apple"
+	// goth case, to pick up the one-time real name/email Apple's form_post
+	// callback stashed under this same value -- see idp.AppleUserInfoCache.
+	State string
 
 	TokenURL    string
 	AuthURL     string
@@ -141,7 +145,7 @@ func GetIdProvider(idpInfo *ProviderInfo, redirectUrl string) (IdProvider, error
 		return NewTelegramIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl), nil
 	default:
 		if isGothSupport(idpInfo.Type) {
-			return NewGothIdProvider(idpInfo.Type, idpInfo.ClientId, idpInfo.ClientSecret, idpInfo.ClientId2, idpInfo.ClientSecret2, redirectUrl, idpInfo.HostUrl)
+			return NewGothIdProvider(idpInfo.Type, idpInfo.ClientId, idpInfo.ClientSecret, idpInfo.ClientId2, idpInfo.ClientSecret2, redirectUrl, idpInfo.HostUrl, idpInfo.State)
 		}
 		if strings.HasPrefix(idpInfo.Type, "Custom") {
 			return NewCustomIdProvider(idpInfo, redirectUrl), nil


### PR DESCRIPTION
## The bug

Sign-in-with-Apple accounts have always gotten an invented display name and
username — the email local part, or Apple's opaque `sub` — instead of the
real name, even when the user has one on their Apple ID. This has been
reported before with no fix: #3464.

## Root cause (two bugs stacked)

1. `idp/goth.go`'s `"Apple"` case in `NewGothIdProvider` never requests the
   `"name"`/`"email"` scopes:
   ```go
   Provider: apple.New(clientId, *secret, redirectUrl, nil),
   ```
   Without them, goth's Apple provider never sets `formPostResponseMode`
   (see `configure()` in `providers/apple/apple.go`), Apple is never asked
   for `response_mode=form_post`, and Apple's one-time `user` payload — the
   **only** place it ever sends the real name, and only on an account's
   **very first** authorization ever — is never sent at all.

2. Requesting the scopes alone would not be enough. The POST `/api/callback`
   route (`web.Router("/api/callback", &controllers.ApiController{}, "POST:Callback")`)
   is clearly meant for exactly this form_post case, but the handler only
   ever read `code` and `state`:
   ```go
   func (c *ApiController) Callback() {
       code := c.GetString("code")
       state := c.GetString("state")
       frontendCallbackUrl := fmt.Sprintf("/callback?code=%s&state=%s", ...)
       c.Ctx.Redirect(http.StatusFound, frontendCallbackUrl)
   }
   ```
   Apple's `user` field was silently discarded. And goth's own `apple.Session`
   has no field for a name either — it only decodes the ID token, which
   carries `email` but never a name (`providers/apple/session.go`). So even
   with the scope fixed, the name would still never reach `getUser`.

## The fix

- Request `apple.ScopeName` and `apple.ScopeEmail` when constructing the
  Apple provider.
- Thread the OAuth `state` through `ProviderInfo` → `GothIdProvider` so two
  separate HTTP requests can be correlated: Apple's direct POST to
  `/api/callback` (which now parses the `user` JSON and stashes it in a new
  `AppleUserInfoCache`, keyed by `state`), and the frontend's later POST to
  `/api/login` (which is where `GetUserInfo`/`getUser` run today).
- `getUser`'s `"apple"` branch now does `AppleUserInfoCache.LoadAndDelete(state)`
  and prefers the cached real name/email over the existing
  `GetUsernameFromEmail` fallback for both `DisplayName` and `Username`,
  when present. `LoadAndDelete` makes each entry single-use, matching
  Apple's own one-time delivery — a returning user (no cache entry) falls
  back to exactly the old behavior, unchanged.

Scoped narrowly to the `"apple"` case only — no other goth-backed provider
(Slack, Steam, Line, Amazon, ...) changes behavior, and no new dependencies
were added.

## Testing

- `go build ./...`, `go vet ./...`, and `gofmt -l` are all clean.
- Added `idp/goth_apple_test.go` covering the new `getUser` logic in
  isolation (no cache entry / a fresh entry for this state / an entry
  cached under a *different* state that must not leak across), since this
  part is a pure function testable without live credentials.
- **Not verified against a real Apple sign-in.** That needs a live Apple
  Developer Sign in with Apple key and a real device/browser flow, which I
  don't have available here. The two most Apple-specific pieces I'd
  especially appreciate a maintainer or CI double-checking against a real
  account: whether `response_mode=form_post` actually round-trips cleanly
  end to end with the existing `redirectUrl` handling in this codebase, and
  the exact shape of the `user` JSON Apple sends (I've matched Apple's
  documented `{"name":{"firstName","lastName"},"email"}` shape, but haven't
  been able to confirm it against a live payload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFVNgE6Cpmm6yZH5EjVhdg
