### PR TITLE
fix: carry the OAuth provider's email_verified through to the user

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -1105,6 +1105,7 @@ func (c *ApiController) Login() {
 						Avatar:            userInfo.AvatarUrl,
 						Address:           []string{},
 						Email:             userInfo.Email,
+						EmailVerified:     userInfo.EmailVerified,
 						Phone:             userInfo.Phone,
 						CountryCode:       userInfo.CountryCode,
 						Region:            userInfo.CountryCode,

--- a/idp/google.go
+++ b/idp/google.go
@@ -155,11 +155,12 @@ func (idp *GoogleIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error)
 			return nil, errors.New("invalid googleIdToken")
 		}
 		userInfo := UserInfo{
-			Id:          googleIdToken.Sub,
-			Username:    googleIdToken.Email,
-			DisplayName: googleIdToken.Name,
-			Email:       googleIdToken.Email,
-			AvatarUrl:   googleIdToken.Picture,
+			Id:            googleIdToken.Sub,
+			Username:      googleIdToken.Email,
+			DisplayName:   googleIdToken.Name,
+			Email:         googleIdToken.Email,
+			EmailVerified: googleIdToken.EmailVerified == "true",
+			AvatarUrl:     googleIdToken.Picture,
 		}
 		return &userInfo, nil
 	}
@@ -221,13 +222,14 @@ func (idp *GoogleIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error)
 	}
 
 	userInfo := UserInfo{
-		Id:          googleUserInfo.Id,
-		Username:    googleUserInfo.Email,
-		DisplayName: googleUserInfo.Name,
-		Email:       googleUserInfo.Email,
-		AvatarUrl:   googleUserInfo.Picture,
-		Phone:       phoneNumber,
-		CountryCode: countryCode,
+		Id:            googleUserInfo.Id,
+		Username:      googleUserInfo.Email,
+		DisplayName:   googleUserInfo.Name,
+		Email:         googleUserInfo.Email,
+		EmailVerified: googleUserInfo.VerifiedEmail,
+		AvatarUrl:     googleUserInfo.Picture,
+		Phone:         phoneNumber,
+		CountryCode:   countryCode,
 	}
 	return &userInfo, nil
 }

--- a/idp/provider.go
+++ b/idp/provider.go
@@ -28,10 +28,13 @@ type UserInfo struct {
 	DisplayName string
 	UnionId     string
 	Email       string
-	Phone       string
-	CountryCode string
-	AvatarUrl   string
-	Extra       map[string]string
+	// EmailVerified reports whether the provider itself vouches for Email.
+	// Providers that make no such assertion leave it false.
+	EmailVerified bool
+	Phone         string
+	CountryCode   string
+	AvatarUrl     string
+	Extra         map[string]string
 }
 
 type ProviderInfo struct {


### PR DESCRIPTION
### Problem

`User.EmailVerified` is only ever set to `true` by the email verification-code flow in `controllers/auth.go`. A user created by signing in through an OAuth provider is always stored with `EmailVerified: false`, even when the provider explicitly asserts the address is verified.

This makes the `emailVerified` / `email_verified` claim unusable for the question it appears to answer — whether the address on the token has been proven — because it is `false` for an entire class of users whose email *is* verified by their IdP.

### Why it happens

`idp.UserInfo` has no field for the provider's verification state, so the information is parsed and then dropped. `idp/google.go` already reads it in both response shapes:

```go
EmailVerified string `json:"email_verified"`   // GoogleIdToken, from the ID token
VerifiedEmail bool   `json:"verified_email"`   // GoogleUserInfo, from the userinfo endpoint
```

Neither is copied into the `UserInfo` returned by `GetUserInfo`, so the signup in `controllers/auth.go` — which copies `Email`, `Phone`, `CountryCode` and the rest across — has nothing to copy.

### Reproduce

1. Configure a Google provider on an application with signup enabled.
2. Sign up with a Google account whose address Google reports as verified.
3. The created user has `email_verified = false`, and tokens issued for it carry `emailVerified: false`.

### Change

Adds `EmailVerified` to `idp.UserInfo`, populates it in the Google provider from the values it already parses, and sets it on the user created by an OAuth signup.

Additive and narrow: every other provider leaves the field at its zero value and behaves exactly as before, and the verification-code path is untouched. `googleIdToken.EmailVerified` is compared against `"true"` because the existing struct declares it as a `string`.

### Deliberately out of scope

- Only the Google provider is wired up. The new field is the seam for the others; each needs its own API checked rather than assumed.
- Only user *creation* sets the flag. Updating it when an existing user links a provider is a behaviour change on existing accounts and belongs in its own change.
- No backfill — existing rows are untouched.

### Related

#3657 reports the same field staying `false` after an invite + verification-code signup, which is a different path to a similar surprise.
