### PR TITLE
fix: show syncers across all organizations

### DIFF
--- a/web/cypress/e2e/syncers-organization.cy.js
+++ b/web/cypress/e2e/syncers-organization.cy.js
@@ -1,0 +1,81 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+describe("Syncer organization filtering", () => {
+  function openSyncers(owner, selection) {
+    cy.intercept("GET", "**/api/get-account*", {
+      status: "ok",
+      data: {owner, name: "admin", displayName: "Admin", isAdmin: true},
+      data2: {name: owner, displayName: owner, enableTour: false},
+    });
+    cy.intercept("GET", "**/api/get-organization-names*", {
+      status: "ok",
+      data: [
+        {name: "built-in", displayName: "Built-in"},
+        {name: "tenant", displayName: "Tenant"},
+      ],
+    });
+    cy.intercept("GET", "**/api/get-syncers?*", (req) => {
+      const organization = new URL(req.url).searchParams.get("organization");
+      const syncers = [
+        {owner: "admin", name: "tenant-syncer", organization: "tenant", type: "Database"},
+      ].filter((syncer) => !organization || syncer.organization === organization);
+      req.reply({status: "ok", data: syncers, data2: syncers.length});
+    }).as("syncers");
+    cy.visit("/syncers", {
+      onBeforeLoad(win) {
+        win.localStorage.setItem("organization", selection);
+        win.localStorage.setItem("language", "en");
+        win.localStorage.setItem("isTourVisible", "false");
+      },
+    });
+  }
+
+  function expectOrganization(organization) {
+    cy.get("@syncers.all").should((requests) => {
+      expect(requests).not.to.be.empty;
+      const {request} = requests[requests.length - 1];
+      expect(new URL(request.url).searchParams.get("organization")).to.eq(organization);
+    });
+  }
+
+  function selectOrganization(label) {
+    cy.get("header [role=combobox]").first().click();
+    cy.contains("[role=option]", new RegExp(`^${label}$`)).click();
+  }
+
+  it("loads all syncers and refreshes when switching organizations", () => {
+    openSyncers("built-in", "All");
+    expectOrganization("");
+    cy.contains("tbody", "tenant-syncer").should("be.visible");
+
+    selectOrganization("Built-in");
+    expectOrganization("built-in");
+    cy.contains("tbody", "tenant-syncer").should("not.exist");
+
+    selectOrganization("All");
+    expectOrganization("");
+    cy.contains("tbody", "tenant-syncer").should("be.visible");
+
+    selectOrganization("Tenant");
+    expectOrganization("tenant");
+    cy.contains("tbody", "tenant-syncer").should("be.visible");
+  });
+
+  it("keeps tenant administrators scoped to their own organization", () => {
+    openSyncers("tenant", "All");
+    expectOrganization("tenant");
+    cy.contains("tbody", "tenant-syncer").should("be.visible");
+  });
+});

--- a/web/src/hooks/use-organization.ts
+++ b/web/src/hooks/use-organization.ts
@@ -6,12 +6,21 @@ import {useAccount} from "@/hooks/use-account";
  * The organization the console is currently scoped to. Admins can switch it from
  * the header; the antd frontend broadcast the change through a
  * "storageOrganizationChanged" window event and this hook keeps that contract.
+ * With includeAll, a global admin's "All" selection yields an empty filter.
  */
-export function useRequestOrganization(overrideName?: string): string {
+export function useRequestOrganization(overrideName?: string, includeAll = false): string {
   const {account} = useAccount();
   const compute = React.useCallback(
-    () => overrideName ?? (account ? Setting.getRequestOrganization(account) : ""),
-    [account, overrideName],
+    () => {
+      if (overrideName !== undefined && overrideName !== null) {
+        return overrideName;
+      }
+      if (!account || (includeAll && Setting.isDefaultOrganizationSelected(account))) {
+        return "";
+      }
+      return Setting.getRequestOrganization(account);
+    },
+    [account, overrideName, includeAll],
   );
   const [organizationName, setOrganizationName] = React.useState(compute);
 

--- a/web/src/pages/SyncerListPage.tsx
+++ b/web/src/pages/SyncerListPage.tsx
@@ -10,7 +10,7 @@ import {newSyncer} from "@/pages/defaults";
 
 export default function SyncerListPage() {
   const {account} = useAccount();
-  const organizationName = useRequestOrganization();
+  const organizationName = useRequestOrganization(undefined, true);
 
   const columns: ColumnDef<any>[] = [
     linkColumn({dataIndex: "name", to: (r) => `/syncers/${r.organization}/${r.name}`, width: 170}),


### PR DESCRIPTION
Fixes #5814.

The Syncers page now sends an empty organization filter when a global administrator selects All, matching `web-old`. Selecting a specific organization still filters the list, and tenant administrators remain scoped to their own organization.

The shared organization hook gains an opt-in All mode. It computes the filter inside the storage-event callback so switching between All and built-in also refreshes the page; existing callers retain their current behavior.

Validation:
- Cypress reproduces the original All → built-in filter error on the base code.
- Two browser regression tests pass against the running Vite frontend with intercepted API responses: All → built-in → All → tenant, visible syncer rows, and tenant-admin isolation.
- Frontend lint, TypeScript checks, and production build pass.

Implemented and locally validated with OpenAI Codex. A maintainer/user will need to handle any required CLA signature; no signature was submitted by Codex.
