### PR TITLE
feat: add MailKite email provider

### DIFF
--- a/email/mailkite.go
+++ b/email/mailkite.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package email
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/casdoor/casdoor/proxy"
+)
+
+const mailKiteSendUrl = "https://api.mailkite.dev/v1/send"
+
+type MailKiteEmailProvider struct {
+	ApiKey  string
+	SendUrl string
+}
+
+type mailKiteSendRequest struct {
+	From    string   `json:"from"`
+	To      []string `json:"to"`
+	Subject string   `json:"subject"`
+	Html    string   `json:"html"`
+}
+
+func NewMailKiteEmailProvider(apiKey string) *MailKiteEmailProvider {
+	return &MailKiteEmailProvider{ApiKey: apiKey, SendUrl: mailKiteSendUrl}
+}
+
+func (m *MailKiteEmailProvider) Send(fromAddress string, fromName string, toAddresses []string, subject string, content string) error {
+	from := fromAddress
+	if fromName != "" {
+		from = fmt.Sprintf("%s <%s>", fromName, fromAddress)
+	}
+
+	body, err := json.Marshal(mailKiteSendRequest{
+		From:    from,
+		To:      toAddresses,
+		Subject: subject,
+		Html:    content,
+	})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, m.SendUrl, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+m.ApiKey)
+	req.Header.Set("User-Agent", "Casdoor")
+
+	resp, err := proxy.DefaultHttpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("MailKiteEmailProvider's Send() error, status code: %d, response: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	return nil
+}

--- a/email/provider.go
+++ b/email/provider.go
@@ -28,6 +28,8 @@ func GetEmailProvider(typ string, clientId string, clientSecret string, host str
 		return NewSendgridEmailProvider(clientSecret, host, endpoint)
 	case "Resend":
 		return NewResendEmailProvider(clientSecret)
+	case "MailKite":
+		return NewMailKiteEmailProvider(clientSecret)
 	default:
 		return NewSmtpEmailProvider(clientId, clientSecret, host, port, typ, sslMode, enableProxy)
 	}

--- a/web-old/src/ProviderEditPage.js
+++ b/web-old/src/ProviderEditPage.js
@@ -433,7 +433,7 @@ class ProviderEditPage extends React.Component {
         return Setting.getLabel(i18next.t("provider:Client secret"), i18next.t("provider:Client secret - Tooltip"));
       }
     case "Email":
-      if (provider.type === "Azure ACS" || provider.type === "SendGrid" || provider.type === "Resend") {
+      if (provider.type === "Azure ACS" || provider.type === "SendGrid" || provider.type === "Resend" || provider.type === "MailKite") {
         return Setting.getLabel(i18next.t("provider:Secret key"), i18next.t("provider:Secret key - Tooltip"));
       } else {
         return Setting.getLabel(i18next.t("general:Password"), i18next.t("general:Password - Tooltip"));
@@ -1049,7 +1049,7 @@ class ProviderEditPage extends React.Component {
               <React.Fragment>
                 {
                   (this.state.provider.category === "Storage" && this.state.provider.type === "Google Cloud Storage") ||
-                  (this.state.provider.category === "Email" && (this.state.provider.type === "Azure ACS" || this.state.provider.type === "SendGrid" || this.state.provider.type === "Resend")) ||
+                  (this.state.provider.category === "Email" && (this.state.provider.type === "Azure ACS" || this.state.provider.type === "SendGrid" || this.state.provider.type === "Resend" || this.state.provider.type === "MailKite")) ||
                   (this.state.provider.category === "Face ID" && this.state.provider.type === "Local UniFace") ||
                   (this.state.provider.category === "Notification" && (this.state.provider.type === "Line" || this.state.provider.type === "Telegram" || this.state.provider.type === "Bark" || this.state.provider.type === "Discord" || this.state.provider.type === "Slack" || this.state.provider.type === "Pushbullet" || this.state.provider.type === "Pushover" || this.state.provider.type === "Lark" || this.state.provider.type === "Microsoft Teams" || this.state.provider.type === "WeCom")) ? null : (
                       <Row style={{marginTop: "20px"}} >

--- a/web-old/src/Setting.js
+++ b/web-old/src/Setting.js
@@ -194,6 +194,10 @@ export const OtherProviderInfo = {
       logo: `${StaticBaseUrl}/img/email_resend.png`,
       url: "https://resend.com/",
     },
+    "MailKite": {
+      logo: `${StaticBaseUrl}/img/social_default.png`,
+      url: "https://mailkite.dev/",
+    },
   },
   Storage: {
     "Local File System": {
@@ -1416,6 +1420,7 @@ export function getProviderTypeOptions(category) {
         {id: "SendGrid", name: "SendGrid"},
         {id: "Custom HTTP Email", name: "Custom HTTP Email"},
         {id: "Resend", name: "Resend"},
+        {id: "MailKite", name: "MailKite"},
       ]
     );
   } else if (category === "SMS") {

--- a/web-old/src/provider/EmailProviderFields.js
+++ b/web-old/src/provider/EmailProviderFields.js
@@ -39,7 +39,7 @@ export function renderEmailProviderFields(provider, updateProviderField, renderE
             </Col>
           </Row>) : null
       }
-      {provider.type === "Resend" ? null : (
+      {["Resend", "MailKite"].includes(provider.type) ? null : (
         <Row style={{marginTop: "20px"}} >
           <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
             {Setting.getLabel(i18next.t("general:Host"), i18next.t("provider:Host - Tooltip"))} :
@@ -51,7 +51,7 @@ export function renderEmailProviderFields(provider, updateProviderField, renderE
           </Col>
         </Row>
       )}
-      {["Azure ACS", "SendGrid", "Resend"].includes(provider.type) ? null : (
+      {["Azure ACS", "SendGrid", "Resend", "MailKite"].includes(provider.type) ? null : (
         <Row style={{marginTop: "20px"}} >
           <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
             {Setting.getLabel(i18next.t("general:Port"), i18next.t("provider:Port - Tooltip"))} :
@@ -63,7 +63,7 @@ export function renderEmailProviderFields(provider, updateProviderField, renderE
           </Col>
         </Row>
       )}
-      {["Azure ACS", "SendGrid", "Resend"].includes(provider.type) ? null : (
+      {["Azure ACS", "SendGrid", "Resend", "MailKite"].includes(provider.type) ? null : (
         <Row style={{marginTop: "20px"}} >
           <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
             {Setting.getLabel(i18next.t("provider:SSL mode"), i18next.t("provider:SSL mode - Tooltip"))} :
@@ -241,7 +241,7 @@ export function renderEmailProviderFields(provider, updateProviderField, renderE
               updateProviderField("receiver", e.target.value);
             }} />
         </Col>
-        {["Azure ACS", "SendGrid", "Resend"].includes(provider.type) ? null : (
+        {["Azure ACS", "SendGrid", "Resend", "MailKite"].includes(provider.type) ? null : (
           <Button style={{marginLeft: "10px", marginBottom: "5px"}} onClick={() => ProviderEditTestEmail.connectSmtpServer(provider)} >
             {i18next.t("provider:Test SMTP Connection")}
           </Button>

--- a/web/src/lib/setting.tsx
+++ b/web/src/lib/setting.tsx
@@ -361,6 +361,10 @@ export const OtherProviderInfo = {
       logo: `${StaticBaseUrl}/img/email_resend.png`,
       url: "https://resend.com/",
     },
+    "MailKite": {
+      logo: `${StaticBaseUrl}/img/social_default.png`,
+      url: "https://mailkite.dev/",
+    },
   },
   Storage: {
     "Local File System": {
@@ -1474,6 +1478,7 @@ export function getProviderTypeOptions(category) {
         {id: "SendGrid", name: "SendGrid"},
         {id: "Custom HTTP Email", name: "Custom HTTP Email"},
         {id: "Resend", name: "Resend"},
+        {id: "MailKite", name: "MailKite"},
       ]
     );
   } else if (category === "SMS") {

--- a/web/src/pages/ProviderEditPage.tsx
+++ b/web/src/pages/ProviderEditPage.tsx
@@ -189,7 +189,7 @@ function getClientSecretLabel(provider: any): Label {
       ? label(i18next.t("provider:Service account JSON"), i18next.t("provider:Service account JSON - Tooltip"))
       : label(i18next.t("provider:Client secret"), i18next.t("provider:Client secret - Tooltip"));
   } else if (provider.category === "Email") {
-    return ["Azure ACS", "SendGrid", "Resend"].includes(provider.type)
+    return ["Azure ACS", "SendGrid", "Resend", "MailKite"].includes(provider.type)
       ? label(i18next.t("provider:Secret key"), i18next.t("provider:Secret key - Tooltip"))
       : label(i18next.t("general:Password"), i18next.t("general:Password - Tooltip"));
   } else if (provider.category === "SMS") {
@@ -306,7 +306,7 @@ function getReceiverLabel(provider: any): Label | null {
 
 function hasClientIdRow(provider: any) {
   if ((provider.category === "Storage" && provider.type === "Google Cloud Storage") ||
-      (provider.category === "Email" && ["Azure ACS", "SendGrid", "Resend"].includes(provider.type)) ||
+      (provider.category === "Email" && ["Azure ACS", "SendGrid", "Resend", "MailKite"].includes(provider.type)) ||
       (provider.category === "Face ID" && provider.type === "Local UniFace") ||
       (provider.category === "Notification" && ["Line", "Telegram", "Bark", "Discord", "Slack", "Pushbullet", "Pushover", "Lark", "Microsoft Teams", "WeCom"].includes(provider.type))) {
     return false;
@@ -998,12 +998,12 @@ export default function ProviderEditPage() {
           <Input value={provider.endpoint ?? ""} onChange={(e) => updateProviderField("endpoint", e.target.value)} />
         </FormRow>
       ) : null}
-      {provider.type !== "Resend" ? (
+      {!["Resend", "MailKite"].includes(provider.type) ? (
         <FormRow label={i18next.t("general:Host")} tooltip={i18next.t("provider:Host - Tooltip")}>
           <Input value={provider.host ?? ""} onChange={(e) => updateProviderField("host", e.target.value)} />
         </FormRow>
       ) : null}
-      {!["Azure ACS", "SendGrid", "Resend"].includes(provider.type) ? (
+      {!["Azure ACS", "SendGrid", "Resend", "MailKite"].includes(provider.type) ? (
         <React.Fragment>
           <FormRow label={i18next.t("general:Port")} tooltip={i18next.t("provider:Port - Tooltip")}>
             <Input type="number" value={provider.port ?? 0} onChange={(e) => updateProviderField("port", e.target.value)} />
@@ -1107,7 +1107,7 @@ export default function ProviderEditPage() {
             placeholder={i18next.t("user:Input your email")}
             onChange={(e) => updateProviderField("receiver", e.target.value)}
           />
-          {!["Azure ACS", "SendGrid", "Resend"].includes(provider.type) ? (
+          {!["Azure ACS", "SendGrid", "Resend", "MailKite"].includes(provider.type) ? (
             <Button variant="outline" onClick={() => ProviderTest.connectSmtpServer(provider)}>
               {i18next.t("provider:Test SMTP Connection")}
             </Button>


### PR DESCRIPTION
## What this adds

A **MailKite** email provider, so Casdoor can send verification codes, invitation and reset mail through [MailKite](https://mailkite.dev) — same shape as the Resend provider added in #5200.

- `email/mailkite.go` — `MailKiteEmailProvider` implementing `EmailProvider.Send()`. It POSTs to `https://api.mailkite.dev/v1/send` with a Bearer API key (`from`, `to`, `subject`, `html`). It uses `net/http` and `proxy.DefaultHttpClient` like the Custom HTTP provider, so **no new dependency** in `go.mod`.
- `email/provider.go` — `case "MailKite"` in `GetEmailProvider`.
- `web` + `web-old` — `MailKite` added to the Email provider type list and to the same field-visibility conditions as `Resend` (Secret key label, hidden Client ID / Host / Port / SSL rows, no "Test SMTP Connection" button). Both frontends changed identically, per the `web-old`-is-the-reference rule.

The provider type logo uses `social_default.png` for now (same as Custom HTTP Email); if you'd like an `email_mailkite.png` in `casbin/static` I'll open that follow-up.

## How to configure

Providers → Add → Category **Email**, Type **MailKite**:

- **Secret key**: a MailKite API key (`mk_live_…`) from https://app.mailkite.dev
- **From address / From name**: as for the other API email providers (the sender domain has to be verified in the MailKite account)

## How I tested it

- `go build ./...`, `go vet ./email/`, and `gofumpt -l email/` (the repo's `.golangci.yml` formatter) — all clean.
- A local `httptest` harness for `Send()` (request method/path, `Authorization: Bearer …`, `Content-Type: application/json`, `from` rendered as `Name <addr>` and as a bare address when no name is set, multiple recipients, and a non-2xx response surfaced as an error with the body). All three cases pass. **Not committed**, since `CLAUDE.md` asks for no `_test.go` files unless requested — happy to add it if you'd like it in the tree.
- `web`: `yarn typecheck && yarn lint` clean. `web-old`: eslint on the three changed files clean.

## Disclosure

I work on MailKite. We'll maintain this provider going forward, and I'll add a `docs/provider/email/mailkite` page to `casdoor-website` once this is in.
