### PR TITLE
fix: retain draft rows when editing properties

### DIFF
--- a/web/src/components/crud/PropertiesTable.tsx
+++ b/web/src/components/crud/PropertiesTable.tsx
@@ -1,0 +1,69 @@
+// Copyright 2026 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from "react";
+import i18next from "i18next";
+import {Input} from "@/components/ui/input";
+import {EditableTable} from "@/components/crud/EditableTable";
+
+interface PropertiesTableProps {
+  properties: Record<string, string> | null | undefined;
+  onChange: (properties: Record<string, string>) => void;
+}
+
+function toRows(properties: PropertiesTableProps["properties"]) {
+  return Object.entries(properties ?? {}).map(([key, value]) => ({key, value}));
+}
+
+export function PropertiesTable({properties, onChange}: PropertiesTableProps) {
+  const [source, setSource] = React.useState(properties);
+  const [rows, setRows] = React.useState(() => toRows(properties));
+
+  if (properties !== source) {
+    setSource(properties);
+    setRows(toRows(properties));
+  }
+
+  return (
+    <EditableTable
+      rows={rows}
+      onChange={(nextRows) => {
+        const next = Object.fromEntries(nextRows.map((row) => [row.key, row.value]));
+        // The map cannot represent multiple rows with the same unfinished key.
+        setRows(nextRows);
+        setSource(next);
+        onChange(next);
+      }}
+      newRow={() => ({key: "", value: ""})}
+      reorderable={false}
+      columns={[
+        {
+          key: "key",
+          title: i18next.t("general:Name"),
+          width: 240,
+          render: (row, _i, patch) => (
+            <Input value={row.key} onChange={(e) => patch({key: e.target.value})} />
+          ),
+        },
+        {
+          key: "value",
+          title: i18next.t("webhook:Value"),
+          render: (row, _i, patch) => (
+            <Input value={row.value} onChange={(e) => patch({value: e.target.value})} />
+          ),
+        },
+      ]}
+    />
+  );
+}

--- a/web/src/pages/GroupEditPage.tsx
+++ b/web/src/pages/GroupEditPage.tsx
@@ -1,7 +1,6 @@
 import i18next from "i18next";
 import {Link, useParams} from "react-router-dom";
-import {Input} from "@/components/ui/input";
-import {EditableTable} from "@/components/crud/EditableTable";
+import {PropertiesTable} from "@/components/crud/PropertiesTable";
 import {Badge} from "@/components/ui/badge";
 import {SimpleEditPage, type EditField} from "@/components/crud/SimpleEditPage";
 import {useAccount} from "@/hooks/use-account";
@@ -74,33 +73,9 @@ export default function GroupEditPage() {
       labelKey: "user:Properties",
       block: true,
       render: (ctx, update) => (
-        <EditableTable
-          rows={Object.entries(ctx.record.properties ?? {}).map(([key, value]) => ({key, value}))}
-          onChange={(rows) =>
-            update(
-              "properties",
-              Object.fromEntries(rows.filter((row: any) => row.key).map((row: any) => [row.key, row.value])),
-            )
-          }
-          newRow={() => ({key: "", value: ""})}
-          reorderable={false}
-          columns={[
-            {
-              key: "key",
-              title: i18next.t("general:Name"),
-              width: 240,
-              render: (row: any, _i, patch) => (
-                <Input value={row.key ?? ""} onChange={(e) => patch({key: e.target.value})} />
-              ),
-            },
-            {
-              key: "value",
-              title: i18next.t("webhook:Value"),
-              render: (row: any, _i, patch) => (
-                <Input value={row.value ?? ""} onChange={(e) => patch({value: e.target.value})} />
-              ),
-            },
-          ]}
+        <PropertiesTable
+          properties={ctx.record.properties}
+          onChange={(properties) => update("properties", properties)}
         />
       ),
     },

--- a/web/src/pages/UserEditPage.tsx
+++ b/web/src/pages/UserEditPage.tsx
@@ -20,6 +20,7 @@ import {RegionSelect} from "@/components/common/RegionSelect";
 import {SearchableSelect} from "@/components/common/SearchableSelect";
 import {EditPageShell} from "@/components/crud/EditPageShell";
 import {EditableTable} from "@/components/crud/EditableTable";
+import {PropertiesTable} from "@/components/crud/PropertiesTable";
 import {FormRow, formGridClass} from "@/components/crud/FormRow";
 import {AffiliationAddressSelect, AffiliationField, useAffiliation} from "@/components/user/AffiliationSelect";
 import {CartTable} from "@/components/user/CartTable";
@@ -246,7 +247,6 @@ export default function UserEditPage({self}: {self?: boolean} = {}) {
 
   const avatarUrl = Setting.getEffectiveAvatarUrl(user);
   // `properties` is a plain map on the wire, the table edits it as rows
-  const propertyRows = Object.entries(user.properties ?? {}).map(([key, value]) => ({key, value}));
 
   const rows: Record<string, React.ReactNode> = {
     "Organization": (
@@ -666,33 +666,9 @@ export default function UserEditPage({self}: {self?: boolean} = {}) {
     ),
     "Properties": (
       <AccountItemRow name="Properties" labelKey="user:Properties" block>
-        <EditableTable
-          rows={propertyRows}
-          onChange={(rows) =>
-            updateField(
-              "properties",
-              Object.fromEntries(rows.filter((row: any) => row.key).map((row: any) => [row.key, row.value])),
-            )
-          }
-          newRow={() => ({key: "", value: ""})}
-          reorderable={false}
-          columns={[
-            {
-              key: "key",
-              title: i18next.t("general:Name"),
-              width: 240,
-              render: (row: any, _i, patch) => (
-                <Input value={row.key ?? ""} onChange={(e) => patch({key: e.target.value})} />
-              ),
-            },
-            {
-              key: "value",
-              title: i18next.t("webhook:Value"),
-              render: (row: any, _i, patch) => (
-                <Input value={row.value ?? ""} onChange={(e) => patch({value: e.target.value})} />
-              ),
-            },
-          ]}
+        <PropertiesTable
+          properties={user.properties}
+          onChange={(properties) => updateField("properties", properties)}
         />
       </AccountItemRow>
     ),


### PR DESCRIPTION
Fixes #5826.

Adding a property in the group editor immediately removes the empty row when the table is rebuilt from the properties map. The user editor has the same problem.

Keep editable rows in a shared PropertiesTable, as the old console did, and convert them to the record map on change. This also lets a key be cleared or temporarily duplicate another key without losing the other row. Loading a different properties object resets the table.

Checked adding multiple rows, entering a value before its key, renaming duplicate keys, clearing a key, deleting a row and reloading in a local browser harness rendering the actual group properties field. TypeScript, lint on the changed files and the Vite production build pass. The harness stubs the page data layer; backend persistence and the full Cypress suite were not run.